### PR TITLE
Update swagger-parser to fix definition parse bug

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,7 @@ val codegenSettings = Seq(
   ),
   libraryDependencies ++= testDependencies ++ Seq(
     "org.scalameta" %% "scalameta" % "2.0.1"
-    , "io.swagger" % "swagger-parser" % "1.0.32"
+    , "io.swagger" % "swagger-parser" % "1.0.34"
     , "org.tpolecat" %% "atto-core"  % "0.6.1"
     , "org.typelevel" %% "cats-core" % catsVersion
     , "org.typelevel" %% "cats-kernel" % catsVersion

--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/SwaggerUtil.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/SwaggerUtil.scala
@@ -295,6 +295,8 @@ object SwaggerUtil {
         Target.pure(Resolved(t"Double", None, Default(d).extract[Double].map(Lit.Double(_))))
       case d: DecimalProperty =>
         Target.pure(Resolved(t"BigDecimal", None, None))
+      case u: UntypedProperty =>
+        Target.error("FIXME: Got an untyped property, currently not supported")
       case p: AbstractProperty if p.getType.toLowerCase == "integer" =>
         Target.pure(Resolved(t"BigInt", None, None))
       case p: AbstractProperty if p.getType.toLowerCase == "number" =>

--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/SwaggerUtil.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/SwaggerUtil.scala
@@ -296,7 +296,7 @@ object SwaggerUtil {
       case d: DecimalProperty =>
         Target.pure(Resolved(t"BigDecimal", None, None))
       case u: UntypedProperty =>
-        Target.error("FIXME: Got an untyped property, currently not supported")
+        Target.pure(Resolved(t"io.circe.Json", None, None))
       case p: AbstractProperty if p.getType.toLowerCase == "integer" =>
         Target.pure(Resolved(t"BigInt", None, None))
       case p: AbstractProperty if p.getType.toLowerCase == "number" =>

--- a/src/test/scala/generators/AkkaHttp/PropertyExtractors.scala
+++ b/src/test/scala/generators/AkkaHttp/PropertyExtractors.scala
@@ -47,8 +47,6 @@ class PropertyExtractors extends FunSuite with Matchers {
     |        format: double
     |      number_property:
     |        type: number
-    |      property:
-    |        default: "what"
     |      object_property:
     |        type: object
     |""".stripMargin

--- a/src/test/scala/generators/AkkaHttp/PropertyExtractors.scala
+++ b/src/test/scala/generators/AkkaHttp/PropertyExtractors.scala
@@ -47,6 +47,8 @@ class PropertyExtractors extends FunSuite with Matchers {
     |        format: double
     |      number_property:
     |        type: number
+    |      untyped_property:
+    |        default: "what"
     |      object_property:
     |        type: object
     |""".stripMargin
@@ -75,6 +77,7 @@ class PropertyExtractors extends FunSuite with Matchers {
         longProperty: Option[Long] = None, intProperty: Option[Int] = None,
         integerProperty: Option[BigInt] = None, floatProperty: Option[Float] = None,
         doubleProperty: Option[Double] = None, numberProperty: Option[BigDecimal] = None,
+        untypedProperty: Option[io.circe.Json] = None,
         objectProperty: Option[io.circe.Json] = None
         /*, refProperty: Option[ref_target_property] = None, refTargetProperty: Option[String] = None,
         arrayProperty: Option[IndexedSeq[ref_target_property]] = Option(IndexedSeq.empty)
@@ -86,20 +89,20 @@ class PropertyExtractors extends FunSuite with Matchers {
       object Something {
         implicit val encodeSomething = {
           val readOnlyKeys = Set[String]()
-          Encoder.forProduct9(
+          Encoder.forProduct10(
               "boolean_value", "string_value", "long_property", "int_property", "integer_property", "float_property",
-              "double_property", "number_property", "object_property"
+              "double_property", "number_property", "untyped_property", "object_property"
               /*, "ref_property", "ref_target_property", "array_property" */
             )( (o: Something) => (
               o.booleanValue, o.stringValue, o.longProperty, o.intProperty, o.integerProperty, o.floatProperty,
-              o.doubleProperty, o.numberProperty, o.objectProperty
+              o.doubleProperty, o.numberProperty, o.untypedProperty, o.objectProperty
               /* , o.refProperty, o.refTargetProperty, o.arrayProperty */
             )
           ).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
         }
-        implicit val decodeSomething = Decoder.forProduct9(
+        implicit val decodeSomething = Decoder.forProduct10(
           "boolean_value", "string_value", "long_property", "int_property", "integer_property", "float_property",
-          "double_property", "number_property", "object_property"
+          "double_property", "number_property", "untyped_property", "object_property"
           /*, "ref_property", "ref_target_property", "array_property" */
         )(Something.apply _)
       }


### PR DESCRIPTION
While parsing swagger with additionalProperties, not all definitions are
resolved in swagger-parser < 1.0.34.
(https://github.com/swagger-api/swagger-parser/pull/602)
This brings us to the most recent version of swagger-parser on the 1.x
line.

Fixes: #40