### PR TITLE
added a note about "sbt"

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,6 +1,9 @@
 Example Usage
 ===
 
+Pre-requisites:
+* Install sbt and have it in your path
+
 Client
 ---
 


### PR DESCRIPTION
the first command suggested by the quickstart file fails with 
> ./cli.sh: 3: hash: sbt: not found
> Please ensure sbt is on your PATH

added a note to the file that need to install sbt before doing anything else