### PR TITLE
Update cats to 1.1.0 (and dependencies)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,13 +3,14 @@ name := projectName
 organization in ThisBuild := "com.twilio"
 version in ThisBuild := "0.33.0-SNAPSHOT"
 
-crossScalaVersions := Seq("2.11.11", "2.12.3")
+crossScalaVersions := Seq("2.11.11", "2.12.4")
 scalaVersion in ThisBuild := crossScalaVersions.value.last
 
 val akkaVersion = "10.0.10"
-val catsVersion = "0.9.0"
-val circeVersion = "0.8.0"
-val http4sVersion = "0.17.6"
+val catsVersion = "1.1.0"
+val catsEffectVersion = "0.10"
+val circeVersion = "0.9.2"
+val http4sVersion = "0.18.5"
 val scalatestVersion = "3.0.1"
 
 mainClass in assembly := Some("com.twilio.swagger.codegen.CLI")
@@ -61,8 +62,11 @@ val codegenSettings = Seq(
   libraryDependencies ++= testDependencies ++ Seq(
     "org.scalameta" %% "scalameta" % "2.0.1"
     , "io.swagger" % "swagger-parser" % "1.0.32"
-    , "org.tpolecat" %% "atto-core"  % "0.6.0"
-    , "org.typelevel" %% "cats" % catsVersion
+    , "org.tpolecat" %% "atto-core"  % "0.6.1"
+    , "org.typelevel" %% "cats-core" % catsVersion
+    , "org.typelevel" %% "cats-kernel" % catsVersion
+    , "org.typelevel" %% "cats-macros" % catsVersion
+    , "org.typelevel" %% "cats-free" % catsVersion
   )
   // Dev
   , scalacOptions in ThisBuild ++= Seq(
@@ -101,9 +105,7 @@ lazy val sample = (project in file("modules/sample"))
       |import cats._
       |import cats.data.EitherT
       |import cats.implicits._
-      |import fs2.Strategy
-      |import fs2.Task
-      |import fs2.interop.cats._
+      |import cats.effect.IO
       |import io.circe._
       |import java.time._
       |import org.http4s._
@@ -128,7 +130,8 @@ lazy val sample = (project in file("modules/sample"))
       , "org.http4s" %% "http4s-circe" % http4sVersion
       , "org.http4s" %% "http4s-dsl" % http4sVersion
       , "org.scalatest" %% "scalatest" % scalatestVersion % Test
-      , "org.typelevel" %% "cats" % catsVersion
+      , "org.typelevel" %% "cats-core" % catsVersion
+      , "org.typelevel" %% "cats-effect" % catsEffectVersion
     )
   )
 

--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/ClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/ClientGenerator.scala
@@ -23,7 +23,7 @@ object ClientGenerator {
       clientExtraImports <- getExtraImports(context.tracing)
       clients <- groupedRoutes.map({ case (pkg, routes) =>
         for {
-          clientCalls <- routes.map(generateClientOperation(pkg, context.tracing, protocolElems) _).sequenceU
+          clientCalls <- routes.map(generateClientOperation(pkg, context.tracing, protocolElems) _).sequence
           clientName = s"${pkg.lastOption.getOrElse("").capitalize}Client"
           tracingName = Option(pkg.mkString("-")).filterNot(_.isEmpty)
           ctorArgs <- clientClsArgs(tracingName, schemes, host, context.tracing)
@@ -38,7 +38,7 @@ object ClientGenerator {
 
           Client(pkg, clientName, stats.map(SwaggerUtil.escapeTree))
         }
-      }).sequenceU
+      }).sequence
     } yield Clients(clients)
   }
 }

--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/ClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/ClientGenerator.scala
@@ -21,9 +21,9 @@ object ClientGenerator {
     for {
       clientImports <- getImports(context.tracing)
       clientExtraImports <- getExtraImports(context.tracing)
-      clients <- groupedRoutes.map({ case (pkg, routes) =>
+      clients <- groupedRoutes.traverse({ case (pkg, routes) =>
         for {
-          clientCalls <- routes.map(generateClientOperation(pkg, context.tracing, protocolElems) _).sequence
+          clientCalls <- routes.traverse(generateClientOperation(pkg, context.tracing, protocolElems) _)
           clientName = s"${pkg.lastOption.getOrElse("").capitalize}Client"
           tracingName = Option(pkg.mkString("-")).filterNot(_.isEmpty)
           ctorArgs <- clientClsArgs(tracingName, schemes, host, context.tracing)
@@ -38,7 +38,7 @@ object ClientGenerator {
 
           Client(pkg, clientName, stats.map(SwaggerUtil.escapeTree))
         }
-      }).sequence
+      })
     } yield Clients(clients)
   }
 }

--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/Common.scala
@@ -84,7 +84,7 @@ object Common {
       basePath = Option(swagger.getBasePath)
       paths = Option(swagger.getPaths).map(_.asScala.toList).getOrElse(List.empty)
       routes <- extractOperations(paths)
-      classNamedRoutes <- routes.map(route => getClassName(route.operation).map(_ -> route)).sequenceU
+      classNamedRoutes <- routes.map(route => getClassName(route.operation).map(_ -> route)).sequence
       groupedRoutes = classNamedRoutes.groupBy(_._1).mapValues(_.map(_._2)).toList
       frameworkImports <- getFrameworkImports(context.tracing)
       frameworkImplicits <- getFrameworkImplicits()
@@ -158,7 +158,7 @@ object Common {
         targetInterpreter <- extractGenerator(arg.context)
         writeFile <- processArgSet(targetInterpreter)(arg)
       } yield writeFile
-    ).sequenceU
+    ).sequence
   }
 
   def runM[F[_]](args: Array[String])(implicit C: CoreTerms[F]): Free[F, NonEmptyList[ReadSwagger[Target[List[WriteTree]]]]] = {

--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/Common.scala
@@ -84,7 +84,7 @@ object Common {
       basePath = Option(swagger.getBasePath)
       paths = Option(swagger.getPaths).map(_.asScala.toList).getOrElse(List.empty)
       routes <- extractOperations(paths)
-      classNamedRoutes <- routes.map(route => getClassName(route.operation).map(_ -> route)).sequence
+      classNamedRoutes <- routes.traverse(route => getClassName(route.operation).map(_ -> route))
       groupedRoutes = classNamedRoutes.groupBy(_._1).mapValues(_.map(_._2)).toList
       frameworkImports <- getFrameworkImports(context.tracing)
       frameworkImplicits <- getFrameworkImplicits()
@@ -153,12 +153,12 @@ object Common {
 
   def processArgs[F[_]](args: NonEmptyList[Args])(implicit C: CoreTerms[F]): Free[F, NonEmptyList[ReadSwagger[Target[List[WriteTree]]]]] = {
     import C._
-    args.map(arg =>
+    args.traverse(arg =>
       for {
         targetInterpreter <- extractGenerator(arg.context)
         writeFile <- processArgSet(targetInterpreter)(arg)
       } yield writeFile
-    ).sequence
+    )
   }
 
   def runM[F[_]](args: Array[String])(implicit C: CoreTerms[F]): Free[F, NonEmptyList[ReadSwagger[Target[List[WriteTree]]]]] = {

--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/ServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/ServerGenerator.scala
@@ -31,7 +31,7 @@ object ServerGenerator {
 
     for {
       routes <- extractOperations(paths)
-      classNamedRoutes <- routes.map(route => getClassName(route.operation).map(_ -> route)).sequenceU
+      classNamedRoutes <- routes.map(route => getClassName(route.operation).map(_ -> route)).sequence
       groupedRoutes = classNamedRoutes.groupBy(_._1).mapValues(_.map(_._2)).toList
       extraImports <- getExtraImports(context.tracing)
       servers <- groupedRoutes.map({ case (className, routes) =>
@@ -44,7 +44,7 @@ object ServerGenerator {
                 responseDefinitions <- generateResponseDefinitions(operation, protocolElems)
                 rendered <- generateRoute(resourceName, basePath, tracingFields, responseDefinitions, protocolElems)(sr)
               } yield rendered
-            }).sequenceU
+            }).sequence
             routeTerms = renderedRoutes.map(_.route)
             combinedRouteTerms <- combineRouteTerms(routeTerms)
             methodSigs = renderedRoutes.map(_.methodSig)
@@ -55,7 +55,7 @@ object ServerGenerator {
           } yield {
             Server(className, frameworkImports ++ extraImports, List(SwaggerUtil.escapeTree(handlerSrc), SwaggerUtil.escapeTree(classSrc)))
           }
-        }).sequenceU
+        }).sequence
     } yield Servers(servers)
   }
 }

--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/core/StructuredLogger.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/core/StructuredLogger.scala
@@ -42,7 +42,7 @@ sealed trait StructuredLoggerInstances extends StructuredLoggerLowPriority {
     def empty: StructuredLogger = new StructuredLogger(List.empty)
     def combine(x: StructuredLogger, y: StructuredLogger): StructuredLogger = new StructuredLogger({
       (y.levels.foldLeft(x.levels.reverse) {
-        case (end :: acc, next) if end.name == next.name => StructuredLogLevel(end.name, end.lines.concat(next.lines)) :: acc
+        case (end :: acc, next) if end.name == next.name => StructuredLogLevel(end.name, end.lines.concatNel(next.lines)) :: acc
         case (acc, next) => next :: acc
       }).reverse
     })

--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/generators/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/generators/AkkaHttpServerGenerator.scala
@@ -104,17 +104,17 @@ object AkkaHttpServerGenerator {
       case ExtractOperations(paths) =>
         for {
           _ <- Target.log.debug("AkkaHttpServerGenerator", "server")(s"extractOperations(${paths})")
-          routes <- paths.map({ case (pathStr, path) =>
+          routes <- paths.traverse { case (pathStr, path) =>
             for {
               _ <- Target.log.info("AkkaHttpServerGenerator", "server", "extractOperations")(s"(${pathStr}, ${path})")
               operationMap <- Target.fromOption(Option(path.getOperationMap), "No operations defined")
             } yield {
-              operationMap.asScala.map { case (httpMethod, operation) =>
+              operationMap.asScala.toList.map { case (httpMethod, operation) =>
                 ServerRoute(pathStr, httpMethod, operation)
               }
             }
-          }).sequence.map(_.flatten)
-        } yield routes
+          }
+        } yield routes.flatten
 
       case GetClassName(operation) =>
         for {

--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/generators/CirceProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/generators/CirceProtocolGenerator.scala
@@ -278,7 +278,7 @@ object CirceProtocolGenerator {
             case (clsName, definition) =>
               SwaggerUtil.modelMetaType(definition)
                 .map(x => (clsName, x))
-          }).sequenceU
+          }).sequence
           result <- SwaggerUtil.ResolvedType.resolve_(entries)
         } yield result.map { case (clsName, SwaggerUtil.Resolved(tpe, _, _)) =>
           PropMeta(clsName, tpe)

--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/generators/CirceProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/generators/CirceProtocolGenerator.scala
@@ -272,13 +272,13 @@ object CirceProtocolGenerator {
     def apply[T](term: ProtocolSupportTerm[T]): Target[T] = term match {
       case ExtractConcreteTypes(definitions) => {
         for {
-          entries <- definitions.map({
+          entries <- definitions.traverse {
             case (clsName, impl: ModelImpl) if (Option(impl.getProperties()).isDefined || Option(impl.getEnum()).isDefined) =>
               Target.pure((clsName, SwaggerUtil.Resolved(Type.Name(clsName), None, None): SwaggerUtil.ResolvedType))
             case (clsName, definition) =>
               SwaggerUtil.modelMetaType(definition)
                 .map(x => (clsName, x))
-          }).sequence
+          }
           result <- SwaggerUtil.ResolvedType.resolve_(entries)
         } yield result.map { case (clsName, SwaggerUtil.Resolved(tpe, _, _)) =>
           PropMeta(clsName, tpe)

--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/generators/ScalaParameter.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/generators/ScalaParameter.scala
@@ -131,7 +131,7 @@ object ScalaParameter {
 
   def fromParameters(protocolElems: List[StrictProtocolElems]): List[Parameter] => Target[List[ScalaParameter]] = { params =>
     for {
-      parameters <- params.map(fromParameter(protocolElems)).sequence
+      parameters <- params.traverse(fromParameter(protocolElems))
       counts = parameters.groupBy(_.paramName.value).mapValues(_.length)
     } yield parameters.map { param =>
         val Term.Name(name) = param.paramName

--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/generators/ScalaParameter.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/generators/ScalaParameter.scala
@@ -115,7 +115,7 @@ object ScalaParameter {
               }
             }
         case _ => baseDefaultValue.map(Target.pure _)
-      }).sequenceU
+      }).sequence
     } yield {
       val defaultValue = if (!required) {
         enumDefaultValue.map(x => q"Option(${x})").orElse(Some(q"None"))
@@ -131,7 +131,7 @@ object ScalaParameter {
 
   def fromParameters(protocolElems: List[StrictProtocolElems]): List[Parameter] => Target[List[ScalaParameter]] = { params =>
     for {
-      parameters <- params.map(fromParameter(protocolElems)).sequenceU
+      parameters <- params.map(fromParameter(protocolElems)).sequence
       counts = parameters.groupBy(_.paramName.value).mapValues(_.length)
     } yield parameters.map { param =>
         val Term.Name(name) = param.paramName

--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/generators/SwaggerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/generators/SwaggerGenerator.scala
@@ -26,7 +26,7 @@ object SwaggerGenerator {
                 RouteMeta(pathStr, httpMethod, operation)
               }
             }
-        }).sequenceU.map(_.flatten)
+        }).sequence.map(_.flatten)
 
       case GetClassName(operation) =>
         for {

--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/package.scala
@@ -1,7 +1,7 @@
 package com.twilio.swagger
 
 import cats.{Applicative, Id}
-import cats.data.{Coproduct, EitherT, NonEmptyList, WriterT}
+import cats.data.{EitherK, EitherT, NonEmptyList, WriterT}
 import cats.instances.all._
 import cats.syntax.applicative._
 import cats.syntax.either._
@@ -19,7 +19,7 @@ package codegen {
   object Target {
     val A = Applicative[Target]
     def pure[T](x: T): Target[T] = A.pure(x)
-    def error[T](x: String): Target[T] = EitherT.left[Logger, String, T](x.pure[Logger])
+    def error[T](x: String): Target[T] = EitherT.left[T](x.pure[Logger])
     def fromOption[T](x: Option[T], default: => String): Target[T] = EitherT.fromOption(x, default)
     def unsafeExtract[T](x: Target[T]): T = x.valueOr({ err => throw new Exception(err.toString) }).value
 
@@ -34,7 +34,7 @@ package codegen {
   object CoreTarget {
     def pure[T](x: T): CoreTarget[T] = x.pure[CoreTarget]
     def fromOption[T](x: Option[T], default: => Error): CoreTarget[T] = EitherT.fromOption(x, default)
-    def error[T](x: Error): CoreTarget[T] = EitherT.left[Logger, Error, T](x.pure[Logger])
+    def error[T](x: Error): CoreTarget[T] = EitherT.left[T](x.pure[Logger])
     def unsafeExtract[T](x: CoreTarget[T]): T = x.valueOr({ err => throw new Exception(err.toString) }).value
 
     object log {
@@ -47,15 +47,15 @@ package codegen {
 }
 
 package object codegen {
-  type CodegenApplicationSP[T] = Coproduct[ProtocolSupportTerm, ServerTerm, T]
-  type CodegenApplicationMSP[T] = Coproduct[ModelProtocolTerm, CodegenApplicationSP, T]
-  type CodegenApplicationEMSP[T] = Coproduct[EnumProtocolTerm, CodegenApplicationMSP, T]
-  type CodegenApplicationCEMSP[T] = Coproduct[ClientTerm, CodegenApplicationEMSP, T]
-  type CodegenApplicationACEMSP[T] = Coproduct[AliasProtocolTerm, CodegenApplicationCEMSP, T]
-  type CodegenApplicationACEMSSP[T] = Coproduct[ScalaTerm, CodegenApplicationACEMSP, T]
-  type CodegenApplicationACEMSSPR[T] = Coproduct[ArrayProtocolTerm, CodegenApplicationACEMSSP, T]
-  type CodegenApplicationACEMSSPRS[T] = Coproduct[SwaggerTerm, CodegenApplicationACEMSSPR, T]
-  type CodegenApplicationACEMSSPRSF[T] = Coproduct[FrameworkTerm, CodegenApplicationACEMSSPRS, T]
+  type CodegenApplicationSP[T] = EitherK[ProtocolSupportTerm, ServerTerm, T]
+  type CodegenApplicationMSP[T] = EitherK[ModelProtocolTerm, CodegenApplicationSP, T]
+  type CodegenApplicationEMSP[T] = EitherK[EnumProtocolTerm, CodegenApplicationMSP, T]
+  type CodegenApplicationCEMSP[T] = EitherK[ClientTerm, CodegenApplicationEMSP, T]
+  type CodegenApplicationACEMSP[T] = EitherK[AliasProtocolTerm, CodegenApplicationCEMSP, T]
+  type CodegenApplicationACEMSSP[T] = EitherK[ScalaTerm, CodegenApplicationACEMSP, T]
+  type CodegenApplicationACEMSSPR[T] = EitherK[ArrayProtocolTerm, CodegenApplicationACEMSSP, T]
+  type CodegenApplicationACEMSSPRS[T] = EitherK[SwaggerTerm, CodegenApplicationACEMSSPR, T]
+  type CodegenApplicationACEMSSPRSF[T] = EitherK[FrameworkTerm, CodegenApplicationACEMSSPRS, T]
   type CodegenApplication[T] = CodegenApplicationACEMSSPRSF[T]
 
   type Logger[T] = WriterT[Id, StructuredLogger, T]

--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/protocol/terms/AliasProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/protocol/terms/AliasProtocolTerms.scala
@@ -1,11 +1,10 @@
 package com.twilio.swagger.codegen
 package terms.protocol
 
-import cats.free.{Free, Inject}
-import scala.meta._
+import cats.InjectK
 
-class AliasProtocolTerms[F[_]](implicit I: Inject[AliasProtocolTerm, F]) {
+class AliasProtocolTerms[F[_]](implicit I: InjectK[AliasProtocolTerm, F]) {
 }
 object AliasProtocolTerms {
-  implicit def aliasProtocolTerm[F[_]](implicit I: Inject[AliasProtocolTerm, F]): AliasProtocolTerms[F] = new AliasProtocolTerms[F]
+  implicit def aliasProtocolTerm[F[_]](implicit I: InjectK[AliasProtocolTerm, F]): AliasProtocolTerms[F] = new AliasProtocolTerms[F]
 }

--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/protocol/terms/ArrayProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/protocol/terms/ArrayProtocolTerms.scala
@@ -2,14 +2,15 @@ package com.twilio.swagger.codegen
 package terms.protocol
 
 import _root_.io.swagger.models.ArrayModel
-import cats.free.{Free, Inject}
+import cats.InjectK
+import cats.free.Free
 import scala.meta._
 
-class ArrayProtocolTerms[F[_]](implicit I: Inject[ArrayProtocolTerm, F]) {
+class ArrayProtocolTerms[F[_]](implicit I: InjectK[ArrayProtocolTerm, F]) {
   def extractArrayType(arr: ArrayModel, concreteTypes: List[PropMeta]): Free[F, Type] =
     Free.inject[ArrayProtocolTerm, F](ExtractArrayType(arr, concreteTypes))
 }
 
 object ArrayProtocolTerms {
-  implicit def arrayProtocolTerms[F[_]](implicit I: Inject[ArrayProtocolTerm, F]): ArrayProtocolTerms[F] = new ArrayProtocolTerms[F]
+  implicit def arrayProtocolTerms[F[_]](implicit I: InjectK[ArrayProtocolTerm, F]): ArrayProtocolTerms[F] = new ArrayProtocolTerms[F]
 }

--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/protocol/terms/ClientGeneratorTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/protocol/terms/ClientGeneratorTerms.scala
@@ -1,11 +1,12 @@
 package com.twilio.swagger.codegen
 package terms.client
 
-import cats.free.{Free, Inject}
+import cats.InjectK
+import cats.free.Free
 import com.twilio.swagger.codegen.terms.RouteMeta
 import scala.meta._
 
-class ClientTerms[F[_]](implicit I: Inject[ClientTerm, F]) {
+class ClientTerms[F[_]](implicit I: InjectK[ClientTerm, F]) {
   def generateClientOperation(className: List[String], tracing: Boolean, protocolElems: List[StrictProtocolElems])(route: RouteMeta): Free[F, Defn] =
     Free.inject[ClientTerm, F](GenerateClientOperation(className, route, tracing, protocolElems))
   def getImports(tracing: Boolean): Free[F, List[Import]] =
@@ -21,5 +22,5 @@ class ClientTerms[F[_]](implicit I: Inject[ClientTerm, F]) {
 }
 
 object ClientTerms {
-  implicit def enumTerms[F[_]](implicit I: Inject[ClientTerm, F]): ClientTerms[F] = new ClientTerms[F]
+  implicit def enumTerms[F[_]](implicit I: InjectK[ClientTerm, F]): ClientTerms[F] = new ClientTerms[F]
 }

--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/protocol/terms/EnumProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/protocol/terms/EnumProtocolTerms.scala
@@ -2,10 +2,12 @@ package com.twilio.swagger.codegen
 package terms.protocol
 
 import _root_.io.swagger.models.ModelImpl
-import cats.free.{Free, Inject}
+import cats.InjectK
+import cats.free.Free
+
 import scala.meta._
 
-class EnumProtocolTerms[F[_]](implicit I: Inject[EnumProtocolTerm, F]) {
+class EnumProtocolTerms[F[_]](implicit I: InjectK[EnumProtocolTerm, F]) {
   def extractEnum(swagger: ModelImpl): Free[F, Either[String, List[String]]] =
     Free.inject[EnumProtocolTerm, F](ExtractEnum(swagger))
   def extractType(swagger: ModelImpl): Free[F, Either[String, Type]] =
@@ -23,5 +25,5 @@ class EnumProtocolTerms[F[_]](implicit I: Inject[EnumProtocolTerm, F]) {
 }
 
 object EnumProtocolTerms {
-  implicit def enumProtocolTerms[F[_]](implicit I: Inject[EnumProtocolTerm, F]): EnumProtocolTerms[F] = new EnumProtocolTerms[F]
+  implicit def enumProtocolTerms[F[_]](implicit I: InjectK[EnumProtocolTerm, F]): EnumProtocolTerms[F] = new EnumProtocolTerms[F]
 }

--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/protocol/terms/ModelProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/protocol/terms/ModelProtocolTerms.scala
@@ -3,10 +3,12 @@ package terms.protocol
 
 import _root_.io.swagger.models.ModelImpl
 import _root_.io.swagger.models.properties.Property
-import cats.free.{Free, Inject}
+import cats.InjectK
+import cats.free.Free
+
 import scala.meta._
 
-class ModelProtocolTerms[F[_]](implicit I: Inject[ModelProtocolTerm, F]) {
+class ModelProtocolTerms[F[_]](implicit I: InjectK[ModelProtocolTerm, F]) {
   def extractProperties(swagger: ModelImpl): Free[F, Either[String, List[(String, Property)]]] =
     Free.inject[ModelProtocolTerm, F](ExtractProperties(swagger))
   def transformProperty(clsName: String, needCamelSnakeConversion: Boolean, concreteTypes: List[PropMeta])(name: String, prop: Property): Free[F, ProtocolParameter] =
@@ -21,5 +23,5 @@ class ModelProtocolTerms[F[_]](implicit I: Inject[ModelProtocolTerm, F]) {
     Free.inject[ModelProtocolTerm, F](RenderDTOCompanion(clsName, deps, encoder, decoder))
 }
 object ModelProtocolTerms {
-  implicit def modelProtocolTerm[F[_]](implicit I: Inject[ModelProtocolTerm, F]): ModelProtocolTerms[F] = new ModelProtocolTerms[F]
+  implicit def modelProtocolTerm[F[_]](implicit I: InjectK[ModelProtocolTerm, F]): ModelProtocolTerms[F] = new ModelProtocolTerms[F]
 }

--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/protocol/terms/ProtocolSupportTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/protocol/terms/ProtocolSupportTerms.scala
@@ -2,10 +2,11 @@ package com.twilio.swagger.codegen
 package terms.protocol
 
 import _root_.io.swagger.models.Model
-import cats.free.{Free, Inject}
+import cats.InjectK
+import cats.free.Free
 import scala.meta._
 
-class ProtocolSupportTerms[F[_]](implicit I: Inject[ProtocolSupportTerm, F]) {
+class ProtocolSupportTerms[F[_]](implicit I: InjectK[ProtocolSupportTerm, F]) {
   def extractConcreteTypes(models: List[(String, Model)]): Free[F, List[PropMeta]] =
     Free.inject[ProtocolSupportTerm, F](ExtractConcreteTypes(models))
   def protocolImports(): Free[F, List[Import]] =
@@ -16,5 +17,5 @@ class ProtocolSupportTerms[F[_]](implicit I: Inject[ProtocolSupportTerm, F]) {
     Free.inject[ProtocolSupportTerm, F](PackageObjectContents())
 }
 object ProtocolSupportTerms {
-  implicit def protocolSupportTerms[F[_]](implicit I: Inject[ProtocolSupportTerm, F]): ProtocolSupportTerms[F] = new ProtocolSupportTerms[F]
+  implicit def protocolSupportTerms[F[_]](implicit I: InjectK[ProtocolSupportTerm, F]): ProtocolSupportTerms[F] = new ProtocolSupportTerms[F]
 }

--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/protocol/terms/ServerTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/protocol/terms/ServerTerms.scala
@@ -2,12 +2,14 @@ package com.twilio.swagger.codegen
 package terms.server
 
 import _root_.io.swagger.models.{ModelImpl, Operation, Path}
+import cats.InjectK
 import cats.data.NonEmptyList
-import cats.free.{Free, Inject}
+import cats.free.Free
 import com.twilio.swagger.codegen.generators.ScalaParameter
+
 import scala.meta._
 
-class ServerTerms[F[_]](implicit I: Inject[ServerTerm, F]) {
+class ServerTerms[F[_]](implicit I: InjectK[ServerTerm, F]) {
   def extractOperations(paths: List[(String, Path)]): Free[F, List[ServerRoute]] =
     Free.inject(ExtractOperations(paths))
   def getClassName(operation: Operation): Free[F, List[String]] =
@@ -31,5 +33,5 @@ class ServerTerms[F[_]](implicit I: Inject[ServerTerm, F]) {
 }
 
 object ServerTerms {
-  implicit def serverTerms[F[_]](implicit I: Inject[ServerTerm, F]): ServerTerms[F] = new ServerTerms[F]
+  implicit def serverTerms[F[_]](implicit I: InjectK[ServerTerm, F]): ServerTerms[F] = new ServerTerms[F]
 }

--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/terms/CoreTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/terms/CoreTerms.scala
@@ -1,13 +1,15 @@
 package com.twilio.swagger.codegen
 package terms
 
+import cats.InjectK
 import cats.arrow.FunctionK
 import cats.data.NonEmptyList
-import cats.free.{Free, Inject}
+import cats.free.Free
 import com.twilio.swagger.codegen.{CodegenApplication, Target}
+
 import scala.meta._
 
-class CoreTerms[F[_]](implicit I: Inject[CoreTerm, F]) {
+class CoreTerms[F[_]](implicit I: InjectK[CoreTerm, F]) {
   def getDefaultFramework: Free[F, String] =
     Free.inject[CoreTerm, F](GetDefaultFramework)
   def extractGenerator(context: Context): Free[F, FunctionK[CodegenApplication, Target]] =
@@ -20,5 +22,5 @@ class CoreTerms[F[_]](implicit I: Inject[CoreTerm, F]) {
     Free.inject[CoreTerm, F](ProcessArgSet(targetInterpreter, args))
 }
 object CoreTerms {
-  implicit def coreTerm[F[_]](implicit I: Inject[CoreTerm, F]): CoreTerms[F] = new CoreTerms[F]
+  implicit def coreTerm[F[_]](implicit I: InjectK[CoreTerm, F]): CoreTerms[F] = new CoreTerms[F]
 }

--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/terms/FrameworkTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/terms/FrameworkTerms.scala
@@ -2,12 +2,14 @@ package com.twilio.swagger.codegen
 package terms.framework
 
 import _root_.io.swagger.models.{ModelImpl, Operation, Path}
+import cats.InjectK
 import cats.data.NonEmptyList
-import cats.free.{Free, Inject}
+import cats.free.Free
 import com.twilio.swagger.codegen.generators.ScalaParameter
+
 import scala.meta._
 
-class FrameworkTerms[F[_]](implicit I: Inject[FrameworkTerm, F]) {
+class FrameworkTerms[F[_]](implicit I: InjectK[FrameworkTerm, F]) {
   def getFrameworkImports(tracing: Boolean): Free[F, List[Import]] =
     Free.inject(GetFrameworkImports(tracing))
   def getFrameworkImplicits(): Free[F, Defn.Object] =
@@ -15,5 +17,5 @@ class FrameworkTerms[F[_]](implicit I: Inject[FrameworkTerm, F]) {
 }
 
 object FrameworkTerms {
-  implicit def serverTerms[F[_]](implicit I: Inject[FrameworkTerm, F]): FrameworkTerms[F] = new FrameworkTerms[F]
+  implicit def serverTerms[F[_]](implicit I: InjectK[FrameworkTerm, F]): FrameworkTerms[F] = new FrameworkTerms[F]
 }

--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/terms/ScalaTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/terms/ScalaTerms.scala
@@ -1,15 +1,17 @@
 package com.twilio.swagger.codegen
 package terms
 
-import cats.free.{Free, Inject}
+import cats.InjectK
+import cats.free.Free
+
 import scala.meta._
 
-class ScalaTerms[F[_]](implicit I: Inject[ScalaTerm, F]) {
+class ScalaTerms[F[_]](implicit I: InjectK[ScalaTerm, F]) {
   def renderImplicits(pkgName: List[String], frameworkImports: List[Import], jsonImports: List[Import], customImports: List[Import]): Free[F, Source] =
     Free.inject[ScalaTerm, F](RenderImplicits(pkgName, frameworkImports, jsonImports, customImports))
   def renderFrameworkImplicits(pkgName: List[String], frameworkImports: List[Import], jsonImports: List[Import], frameworkImplicits: Defn.Object): Free[F, Source] =
     Free.inject[ScalaTerm, F](RenderFrameworkImplicits(pkgName, frameworkImports, jsonImports, frameworkImplicits))
 }
 object ScalaTerms {
-  implicit def scalaTerm[F[_]](implicit I: Inject[ScalaTerm, F]): ScalaTerms[F] = new ScalaTerms[F]
+  implicit def scalaTerm[F[_]](implicit I: InjectK[ScalaTerm, F]): ScalaTerms[F] = new ScalaTerms[F]
 }

--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/terms/SwaggerTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/terms/SwaggerTerms.scala
@@ -2,15 +2,17 @@ package com.twilio.swagger.codegen
 package terms
 
 import _root_.io.swagger.models.{ModelImpl, Operation, Path}
-import cats.free.{Free, Inject}
+import cats.InjectK
+import cats.free.Free
+
 import scala.meta._
 
-class SwaggerTerms[F[_]](implicit I: Inject[SwaggerTerm, F]) {
+class SwaggerTerms[F[_]](implicit I: InjectK[SwaggerTerm, F]) {
   def extractOperations(paths: List[(String, Path)]): Free[F, List[RouteMeta]] =
     Free.inject[SwaggerTerm, F](ExtractOperations(paths))
   def getClassName(operation: Operation): Free[F, List[String]] =
     Free.inject[SwaggerTerm, F](GetClassName(operation))
 }
 object SwaggerTerms {
-  implicit def swaggerTerm[F[_]](implicit I: Inject[SwaggerTerm, F]): SwaggerTerms[F] = new SwaggerTerms[F]
+  implicit def swaggerTerm[F[_]](implicit I: InjectK[SwaggerTerm, F]): SwaggerTerms[F] = new SwaggerTerms[F]
 }

--- a/src/test/scala/generators/Http4s/Client/Basic.scala
+++ b/src/test/scala/generators/Http4s/Client/Basic.scala
@@ -114,35 +114,35 @@ class BasicTest extends FunSuite with Matchers {
     val List(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])
 
     val client = q"""
-    class Client(host: String = "http://localhost:1234")(implicit httpClient: Client) {
+    class Client[F[_]](host: String = "http://localhost:1234")(implicit effect: Effect[F], httpClient: Client[F]) {
       val basePath: String = ""
-      def getFoo(headers: List[Header] = List.empty): Task[IgnoredEntity] = {
+      def getFoo(headers: List[Header] = List.empty): F[IgnoredEntity] = {
         val allHeaders = headers ++ List[Option[Header]]().flatten
-        httpClient.expect[IgnoredEntity](Request(method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders)).withBody(EmptyBody))
+        httpClient.expect[IgnoredEntity](Request[F](method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders)).withBody(EmptyBody))
       }
-      def putFoo(headers: List[Header] = List.empty): Task[IgnoredEntity] = {
+      def putFoo(headers: List[Header] = List.empty): F[IgnoredEntity] = {
         val allHeaders = headers ++ List[Option[Header]]().flatten
-        httpClient.expect[IgnoredEntity](Request(method = Method.PUT, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders)).withBody(EmptyBody))
+        httpClient.expect[IgnoredEntity](Request[F](method = Method.PUT, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders)).withBody(EmptyBody))
       }
-      def postFoo(headers: List[Header] = List.empty): Task[IgnoredEntity] = {
+      def postFoo(headers: List[Header] = List.empty): F[IgnoredEntity] = {
         val allHeaders = headers ++ List[Option[Header]]().flatten
-        httpClient.expect[IgnoredEntity](Request(method = Method.POST, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders)).withBody(EmptyBody))
+        httpClient.expect[IgnoredEntity](Request[F](method = Method.POST, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders)).withBody(EmptyBody))
       }
-      def deleteFoo(headers: List[Header] = List.empty): Task[IgnoredEntity] = {
+      def deleteFoo(headers: List[Header] = List.empty): F[IgnoredEntity] = {
         val allHeaders = headers ++ List[Option[Header]]().flatten
-        httpClient.expect[IgnoredEntity](Request(method = Method.DELETE, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders)).withBody(EmptyBody))
+        httpClient.expect[IgnoredEntity](Request[F](method = Method.DELETE, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders)).withBody(EmptyBody))
       }
-      def patchFoo(headers: List[Header] = List.empty): Task[IgnoredEntity] = {
+      def patchFoo(headers: List[Header] = List.empty): F[IgnoredEntity] = {
         val allHeaders = headers ++ List[Option[Header]]().flatten
-        httpClient.expect[IgnoredEntity](Request(method = Method.PATCH, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders)).withBody(EmptyBody))
+        httpClient.expect[IgnoredEntity](Request[F](method = Method.PATCH, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders)).withBody(EmptyBody))
       }
-      def getBar(headers: List[Header] = List.empty): Task[IgnoredEntity] = {
+      def getBar(headers: List[Header] = List.empty): F[IgnoredEntity] = {
         val allHeaders = headers ++ List[Option[Header]]().flatten
-        httpClient.expect[IgnoredEntity](Request(method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/bar"), headers = Headers(allHeaders)).withBody(EmptyBody))
+        httpClient.expect[IgnoredEntity](Request[F](method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/bar"), headers = Headers(allHeaders)).withBody(EmptyBody))
       }
-      def getBaz(headers: List[Header] = List.empty): Task[io.circe.Json] = {
+      def getBaz(headers: List[Header] = List.empty): F[io.circe.Json] = {
         val allHeaders = headers ++ List[Option[Header]]().flatten
-        httpClient.expect[io.circe.Json](Request(method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/baz"), headers = Headers(allHeaders)).withBody(EmptyBody))
+        httpClient.expect[io.circe.Json](Request[F](method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/baz"), headers = Headers(allHeaders)).withBody(EmptyBody))
       }
     }
     """

--- a/src/test/scala/generators/Http4s/Client/DefaultParameters.scala
+++ b/src/test/scala/generators/Http4s/Client/DefaultParameters.scala
@@ -134,21 +134,21 @@ class DefaultParametersTest extends FunSuite with Matchers {
 
     val companion = q"""
     object StoreClient {
-      def apply(host: String = "http://petstore.swagger.io")(implicit httpClient: Client): StoreClient = new StoreClient(host = host)(httpClient = httpClient)
-      def httpClient(httpClient: Client, host: String = "http://petstore.swagger.io"): StoreClient = new StoreClient(host = host)(httpClient = httpClient)
+      def apply[F[_]](host: String = "http://petstore.swagger.io")(implicit effect: Effect[F], httpClient: Client[F]): StoreClient[F] = new StoreClient[F](host = host)(effect = effect, httpClient = httpClient)
+      def httpClient[F[_]](effect: Effect[F], httpClient: Client[F], host: String = "http://petstore.swagger.io"): StoreClient[F] = new StoreClient[F](host = host)(effect = effect, httpClient = httpClient)
     }
     """
 
     val client = q"""
-    class StoreClient(host: String = "http://petstore.swagger.io")(implicit httpClient: Client) {
+    class StoreClient[F[_]](host: String = "http://petstore.swagger.io")(implicit effect: Effect[F], httpClient: Client[F]) {
       val basePath: String = ""
-      def getOrderById(orderId: Long, defparmOpt: Option[Int] = Option(1), defparm: Int = 2, headerMeThis: String, headers: List[Header] = List.empty): Task[Order] = {
+      def getOrderById(orderId: Long, defparmOpt: Option[Int] = Option(1), defparm: Int = 2, headerMeThis: String, headers: List[Header] = List.empty): F[Order] = {
         val allHeaders = headers ++ List[Option[Header]](Some(Header("HeaderMeThis", Formatter.show(headerMeThis)))).flatten
-        httpClient.expect[Order](Request(method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/store/order/" + Formatter.addPath(orderId) + "?" + Formatter.addArg("defparm_opt", defparmOpt) + Formatter.addArg("defparm", defparm)), headers = Headers(allHeaders)).withBody(EmptyBody))
+        httpClient.expect[Order](Request[F](method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/store/order/" + Formatter.addPath(orderId) + "?" + Formatter.addArg("defparm_opt", defparmOpt) + Formatter.addArg("defparm", defparm)), headers = Headers(allHeaders)).withBody(EmptyBody))
       }
-      def deleteOrder(orderId: Long, headers: List[Header] = List.empty): Task[IgnoredEntity] = {
+      def deleteOrder(orderId: Long, headers: List[Header] = List.empty): F[IgnoredEntity] = {
         val allHeaders = headers ++ List[Option[Header]]().flatten
-        httpClient.expect[IgnoredEntity](Request(method = Method.DELETE, uri = Uri.unsafeFromString(host + basePath + "/store/order/" + Formatter.addPath(orderId)), headers = Headers(allHeaders)).withBody(EmptyBody))
+        httpClient.expect[IgnoredEntity](Request[F](method = Method.DELETE, uri = Uri.unsafeFromString(host + basePath + "/store/order/" + Formatter.addPath(orderId)), headers = Headers(allHeaders)).withBody(EmptyBody))
       }
     }
     """

--- a/src/test/scala/package.scala
+++ b/src/test/scala/package.scala
@@ -30,7 +30,7 @@ package object swagger {
       basePath = Option(swagger.getBasePath)
       paths = Option(swagger.getPaths).map(_.asScala.toList).getOrElse(List.empty)
       routes <- extractOperations(paths)
-      classNamedRoutes <- routes.map(route => getClassName(route.operation).map(_ -> route)).sequenceU
+      classNamedRoutes <- routes.map(route => getClassName(route.operation).map(_ -> route)).sequence
       groupedRoutes = classNamedRoutes.groupBy(_._1).mapValues(_.map(_._2)).toList
       frameworkImports <- getFrameworkImports(context.tracing)
 


### PR DESCRIPTION
Because of the update to cats 1.1.0, all of the dependencies needed to
be updated, too. There were also breaking api changes to both cats,
http4s, and fs2:

cats:
  1. Inject -> InjectK
  1. Coproduct -> EitherK
  1. EitherT.left now infers from F[A]
  1. No more need for sequenceU*, traverseU* due to Unapply updates

fs2:
  1. fs2.Strategy -> ExecutionContext
  1. fs2.Task -> cats.effect.IO

http4s:
  1. Most types now take a `F[_] : Effect`
  1. Request -> Request[F[_]]
  1. Entity*coder[A] -> Entity*coder[F[_], A]
  1. jsonEncoderOf[A] -> jsonEncoderOf[F[_], A]

I tested code generation with petstore.yaml and the resulting project
succeeded.