### PR TITLE
NPE and cleanup

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
@@ -297,11 +297,11 @@ object SwaggerUtil {
         Target.pure(Resolved(t"BigDecimal", None, None))
       case u: UntypedProperty =>
         Target.pure(Resolved(t"io.circe.Json", None, None))
-      case p: AbstractProperty if p.getType.toLowerCase == "integer" =>
+      case p: AbstractProperty if Option(p.getType).exists(_.toLowerCase == "integer") =>
         Target.pure(Resolved(t"BigInt", None, None))
-      case p: AbstractProperty if p.getType.toLowerCase == "number" =>
+      case p: AbstractProperty if Option(p.getType).exists(_.toLowerCase == "number") =>
         Target.pure(Resolved(t"BigDecimal", None, None))
-      case p: AbstractProperty if p.getType.toLowerCase == "string" =>
+      case p: AbstractProperty if Option(p.getType).exists(_.toLowerCase == "string") =>
         Target.pure(Resolved(t"String", None, None))
       case x =>
         Target.error(s"Unsupported swagger class ${x.getClass().getName()} (${x})")

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpClientGenerator.scala
@@ -46,11 +46,6 @@ object AkkaHttpClientGenerator {
 
     def apply[T](term: ClientTerm[T]): Target[T] = term match {
       case GenerateClientOperation(className, RouteMeta(pathStr, httpMethod, operation), tracing, protocolElems) => {
-        def toCamelCase(s: String): String = {
-          val fromSnakeOrDashed = "[_-]([a-z])".r.replaceAllIn(s, m => m.group(1).toUpperCase(Locale.US))
-          "^([A-Z])".r.replaceAllIn(fromSnakeOrDashed, m => m.group(1).toLowerCase(Locale.US))
-        }
-
         def generateUrlWithParams(path: String, pathArgs: List[ScalaParameter], qsArgs: List[ScalaParameter]): Target[Term] = {
           for {
             _ <- Target.log.debug("generateClientOperation", "generateUrlWithParams")(s"Using ${path} and ${pathArgs.map(_.argName)}")

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sClientGenerator.scala
@@ -46,11 +46,6 @@ object Http4sClientGenerator {
 
     def apply[T](term: ClientTerm[T]): Target[T] = term match {
       case GenerateClientOperation(className, RouteMeta(pathStr, httpMethod, operation), tracing, protocolElems) => {
-        def toCamelCase(s: String): String = {
-          val fromSnakeOrDashed = "[_-]([a-z])".r.replaceAllIn(s, m => m.group(1).toUpperCase(Locale.US))
-          "^([A-Z])".r.replaceAllIn(fromSnakeOrDashed, m => m.group(1).toLowerCase(Locale.US))
-        }
-
         def generateUrlWithParams(path: String, pathArgs: List[ScalaParameter], qsArgs: List[ScalaParameter]): Target[Term] = {
           for {
             _ <- Target.log.debug("generateClientOperation", "generateUrlWithParams")(s"Using ${path} and ${pathArgs.map(_.argName)}")

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaParameter.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaParameter.scala
@@ -8,7 +8,9 @@ import cats.syntax.traverse._
 import cats.instances.all._
 
 case class RawParameterName private[generators] (value: String) { def toLit: Lit.String = Lit.String(value) }
-class ScalaParameter private[generators] (val in: Option[String], val param: Term.Param, val paramName: Term.Name, val argName: RawParameterName, val argType: Type)
+class ScalaParameter private[generators] (val in: Option[String], val param: Term.Param, val paramName: Term.Name, val argName: RawParameterName, val argType: Type) {
+  override def toString: String = s"ScalaParameter(${in}, ${param}, ${paramName}, ${argName}, ${argType})"
+}
 object ScalaParameter {
   def unapply(param: ScalaParameter): Option[(Option[String], Term.Param, Term.Name, RawParameterName, Type)] =
     Some((param.in, param.param, param.paramName, param.argName, param.argType))

--- a/src/test/scala/core/Types.scala
+++ b/src/test/scala/core/Types.scala
@@ -1,0 +1,89 @@
+package tests.core
+
+import _root_.io.swagger.parser.SwaggerParser
+import cats.instances.all._
+import com.twilio.swagger._
+import com.twilio.guardrail.generators.AkkaHttp
+import com.twilio.guardrail.{Context, ClassDefinition, ProtocolDefinitions, ProtocolGenerator, CodegenApplication, Target}
+import org.scalatest.{FunSuite, Matchers}
+import scala.meta._
+
+class TypesTest extends FunSuite with Matchers {
+
+  val swagger = s"""
+    |swagger: "2.0"
+    |info:
+    |  title: Whatever
+    |  version: 1.0.0
+    |host: localhost:1234
+    |definitions:
+    |  Types:
+    |    type: object
+    |    properties:
+    |      array:
+    |        type: array
+    |        items:
+    |          type: boolean
+    |      map:
+    |        type: objet
+    |        additionalProperties:
+    |          type: boolean
+    |      obj:
+    |        type: object
+    |      bool:
+    |        type: boolean
+    |      string:
+    |        type: string
+    |      date:
+    |        type: string
+    |        format: date
+    |      date_time:
+    |        type: string
+    |        format: date-time
+    |      long:
+    |        type: integer
+    |        format: int64
+    |      int:
+    |        type: integer
+    |        format: int32
+    |      float:
+    |        type: number
+    |        format: float
+    |      double:
+    |        type: number
+    |        format: double
+    |      number:
+    |        type: number
+    |      integer:
+    |        type: integer
+    |      untyped:
+    |        description: Untyped
+    |""".stripMargin
+
+  test("Generate no definitions") {
+    val (
+      ProtocolDefinitions(ClassDefinition(_, _, cls, cmp) :: Nil, _, _, _),
+      _,
+      _
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+
+    val definition = q"""
+      case class Types(array: Option[IndexedSeq[Boolean]] = Option(IndexedSeq.empty), obj: Option[io.circe.Json] = None, bool: Option[Boolean] = None, string: Option[String] = None, date: Option[java.time.LocalDate] = None, dateTime: Option[java.time.OffsetDateTime] = None, long: Option[Long] = None, int: Option[Int] = None, float: Option[Float] = None, double: Option[Double] = None, number: Option[BigDecimal] = None, integer: Option[BigInt] = None, untyped: Option[io.circe.Json] = None)
+    """
+
+    val companion = q"""
+      object Types {
+        implicit val encodeTypes = {
+          val readOnlyKeys = Set[String]()
+          Encoder.forProduct13("array", "obj", "bool", "string", "date", "date_time", "long", "int", "float", "double", "number", "integer", "untyped")( (o: Types) =>
+            (o.array, o.obj, o.bool, o.string, o.date, o.dateTime, o.long, o.int, o.float, o.double, o.number, o.integer, o.untyped)
+          ).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
+        }
+        implicit val decodeTypes = Decoder.forProduct13("array", "obj", "bool", "string", "date", "date_time", "long", "int", "float", "double", "number", "integer", "untyped")(Types.apply _)
+      }
+    """
+
+    cls.structure shouldEqual definition.structure
+    cmp.structure shouldEqual companion.structure
+  }
+}


### PR DESCRIPTION
- Wrapping java API accesses with `Option` even though `UntypedProperty` should catch these cases
- Removing orphaned `toCamelCase` methods
- Adding `toString` to `ScalaParameter` for ease of use