### PR TITLE
Async multipart form file upload

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,10 +1,8 @@
-//align = true
-maxColumn = 120
-align=most
+style = defaultWithAlign
 
-align.openParenCallSite = true
-align.openParenDefnSite = false
-
-newlines.beforeImplicitKWInVerticalMultiline = false
-newlines.afterImplicitKWInVerticalMultiline = false
-newlines.penalizeSingleSelectMultiArgList = false
+danglingParentheses        = true
+maxColumn                  = 160
+project.excludeFilters     = [".*\\.sbt"]
+rewrite.rules              = [AsciiSortImports, RedundantBraces, RedundantParens]
+spaces.inImportCurlyBraces = true
+unindentTopLevelOperators  = true

--- a/build.sbt
+++ b/build.sbt
@@ -74,7 +74,7 @@ val codegenSettings = Seq(
     Resolver.bintrayRepo("scalameta", "maven")
   ),
   libraryDependencies ++= testDependencies ++ Seq(
-    "org.scalameta" %% "scalameta" % "2.0.1",
+    "org.scalameta" %% "scalameta" % "3.7.4",
     "io.swagger" % "swagger-parser" % "1.0.34",
     "org.tpolecat" %% "atto-core" % "0.6.1",
     "org.typelevel" %% "cats-core" % catsVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -14,12 +14,12 @@ scalaVersion in ThisBuild := crossScalaVersions.value.last
 scalafmtOnCompile in ThisBuild := true
 scalafmtFailTest in ThisBuild := false
 
-val akkaVersion = "10.0.10"
-val catsVersion = "1.1.0"
+val akkaVersion       = "10.0.10"
+val catsVersion       = "1.1.0"
 val catsEffectVersion = "0.10"
-val circeVersion = "0.9.3"
-val http4sVersion = "0.18.12"
-val scalatestVersion = "3.0.5"
+val circeVersion      = "0.9.3"
+val http4sVersion     = "0.18.12"
+val scalatestVersion  = "3.0.5"
 
 mainClass in assembly := Some("com.twilio.guardrail.CLI")
 
@@ -74,13 +74,13 @@ val codegenSettings = Seq(
     Resolver.bintrayRepo("scalameta", "maven")
   ),
   libraryDependencies ++= testDependencies ++ Seq(
-    "org.scalameta" %% "scalameta" % "3.7.4",
-    "io.swagger" % "swagger-parser" % "1.0.34",
-    "org.tpolecat" %% "atto-core" % "0.6.1",
-    "org.typelevel" %% "cats-core" % catsVersion,
-    "org.typelevel" %% "cats-kernel" % catsVersion,
-    "org.typelevel" %% "cats-macros" % catsVersion,
-    "org.typelevel" %% "cats-free" % catsVersion
+    "org.scalameta" %% "scalameta"     % "3.7.4",
+    "io.swagger"    % "swagger-parser" % "1.0.34",
+    "org.tpolecat"  %% "atto-core"     % "0.6.1",
+    "org.typelevel" %% "cats-core"     % catsVersion,
+    "org.typelevel" %% "cats-kernel"   % catsVersion,
+    "org.typelevel" %% "cats-macros"   % catsVersion,
+    "org.typelevel" %% "cats-free"     % catsVersion
   )
   // Dev
   ,
@@ -140,19 +140,19 @@ lazy val sample = (project in file("modules/sample"))
       |import scala.meta._
       |""".stripMargin,
     libraryDependencies ++= Seq(
-      "com.typesafe.akka" %% "akka-http" % akkaVersion,
-      "com.typesafe.akka" %% "akka-http-testkit" % akkaVersion,
-      "io.circe" %% "circe-core" % circeVersion,
-      "io.circe" %% "circe-generic" % circeVersion,
-      "io.circe" %% "circe-java8" % circeVersion,
-      "io.circe" %% "circe-parser" % circeVersion,
-      "org.http4s" %% "http4s-blaze-client" % http4sVersion,
-      "org.http4s" %% "http4s-blaze-server" % http4sVersion,
-      "org.http4s" %% "http4s-circe" % http4sVersion,
-      "org.http4s" %% "http4s-dsl" % http4sVersion,
-      "org.scalatest" %% "scalatest" % scalatestVersion % Test,
-      "org.typelevel" %% "cats-core" % catsVersion,
-      "org.typelevel" %% "cats-effect" % catsEffectVersion
+      "com.typesafe.akka" %% "akka-http"           % akkaVersion,
+      "com.typesafe.akka" %% "akka-http-testkit"   % akkaVersion,
+      "io.circe"          %% "circe-core"          % circeVersion,
+      "io.circe"          %% "circe-generic"       % circeVersion,
+      "io.circe"          %% "circe-java8"         % circeVersion,
+      "io.circe"          %% "circe-parser"        % circeVersion,
+      "org.http4s"        %% "http4s-blaze-client" % http4sVersion,
+      "org.http4s"        %% "http4s-blaze-server" % http4sVersion,
+      "org.http4s"        %% "http4s-circe"        % http4sVersion,
+      "org.http4s"        %% "http4s-dsl"          % http4sVersion,
+      "org.scalatest"     %% "scalatest"           % scalatestVersion % Test,
+      "org.typelevel"     %% "cats-core"           % catsVersion,
+      "org.typelevel"     %% "cats-effect"         % catsEffectVersion
     ),
     skip in publish := true
   )

--- a/build.sbt
+++ b/build.sbt
@@ -55,6 +55,7 @@ artifact in (Compile, assembly) := {
 addArtifact(artifact in (Compile, assembly), assembly)
 
 addCommandAlias("cli", "runMain com.twilio.guardrail.CLI")
+addCommandAlias("format", "; codegen/scalafmt ; codegen/test:scalafmt ; scalafmt ; test:scalafmt ; sample/scalafmt ; sample/test:scalafmt")
 
 val resetSample = TaskKey[Unit]("resetSample", "Reset sample module")
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Args.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Args.scala
@@ -15,15 +15,7 @@ case class Args(
 )
 
 object Args {
-  val empty = Args(CodegenTarget.Client,
-                   Option.empty,
-                   Option.empty,
-                   Option.empty,
-                   List.empty,
-                   false,
-                   Context.empty,
-                   false,
-                   List.empty)
+  val empty = Args(CodegenTarget.Client, Option.empty, Option.empty, Option.empty, List.empty, false, Context.empty, false, List.empty)
   def isEmpty: Args => Boolean = { args =>
     args.specPath.isEmpty &&
     args.outputPath.isEmpty &&

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/CLI.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/CLI.scala
@@ -8,6 +8,7 @@ import cats.~>
 import com.twilio.guardrail.core.CoreTermInterp
 import com.twilio.guardrail.terms.CoreTerm
 import com.twilio.swagger.core.{ LogLevel, LogLevels }
+import com.twilio.guardrail.generators.GeneratorSettings
 
 import scala.io.AnsiColor
 
@@ -20,11 +21,11 @@ object CLICommon {
       args.span(arg => LogLevels(arg.stripPrefix("--")).isDefined)
     val level: Option[String] = levels.lastOption.map(_.stripPrefix("--"))
 
-    val fallback = List.empty[ReadSwagger[Target[List[WriteTree]]]]
+    val fallback = List.empty[(GeneratorSettings, ReadSwagger[Target[List[WriteTree]]])]
     val result = Common
       .runM[CoreTerm](newArgs)
       .foldMap(interpreter)
-      .fold[List[ReadSwagger[Target[List[WriteTree]]]]](
+      .fold[List[(GeneratorSettings, ReadSwagger[Target[List[WriteTree]]])]](
         {
           case MissingArg(args, Error.ArgName(arg)) =>
             println(s"${AnsiColor.RED}Missing argument:${AnsiColor.RESET} ${AnsiColor.BOLD}${arg}${AnsiColor.RESET} (In block ${args})")
@@ -64,16 +65,17 @@ object CLICommon {
     print(coreLogger.show)
 
     val (logger, paths) = deferred
-      .map({ rs =>
-        ReadSwagger
-          .unsafeReadSwagger(rs)
-          .fold({ err =>
-            println(s"${AnsiColor.RED}Error: $err${AnsiColor.RESET}")
-            unsafePrintHelp()
-            List.empty[Path]
-          }, _.map(WriteTree.unsafeWriteTree))
+      .traverse({
+        case (generatorSettings, rs) =>
+          ReadSwagger
+            .unsafeReadSwagger(rs)
+            .fold({ err =>
+              println(s"${AnsiColor.RED}Error: $err${AnsiColor.RESET}")
+              unsafePrintHelp()
+              List.empty[Path]
+            }, _.map(WriteTree.unsafeWriteTree))
+            .run(generatorSettings)
       })
-      .sequence
       .map(_.flatten)
       .run
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/CLI.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/CLI.scala
@@ -7,7 +7,7 @@ import cats.syntax.traverse._
 import cats.~>
 import com.twilio.guardrail.core.CoreTermInterp
 import com.twilio.guardrail.terms.CoreTerm
-import com.twilio.swagger.core.{LogLevel, LogLevels}
+import com.twilio.swagger.core.{ LogLevel, LogLevels }
 
 import scala.io.AnsiColor
 
@@ -27,8 +27,7 @@ object CLICommon {
       .fold[List[ReadSwagger[Target[List[WriteTree]]]]](
         {
           case MissingArg(args, Error.ArgName(arg)) =>
-            println(
-              s"${AnsiColor.RED}Missing argument:${AnsiColor.RESET} ${AnsiColor.BOLD}${arg}${AnsiColor.RESET} (In block ${args})")
+            println(s"${AnsiColor.RED}Missing argument:${AnsiColor.RESET} ${AnsiColor.BOLD}${arg}${AnsiColor.RESET} (In block ${args})")
             unsafePrintHelp()
             fallback
           case NoArgsSpecified =>
@@ -120,9 +119,8 @@ object CLICommon {
 trait CLICommon {
   val interpreter: CoreTerm ~> CoreTarget
 
-  def main(args: Array[String]): Unit = {
+  def main(args: Array[String]): Unit =
     CLICommon.run(args)(interpreter)
-  }
 }
 
 object CLI extends CLICommon {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ClientGenerator.scala
@@ -4,11 +4,11 @@ import _root_.io.swagger.models._
 import cats.free.Free
 import cats.instances.all._
 import cats.syntax.all._
-import com.twilio.guardrail.protocol.terms.client.{ClientTerm, ClientTerms}
+import com.twilio.guardrail.protocol.terms.client.{ ClientTerm, ClientTerms }
 import com.twilio.guardrail.terms.framework.FrameworkTerms
 
 import scala.collection.JavaConverters._
-import scala.meta.{Lit, Term, Type, _}
+import scala.meta.{ Lit, Term, Type, _ }
 import com.twilio.guardrail.terms.RouteMeta
 
 case class Clients(clients: List[Client])
@@ -21,31 +21,23 @@ object ClientGenerator {
       schemes: List[String],
       host: Option[String],
       basePath: Option[String],
-      groupedRoutes: List[(List[String], List[RouteMeta])])(
-      protocolElems: List[StrictProtocolElems])(implicit C: ClientTerms[F], F: FrameworkTerms[F]): Free[F, Clients] = {
+      groupedRoutes: List[(List[String], List[RouteMeta])]
+  )(protocolElems: List[StrictProtocolElems])(implicit C: ClientTerms[F], F: FrameworkTerms[F]): Free[F, Clients] = {
     import C._
     import F._
     for {
-      generatorSettings <- getGeneratorSettings()
-      clientImports <- getImports(context.tracing)
+      generatorSettings  <- getGeneratorSettings()
+      clientImports      <- getImports(context.tracing)
       clientExtraImports <- getExtraImports(context.tracing)
       clients <- groupedRoutes.traverse({
         case (pkg, routes) =>
           for {
-            clientCalls <- routes.traverse(
-              generateClientOperation(pkg, context.tracing, protocolElems, generatorSettings) _)
-            clientName = s"${pkg.lastOption.getOrElse("").capitalize}Client"
+            clientCalls <- routes.traverse(generateClientOperation(pkg, context.tracing, protocolElems, generatorSettings) _)
+            clientName  = s"${pkg.lastOption.getOrElse("").capitalize}Client"
             tracingName = Option(pkg.mkString("-")).filterNot(_.isEmpty)
-            ctorArgs <- clientClsArgs(tracingName, schemes, host, context.tracing)
+            ctorArgs  <- clientClsArgs(tracingName, schemes, host, context.tracing)
             companion <- buildCompanion(clientName, tracingName, schemes, host, ctorArgs, context.tracing)
-            client <- buildClient(clientName,
-                                  tracingName,
-                                  schemes,
-                                  host,
-                                  basePath,
-                                  ctorArgs,
-                                  clientCalls,
-                                  context.tracing)
+            client    <- buildClient(clientName, tracingName, schemes, host, basePath, ctorArgs, clientCalls, context.tracing)
           } yield {
             val stats: List[Stat] = (
               (clientImports ++ frameworkImports ++ clientExtraImports) :+

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ClientGenerator.scala
@@ -5,7 +5,6 @@ import cats.free.Free
 import cats.instances.all._
 import cats.syntax.all._
 import com.twilio.guardrail.protocol.terms.client.{ ClientTerm, ClientTerms }
-import com.twilio.guardrail.terms.framework.FrameworkTerms
 
 import scala.collection.JavaConverters._
 import scala.meta.{ Lit, Term, Type, _ }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ClientGenerator.scala
@@ -5,6 +5,7 @@ import cats.free.Free
 import cats.instances.all._
 import cats.syntax.all._
 import com.twilio.guardrail.protocol.terms.client.{ClientTerm, ClientTerms}
+import com.twilio.guardrail.terms.framework.FrameworkTerms
 
 import scala.collection.JavaConverters._
 import scala.meta.{Lit, Term, Type, _}
@@ -20,16 +21,19 @@ object ClientGenerator {
       schemes: List[String],
       host: Option[String],
       basePath: Option[String],
-      groupedRoutes: List[(List[String], List[RouteMeta])])(protocolElems: List[StrictProtocolElems])(
-      implicit C: ClientTerms[F]): Free[F, Clients] = {
+      groupedRoutes: List[(List[String], List[RouteMeta])])(
+      protocolElems: List[StrictProtocolElems])(implicit C: ClientTerms[F], F: FrameworkTerms[F]): Free[F, Clients] = {
     import C._
+    import F._
     for {
+      generatorSettings <- getGeneratorSettings()
       clientImports <- getImports(context.tracing)
       clientExtraImports <- getExtraImports(context.tracing)
       clients <- groupedRoutes.traverse({
         case (pkg, routes) =>
           for {
-            clientCalls <- routes.traverse(generateClientOperation(pkg, context.tracing, protocolElems) _)
+            clientCalls <- routes.traverse(
+              generateClientOperation(pkg, context.tracing, protocolElems, generatorSettings) _)
             clientName = s"${pkg.lastOption.getOrElse("").capitalize}Client"
             tracingName = Option(pkg.mkString("-")).filterNot(_.isEmpty)
             ctorArgs <- clientClsArgs(tracingName, schemes, host, context.tracing)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ClientGenerator.scala
@@ -22,17 +22,15 @@ object ClientGenerator {
       host: Option[String],
       basePath: Option[String],
       groupedRoutes: List[(List[String], List[RouteMeta])]
-  )(protocolElems: List[StrictProtocolElems])(implicit C: ClientTerms[F], F: FrameworkTerms[F]): Free[F, Clients] = {
+  )(protocolElems: List[StrictProtocolElems])(implicit C: ClientTerms[F]): Free[F, Clients] = {
     import C._
-    import F._
     for {
-      generatorSettings  <- getGeneratorSettings()
       clientImports      <- getImports(context.tracing)
       clientExtraImports <- getExtraImports(context.tracing)
       clients <- groupedRoutes.traverse({
         case (pkg, routes) =>
           for {
-            clientCalls <- routes.traverse(generateClientOperation(pkg, context.tracing, protocolElems, generatorSettings) _)
+            clientCalls <- routes.traverse(generateClientOperation(pkg, context.tracing, protocolElems) _)
             clientName  = s"${pkg.lastOption.getOrElse("").capitalize}Client"
             tracingName = Option(pkg.mkString("-")).filterNot(_.isEmpty)
             ctorArgs  <- clientClsArgs(tracingName, schemes, host, context.tracing)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -8,30 +8,28 @@ import cats.syntax.either._
 import cats.syntax.semigroup._
 import cats.syntax.traverse._
 import cats.~>
-import com.twilio.guardrail.terms.{CoreTerm, CoreTerms, ScalaTerms, SwaggerTerms}
+import com.twilio.guardrail.terms.{ CoreTerm, CoreTerms, ScalaTerms, SwaggerTerms }
 import com.twilio.guardrail.terms.framework.FrameworkTerms
-import java.nio.file.{Path, Paths}
+import java.nio.file.{ Path, Paths }
 import scala.collection.JavaConverters._
 import scala.io.AnsiColor
 import scala.meta._
 
 object Common {
-  def writePackage(
-      kind: CodegenTarget,
-      context: Context,
-      swagger: Swagger,
-      outputPath: Path,
-      pkgName: List[String],
-      dtoPackage: List[String],
-      customImports: List[Import])(
-      implicit F: FrameworkTerms[CodegenApplication],
-      Sc: ScalaTerms[CodegenApplication],
-      Sw: SwaggerTerms[CodegenApplication]): Free[CodegenApplication, List[WriteTree]] = {
+  def writePackage(kind: CodegenTarget,
+                   context: Context,
+                   swagger: Swagger,
+                   outputPath: Path,
+                   pkgName: List[String],
+                   dtoPackage: List[String],
+                   customImports: List[Import])(implicit F: FrameworkTerms[CodegenApplication],
+                                                Sc: ScalaTerms[CodegenApplication],
+                                                Sw: SwaggerTerms[CodegenApplication]): Free[CodegenApplication, List[WriteTree]] = {
     import F._
     import Sc._
     import Sw._
 
-    val resolveFile: Path => List[String] => Path = root => _.foldLeft(root)(_.resolve(_))
+    val resolveFile: Path => List[String] => Path       = root => _.foldLeft(root)(_.resolve(_))
     val splitComponents: String => Option[List[String]] = x => Some(x.split('.').toList).filterNot(_.isEmpty)
 
     val buildPackage: String => Option[Term.Ref] = pkg =>
@@ -39,10 +37,10 @@ object Common {
         .map(dtoPackage ++ _)
         .map(_.map(Term.Name.apply _).reduceLeft(Term.Select.apply _))
 
-    val pkgPath = resolveFile(outputPath)(pkgName)
+    val pkgPath        = resolveFile(outputPath)(pkgName)
     val dtoPackagePath = resolveFile(pkgPath.resolve("definitions"))(dtoPackage)
 
-    val definitions: List[String] = pkgName :+ "definitions"
+    val definitions: List[String]   = pkgName :+ "definitions"
     val dtoComponents: List[String] = definitions ++ dtoPackage
     val buildPkgTerm: List[String] => Term.Ref =
       _.map(Term.Name.apply _).reduceLeft(Term.Select.apply _)
@@ -50,8 +48,8 @@ object Common {
     for {
       proto <- ProtocolGenerator.fromSwagger[CodegenApplication](swagger)
       ProtocolDefinitions(protocolElems, protocolImports, packageObjectImports, packageObjectContents) = proto
-      implicitsImport = q"import ${buildPkgTerm(List("_root_") ++ pkgName ++ List("Implicits"))}._"
-      imports = customImports ++ protocolImports ++ List(implicitsImport)
+      implicitsImport                                                                                  = q"import ${buildPkgTerm(List("_root_") ++ pkgName ++ List("Implicits"))}._"
+      imports                                                                                          = customImports ++ protocolImports ++ List(implicitsImport)
 
       protoOut = protocolElems
         .map({
@@ -65,7 +63,8 @@ object Common {
                 $cls
                 $obj
               """
-               )),
+               )
+             ),
              List.empty[Stat])
 
           case ClassDefinition(_, _, cls, obj) =>
@@ -78,7 +77,8 @@ object Common {
                 $cls
                 $obj
               """
-               )),
+               )
+             ),
              List.empty[Stat])
 
           case RandomType(_, _) =>
@@ -100,19 +100,19 @@ object Common {
 
       schemes = Option(swagger.getSchemes)
         .fold(List.empty[String])(_.asScala.to[List].map(_.toValue))
-      host = Option(swagger.getHost)
+      host     = Option(swagger.getHost)
       basePath = Option(swagger.getBasePath)
       paths = Option(swagger.getPaths)
         .map(_.asScala.toList)
         .getOrElse(List.empty)
-      routes <- extractOperations(paths)
+      routes           <- extractOperations(paths)
       classNamedRoutes <- routes.traverse(route => getClassName(route.operation).map(_ -> route))
       groupedRoutes = classNamedRoutes
         .groupBy(_._1)
         .mapValues(_.map(_._2))
         .toList
-      generatorSettings <- getGeneratorSettings()
-      frameworkImports <- getFrameworkImports(context.tracing)
+      generatorSettings  <- getGeneratorSettings()
+      frameworkImports   <- getFrameworkImports(context.tracing)
       frameworkImplicits <- getFrameworkImplicits(generatorSettings)
       frameworkImplicitName = frameworkImplicits.name
 
@@ -120,8 +120,7 @@ object Common {
         case CodegenTarget.Client =>
           for {
             clientMeta <- ClientGenerator
-              .fromSwagger[CodegenApplication](context, frameworkImports)(schemes, host, basePath, groupedRoutes)(
-                protocolElems)
+              .fromSwagger[CodegenApplication](context, frameworkImports)(schemes, host, basePath, groupedRoutes)(protocolElems)
             Clients(clients) = clientMeta
           } yield CodegenDefinitions(clients, List.empty)
 
@@ -172,7 +171,7 @@ object Common {
           .to[List]
         )
 
-      implicits <- renderImplicits(pkgName, frameworkImports, protocolImports, customImports)
+      implicits              <- renderImplicits(pkgName, frameworkImports, protocolImports, customImports)
       frameworkImplicitsFile <- renderFrameworkImplicits(pkgName, frameworkImports, protocolImports, frameworkImplicits)
     } yield
       (
@@ -186,25 +185,25 @@ object Common {
       ).toList
   }
 
-  def processArgs[F[_]](args: NonEmptyList[Args])(
-      implicit C: CoreTerms[F]): Free[F, NonEmptyList[ReadSwagger[Target[List[WriteTree]]]]] = {
+  def processArgs[F[_]](args: NonEmptyList[Args])(implicit C: CoreTerms[F]): Free[F, NonEmptyList[ReadSwagger[Target[List[WriteTree]]]]] = {
     import C._
-    args.traverse(arg =>
-      for {
-        targetInterpreter <- extractGenerator(arg.context)
-        writeFile <- processArgSet(targetInterpreter)(arg)
-      } yield writeFile)
+    args.traverse(
+      arg =>
+        for {
+          targetInterpreter <- extractGenerator(arg.context)
+          writeFile         <- processArgSet(targetInterpreter)(arg)
+        } yield writeFile
+    )
   }
 
-  def runM[F[_]](args: Array[String])(
-      implicit C: CoreTerms[F]): Free[F, NonEmptyList[ReadSwagger[Target[List[WriteTree]]]]] = {
+  def runM[F[_]](args: Array[String])(implicit C: CoreTerms[F]): Free[F, NonEmptyList[ReadSwagger[Target[List[WriteTree]]]]] = {
     import C._
 
     for {
       defaultFramework <- getDefaultFramework
-      parsed <- parseArgs(args, defaultFramework)
-      args <- validateArgs(parsed)
-      writeTrees <- processArgs(args)
+      parsed           <- parseArgs(args, defaultFramework)
+      args             <- validateArgs(parsed)
+      writeTrees       <- processArgs(args)
     } yield writeTrees
   }
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -111,8 +111,9 @@ object Common {
         .groupBy(_._1)
         .mapValues(_.map(_._2))
         .toList
+      generatorSettings <- getGeneratorSettings()
       frameworkImports <- getFrameworkImports(context.tracing)
-      frameworkImplicits <- getFrameworkImplicits()
+      frameworkImplicits <- getFrameworkImplicits(generatorSettings)
       frameworkImplicitName = frameworkImplicits.name
 
       codegen <- kind match {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -16,13 +16,14 @@ import scala.io.AnsiColor
 import scala.meta._
 
 object Common {
-  def writePackage(kind: CodegenTarget,
-                   context: Context,
-                   swagger: Swagger,
-                   outputPath: Path,
-                   pkgName: List[String],
-                   dtoPackage: List[String],
-                   customImports: List[Import])(
+  def writePackage(
+      kind: CodegenTarget,
+      context: Context,
+      swagger: Swagger,
+      outputPath: Path,
+      pkgName: List[String],
+      dtoPackage: List[String],
+      customImports: List[Import])(
       implicit F: FrameworkTerms[CodegenApplication],
       Sc: ScalaTerms[CodegenApplication],
       Sw: SwaggerTerms[CodegenApplication]): Free[CodegenApplication, List[WriteTree]] = {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Error.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Error.scala
@@ -1,13 +1,13 @@
 package com.twilio.guardrail
 
 sealed trait Error
-case class MissingArg(arg: Args, name: Error.ArgName) extends Error
-case class UnknownArguments(args: List[String]) extends Error
-case class UnknownFramework(name: String) extends Error
+case class MissingArg(arg: Args, name: Error.ArgName)         extends Error
+case class UnknownArguments(args: List[String])               extends Error
+case class UnknownFramework(name: String)                     extends Error
 case class UnparseableArgument(name: String, message: String) extends Error
-case object NoArgsSpecified extends Error
-case object NoFramework extends Error
-case object PrintHelp extends Error
+case object NoArgsSpecified                                   extends Error
+case object NoFramework                                       extends Error
+case object PrintHelp                                         extends Error
 object Error {
   case class ArgName(value: String) extends AnyVal
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolElems.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolElems.scala
@@ -5,29 +5,22 @@ import scala.meta._
 
 sealed trait ProtocolElems
 
-sealed trait LazyProtocolElems extends ProtocolElems { def name: String }
-case class Deferred(name: String) extends LazyProtocolElems
+sealed trait LazyProtocolElems         extends ProtocolElems { def name: String }
+case class Deferred(name: String)      extends LazyProtocolElems
 case class DeferredArray(name: String) extends LazyProtocolElems
-case class DeferredMap(name: String) extends LazyProtocolElems
+case class DeferredMap(name: String)   extends LazyProtocolElems
 
-sealed trait StrictProtocolElems extends ProtocolElems { def name: String }
-case class RandomType(name: String, tpe: Type) extends StrictProtocolElems
-case class ClassDefinition(name: String, tpe: Type.Name, cls: Defn.Class, companion: Defn.Object)
-    extends StrictProtocolElems
-case class EnumDefinition(
-    name: String,
-    tpe: Type.Name,
-    elems: List[(String, Term.Name, Term.Select)],
-    cls: Defn.Class,
-    companion: Defn.Object)
+sealed trait StrictProtocolElems                                                                  extends ProtocolElems { def name: String }
+case class RandomType(name: String, tpe: Type)                                                    extends StrictProtocolElems
+case class ClassDefinition(name: String, tpe: Type.Name, cls: Defn.Class, companion: Defn.Object) extends StrictProtocolElems
+case class EnumDefinition(name: String, tpe: Type.Name, elems: List[(String, Term.Name, Term.Select)], cls: Defn.Class, companion: Defn.Object)
     extends StrictProtocolElems
 
 object ProtocolElems {
-  def resolve[F[_]](elems: List[ProtocolElems], limit: Int = 10)(
-      implicit M: MonadError[F, String]): F[List[StrictProtocolElems]] = {
+  def resolve[F[_]](elems: List[ProtocolElems], limit: Int = 10)(implicit M: MonadError[F, String]): F[List[StrictProtocolElems]] =
     M.tailRecM[(Int, List[ProtocolElems]), List[StrictProtocolElems]]((limit, elems))({
       case (iters, xs) if iters > 0 =>
-        val lazyElems = xs.collect { case x: LazyProtocolElems     => x }
+        val lazyElems   = xs.collect { case x: LazyProtocolElems   => x }
         val strictElems = xs.collect { case x: StrictProtocolElems => x }
         if (lazyElems.nonEmpty) {
           val newElems = strictElems ++ lazyElems.map {
@@ -74,5 +67,4 @@ object ProtocolElems {
         val lazyElems = xs.collect { case x: LazyProtocolElems => x }
         M.raiseError(s"Unable to resolve: ${lazyElems.map(_.name)}")
     })
-  }
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolElems.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolElems.scala
@@ -14,11 +14,12 @@ sealed trait StrictProtocolElems extends ProtocolElems { def name: String }
 case class RandomType(name: String, tpe: Type) extends StrictProtocolElems
 case class ClassDefinition(name: String, tpe: Type.Name, cls: Defn.Class, companion: Defn.Object)
     extends StrictProtocolElems
-case class EnumDefinition(name: String,
-                          tpe: Type.Name,
-                          elems: List[(String, Term.Name, Term.Select)],
-                          cls: Defn.Class,
-                          companion: Defn.Object)
+case class EnumDefinition(
+    name: String,
+    tpe: Type.Name,
+    elems: List[(String, Term.Name, Term.Select)],
+    cls: Defn.Class,
+    companion: Defn.Object)
     extends StrictProtocolElems
 
 object ProtocolElems {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
@@ -16,16 +16,18 @@ import scala.language.postfixOps
 import scala.language.reflectiveCalls
 import scala.meta._
 
-case class ProtocolDefinitions(elems: List[StrictProtocolElems],
-                               protocolImports: List[Import],
-                               packageObjectImports: List[Import],
-                               packageObjectContents: List[Stat])
+case class ProtocolDefinitions(
+    elems: List[StrictProtocolElems],
+    protocolImports: List[Import],
+    packageObjectImports: List[Import],
+    packageObjectContents: List[Stat])
 
-case class ProtocolParameter(term: Term.Param,
-                             name: String,
-                             dep: Option[Term.Name],
-                             readOnlyKey: Option[String],
-                             emptyToNullKey: Option[String])
+case class ProtocolParameter(
+    term: Term.Param,
+    name: String,
+    dep: Option[Term.Name],
+    readOnlyKey: Option[String],
+    emptyToNullKey: Option[String])
 
 object ProtocolGenerator {
   private[this] def fromEnum[F[_]](clsName: String, swagger: ModelImpl)(
@@ -148,11 +150,12 @@ object ProtocolGenerator {
     } yield ret
   }
 
-  def fromSwagger[F[_]](swagger: Swagger)(implicit E: EnumProtocolTerms[F],
-                                          M: ModelProtocolTerms[F],
-                                          A: AliasProtocolTerms[F],
-                                          R: ArrayProtocolTerms[F],
-                                          S: ProtocolSupportTerms[F]): Free[F, ProtocolDefinitions] = {
+  def fromSwagger[F[_]](swagger: Swagger)(
+      implicit E: EnumProtocolTerms[F],
+      M: ModelProtocolTerms[F],
+      A: AliasProtocolTerms[F],
+      R: ArrayProtocolTerms[F],
+      S: ProtocolSupportTerms[F]): Free[F, ProtocolDefinitions] = {
     import S._
 
     val definitions = Option(swagger.getDefinitions).toList.flatMap(_.asScala)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ReadSwagger.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ReadSwagger.scala
@@ -9,14 +9,13 @@ import scala.util.Try
 
 case class ReadSwagger[T](path: Path, next: Swagger => T)
 object ReadSwagger {
-  def unsafeReadSwagger[T: Monoid](rs: ReadSwagger[T]): T = {
+  def unsafeReadSwagger[T: Monoid](rs: ReadSwagger[T]): T =
     (for {
       absolutePath <- Try(rs.path.toAbsolutePath.toString).toOption
-      swagger <- Option(new SwaggerParser().read(absolutePath))
+      swagger      <- Option(new SwaggerParser().read(absolutePath))
     } yield rs.next(swagger))
       .getOrElse {
         println(s"${AnsiColor.RED}Spec file ${rs.path} is either incorrectly formatted or missing.${AnsiColor.RESET}")
         Monoid.empty[T]
       }
-  }
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
@@ -7,7 +7,6 @@ import cats.free.Free
 import cats.instances.all._
 import cats.syntax.all._
 import com.twilio.guardrail.generators.ScalaParameter
-import com.twilio.guardrail.terms.framework.FrameworkTerms
 import com.twilio.guardrail.protocol.terms.server.{ ServerTerm, ServerTerms }
 
 import scala.collection.JavaConverters._
@@ -34,9 +33,8 @@ object ServerGenerator {
 
   def fromSwagger[F[_]](context: Context, swagger: Swagger, frameworkImports: List[Import])(
       protocolElems: List[StrictProtocolElems]
-  )(implicit S: ServerTerms[F], F: FrameworkTerms[F]): Free[F, Servers] = {
+  )(implicit S: ServerTerms[F]): Free[F, Servers] = {
     import S._
-    import F._
 
     val paths: List[(String, Path)] =
       Option(swagger.getPaths).map(_.asScala.toList).getOrElse(List.empty)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
@@ -43,9 +43,8 @@ object ServerGenerator {
     val basePath: Option[String] = Option(swagger.getBasePath)
 
     for {
-      generatorSettings <- getGeneratorSettings()
-      routes            <- extractOperations(paths)
-      classNamedRoutes  <- routes.traverse(route => getClassName(route.operation).map(_ -> route))
+      routes           <- extractOperations(paths)
+      classNamedRoutes <- routes.traverse(route => getClassName(route.operation).map(_ -> route))
       groupedRoutes = classNamedRoutes
         .groupBy(_._1)
         .mapValues(_.map(_._2))
@@ -60,9 +59,9 @@ object ServerGenerator {
             renderedRoutes <- routes.traverse {
               case sr @ ServerRoute(path, method, operation) =>
                 for {
-                  tracingFields       <- buildTracingFields(operation, className, context.tracing, generatorSettings)
-                  responseDefinitions <- generateResponseDefinitions(operation, protocolElems, generatorSettings)
-                  rendered            <- generateRoute(resourceName, basePath, tracingFields, responseDefinitions, protocolElems, generatorSettings)(sr)
+                  tracingFields       <- buildTracingFields(operation, className, context.tracing)
+                  responseDefinitions <- generateResponseDefinitions(operation, protocolElems)
+                  rendered            <- generateRoute(resourceName, basePath, tracingFields, responseDefinitions, protocolElems)(sr)
                 } yield rendered
             }
             routeTerms = renderedRoutes.map(_.route)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
@@ -59,7 +59,7 @@ object ServerGenerator {
             renderedRoutes <- routes.traverse {
               case sr @ ServerRoute(path, method, operation) =>
                 for {
-                  tracingFields <- buildTracingFields(operation, className, context.tracing)
+                  tracingFields <- buildTracingFields(operation, className, context.tracing, generatorSettings)
                   responseDefinitions <- generateResponseDefinitions(operation, protocolElems, generatorSettings)
                   rendered <- generateRoute(resourceName,
                                             basePath,

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
@@ -422,9 +422,10 @@ object SwaggerUtil {
   private[this] def hasEmptySuccessType(responses: JMap[String, Response]): Boolean =
     successCodesWithoutEntities.exists(responses.containsKey)
 
-  def getResponseType(httpMethod: HttpMethod,
-                      operation: Operation,
-                      ignoredType: Type = t"IgnoredEntity"): Target[ResolvedType] = {
+  def getResponseType(
+      httpMethod: HttpMethod,
+      operation: Operation,
+      ignoredType: Type = t"IgnoredEntity"): Target[ResolvedType] = {
     if (httpMethod == HttpMethod.GET || httpMethod == HttpMethod.PUT || httpMethod == HttpMethod.POST) {
       Option(operation.getResponses)
         .flatMap { responses =>

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/WriteTree.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/WriteTree.scala
@@ -1,7 +1,7 @@
 package com.twilio.guardrail
 
 import java.nio.charset.StandardCharsets.UTF_8
-import java.nio.file.{Files, Path, StandardOpenOption}
+import java.nio.file.{ Files, Path, StandardOpenOption }
 import scala.io.AnsiColor
 import scala.meta._
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
@@ -6,8 +6,8 @@ import cats.instances.all._
 import cats.syntax.flatMap._
 import cats.syntax.either._
 import cats.syntax.traverse._
-import cats.{~>, FlatMap}
-import com.twilio.guardrail.generators.{AkkaHttp, Http4s}
+import cats.{ FlatMap, ~> }
+import com.twilio.guardrail.generators.{ AkkaHttp, Http4s }
 import com.twilio.guardrail.terms._
 import java.nio.file.Paths
 import scala.io.AnsiColor
@@ -22,8 +22,7 @@ object CoreTermInterp extends (CoreTerm ~> CoreTarget) {
     case ExtractGenerator(context) =>
       for {
         _ <- CoreTarget.log.debug("core", "extractGenerator")("Looking up framework")
-        framework <- context.framework.fold(
-          CoreTarget.error[cats.arrow.FunctionK[CodegenApplication, Target]](NoFramework))({
+        framework <- context.framework.fold(CoreTarget.error[cats.arrow.FunctionK[CodegenApplication, Target]](NoFramework))({
           case "akka-http" => CoreTarget.pure(AkkaHttp)
           case "http4s"    => CoreTarget.pure(Http4s)
           case unknown     => CoreTarget.error(UnknownFramework(unknown))
@@ -47,7 +46,7 @@ object CoreTermInterp extends (CoreTerm ~> CoreTarget) {
         Args.empty.copy(context = Args.empty.context.copy(framework = Some(defaultFramework)), defaults = true)
 
       type From = (List[Args], List[String])
-      type To = List[Args]
+      type To   = List[Args]
       val start: From = (List.empty[Args], args.toList)
       import CoreTarget.log.debug
       FlatMap[CoreTarget].tailRecM[From, To](start)({
@@ -88,7 +87,8 @@ object CoreTermInterp extends (CoreTerm ~> CoreTarget) {
                 Continue(
                   (sofar
                      .copy(outputPath = Option(expandTilde(value))) :: already,
-                   xs))
+                   xs)
+                )
               case (sofar :: already, "--packageName" :: value :: xs) =>
                 Continue((sofar.copy(packageName = Option(value.trim.split('.').to[List])) :: already, xs))
               case (sofar :: already, "--dtoPackage" :: value :: xs) =>
@@ -109,22 +109,23 @@ object CoreTermInterp extends (CoreTerm ~> CoreTarget) {
         case Parsed.Success(tree) => Right(tree)
       }
       for {
-        _ <- CoreTarget.log.debug("core", "processArgSet")("Processing arguments")
-        specPath <- CoreTarget.fromOption(args.specPath, MissingArg(args, Error.ArgName("--specPath")))
+        _          <- CoreTarget.log.debug("core", "processArgSet")("Processing arguments")
+        specPath   <- CoreTarget.fromOption(args.specPath, MissingArg(args, Error.ArgName("--specPath")))
         outputPath <- CoreTarget.fromOption(args.outputPath, MissingArg(args, Error.ArgName("--outputPath")))
-        pkgName <- CoreTarget.fromOption(args.packageName, MissingArg(args, Error.ArgName("--packageName")))
-        kind = args.kind
+        pkgName    <- CoreTarget.fromOption(args.packageName, MissingArg(args, Error.ArgName("--packageName")))
+        kind       = args.kind
         dtoPackage = args.dtoPackage
-        context = args.context
+        context    = args.context
         customImports <- args.imports
-          .map(x =>
-            for {
-              _ <- CoreTarget.log.debug("core", "processArgSet")(s"Attempting to parse $x as an import directive")
-              importer <- x
-                .parse[Importer]
-                .fold[CoreTarget[Importer]](err => CoreTarget.error(UnparseableArgument("import", err.toString)),
-                                            CoreTarget.pure(_))
-            } yield Import(List(importer)))
+          .map(
+            x =>
+              for {
+                _ <- CoreTarget.log.debug("core", "processArgSet")(s"Attempting to parse $x as an import directive")
+                importer <- x
+                  .parse[Importer]
+                  .fold[CoreTarget[Importer]](err => CoreTarget.error(UnparseableArgument("import", err.toString)), CoreTarget.pure(_))
+              } yield Import(List(importer))
+          )
           .sequence[CoreTarget, Import]
         _ <- CoreTarget.log.debug("core", "processArgSet")("Finished processing arguments")
       } yield {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/core/StructuredLogger.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/core/StructuredLogger.scala
@@ -2,7 +2,7 @@ package com.twilio.swagger.core
 
 import cats.data.NonEmptyList
 import cats.implicits._
-import cats.{Monoid, Order, Show}
+import cats.{ Monoid, Order, Show }
 
 sealed abstract class LogLevel(val level: String)
 object LogLevel {
@@ -23,11 +23,11 @@ object LogLevel {
 }
 
 object LogLevels {
-  case object Debug extends LogLevel("debug")
-  case object Info extends LogLevel("info")
+  case object Debug   extends LogLevel("debug")
+  case object Info    extends LogLevel("info")
   case object Warning extends LogLevel("warning")
-  case object Error extends LogLevel("error")
-  case object Silent extends LogLevel("silent")
+  case object Error   extends LogLevel("error")
+  case object Silent  extends LogLevel("silent")
 
   val members = Vector(Debug, Info, Warning, Error, Silent)
 
@@ -54,7 +54,7 @@ sealed trait StructuredLoggerInstances extends StructuredLoggerLowPriority {
   }
 
   class ShowStructuredLogger(desiredLevel: LogLevel) extends Show[StructuredLogger] {
-    def show(value: StructuredLogger): String = {
+    def show(value: StructuredLogger): String =
       value.levels
         .foldLeft(List.empty[(LogLevel, NonEmptyList[String], String)])({
           case (acc, StructuredLogLevel(name, lines)) =>
@@ -72,25 +72,28 @@ sealed trait StructuredLoggerInstances extends StructuredLoggerLowPriority {
             s"${level.show} ${prefix}: ${message}"
         })
         .mkString("\n")
-    }
   }
 
   def debug(name: NonEmptyList[String], message: String): StructuredLogger =
     new StructuredLogger(
       StructuredLogLevel(name, (LogLevels.Debug, message).pure[NonEmptyList])
-        .pure[List])
+        .pure[List]
+    )
   def info(name: NonEmptyList[String], message: String): StructuredLogger =
     new StructuredLogger(
       StructuredLogLevel(name, (LogLevels.Info, message).pure[NonEmptyList])
-        .pure[List])
+        .pure[List]
+    )
   def warning(name: NonEmptyList[String], message: String): StructuredLogger =
     new StructuredLogger(
       StructuredLogLevel(name, (LogLevels.Warning, message).pure[NonEmptyList])
-        .pure[List])
+        .pure[List]
+    )
   def error(name: NonEmptyList[String], message: String): StructuredLogger =
     new StructuredLogger(
       StructuredLogLevel(name, (LogLevels.Error, message).pure[NonEmptyList])
-        .pure[List])
+        .pure[List]
+    )
 }
 
 trait StructuredLoggerLowPriority { self: StructuredLoggerInstances =>

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/extract/Default.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/extract/Default.scala
@@ -9,13 +9,11 @@ object Default {
   }
 
   object GetDefault {
-    def build[F](f: F => Any): GetDefault[F] = {
+    def build[F](f: F => Any): GetDefault[F] =
       new GetDefault[F] {
-        def extract[T](from: F)(implicit T: Extractable[T]): Option[T] = {
+        def extract[T](from: F)(implicit T: Extractable[T]): Option[T] =
           T.extract(f(from)).toOption
-        }
       }
-    }
 
     implicit val getDefaultBooleanProperty: GetDefault[BooleanProperty] =
       build[BooleanProperty](_.getDefault)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/extract/VendorExtension.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/extract/VendorExtension.scala
@@ -10,13 +10,11 @@ object VendorExtension {
   }
 
   object VendorExtensible {
-    def build[F](f: F => String => Any): VendorExtensible[F] = {
+    def build[F](f: F => String => Any): VendorExtensible[F] =
       new VendorExtensible[F] {
-        def extract[T](from: F, key: String)(implicit T: Extractable[T]): Option[T] = {
+        def extract[T](from: F, key: String)(implicit T: Extractable[T]): Option[T] =
           T.extract(f(from)(key)).toOption
-        }
       }
-    }
 
     implicit val defaultVendorExtensibleModel: VendorExtensible[Model] =
       build[Model](m => key => m.getVendorExtensions.get(key))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/extract/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/extract/package.scala
@@ -11,4 +11,6 @@ package object extract {
     VendorExtension(v).extract[Boolean]("x-server-raw-response")
   def ScalaEmptyIsNull[F: VendorExtension.VendorExtensible](v: F): Option[Boolean] =
     VendorExtension(v).extract[Boolean]("x-scala-empty-is-null")
+  def ScalaFileHashAlgorithm[F: VendorExtension.VendorExtensible](v: F): Option[String] =
+    VendorExtension(v).extract[String]("x-scala-file-hash")
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttp.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttp.scala
@@ -12,14 +12,14 @@ import SwaggerGenerator._
 import AkkaHttpGenerator._
 
 object AkkaHttp extends FunctionK[CodegenApplication, Target] {
-  val interpSP: CodegenApplicationSP ~> Target = ProtocolSupportTermInterp or ServerTermInterp
-  val interpMSP: CodegenApplicationMSP ~> Target = ModelProtocolTermInterp or interpSP
-  val interpEMSP: CodegenApplicationEMSP ~> Target = EnumProtocolTermInterp or interpMSP
-  val interpCEMSP: CodegenApplicationCEMSP ~> Target = ClientTermInterp or interpEMSP
-  val interpACEMSP: CodegenApplicationACEMSP ~> Target = AliasProtocolTermInterp or interpCEMSP
-  val interpACEMSSP: CodegenApplicationACEMSSP ~> Target = ScalaInterp or interpACEMSP
-  val interpACEMSSPR: CodegenApplicationACEMSSPR ~> Target = ArrayProtocolTermInterp or interpACEMSSP
-  val interpACEMSSPRS: CodegenApplicationACEMSSPRS ~> Target = SwaggerInterp or interpACEMSSPR
+  val interpSP: CodegenApplicationSP ~> Target                 = ProtocolSupportTermInterp or ServerTermInterp
+  val interpMSP: CodegenApplicationMSP ~> Target               = ModelProtocolTermInterp or interpSP
+  val interpEMSP: CodegenApplicationEMSP ~> Target             = EnumProtocolTermInterp or interpMSP
+  val interpCEMSP: CodegenApplicationCEMSP ~> Target           = ClientTermInterp or interpEMSP
+  val interpACEMSP: CodegenApplicationACEMSP ~> Target         = AliasProtocolTermInterp or interpCEMSP
+  val interpACEMSSP: CodegenApplicationACEMSSP ~> Target       = ScalaInterp or interpACEMSP
+  val interpACEMSSPR: CodegenApplicationACEMSSPR ~> Target     = ArrayProtocolTermInterp or interpACEMSSP
+  val interpACEMSSPRS: CodegenApplicationACEMSSPRS ~> Target   = SwaggerInterp or interpACEMSSPR
   val interpACEMSSPRSF: CodegenApplicationACEMSSPRSF ~> Target = FrameworkInterp or interpACEMSSPRS
-  def apply[T](x: CodegenApplication[T]): Target[T] = interpACEMSSPRSF.apply(x)
+  def apply[T](x: CodegenApplication[T]): Target[T]            = interpACEMSSPRSF.apply(x)
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpClientGenerator.scala
@@ -46,9 +46,10 @@ object AkkaHttpClientGenerator {
 
     def apply[T](term: ClientTerm[T]): Target[T] = term match {
       case GenerateClientOperation(className, RouteMeta(pathStr, httpMethod, operation), tracing, protocolElems) =>
-        def generateUrlWithParams(path: String,
-                                  pathArgs: List[ScalaParameter],
-                                  qsArgs: List[ScalaParameter]): Target[Term] = {
+        def generateUrlWithParams(
+            path: String,
+            pathArgs: List[ScalaParameter],
+            qsArgs: List[ScalaParameter]): Target[Term] = {
           for {
             _ <- Target.log.debug("generateClientOperation", "generateUrlWithParams")(
               s"Using $path and ${pathArgs.map(_.argName)}")
@@ -149,22 +150,24 @@ object AkkaHttpClientGenerator {
           q"scala.collection.immutable.Seq[Option[HttpHeader]](..$args).flatten"
         }
 
-        def build(methodName: String,
-                  httpMethod: HttpMethod,
-                  urlWithParams: Term,
-                  formDataParams: Option[Term],
-                  textPlain: Boolean,
-                  formDataNeedsMultipart: Boolean,
-                  headerParams: Term,
-                  responseTypeRef: Type,
-                  tracing: Boolean)(tracingArgsPre: List[ScalaParameter],
-                                    tracingArgsPost: List[ScalaParameter],
-                                    pathArgs: List[ScalaParameter],
-                                    qsArgs: List[ScalaParameter],
-                                    formArgs: List[ScalaParameter],
-                                    body: Option[ScalaParameter],
-                                    headerArgs: List[ScalaParameter],
-                                    extraImplicits: List[Term.Param]): Defn = {
+        def build(
+            methodName: String,
+            httpMethod: HttpMethod,
+            urlWithParams: Term,
+            formDataParams: Option[Term],
+            textPlain: Boolean,
+            formDataNeedsMultipart: Boolean,
+            headerParams: Term,
+            responseTypeRef: Type,
+            tracing: Boolean)(
+            tracingArgsPre: List[ScalaParameter],
+            tracingArgsPost: List[ScalaParameter],
+            pathArgs: List[ScalaParameter],
+            qsArgs: List[ScalaParameter],
+            formArgs: List[ScalaParameter],
+            body: Option[ScalaParameter],
+            headerArgs: List[ScalaParameter],
+            extraImplicits: List[Term.Param]): Defn = {
           val implicitParams = Option(extraImplicits).filter(_.nonEmpty)
           val defaultHeaders =
             param"headers: scala.collection.immutable.Seq[HttpHeader] = Nil"
@@ -315,12 +318,13 @@ object AkkaHttpClientGenerator {
                List(ihc, iec, imat)))
 
       case BuildCompanion(clientName, tracingName, schemes, host, ctorArgs, tracing) =>
-        def extraConstructors(tracingName: Option[String],
-                              schemes: List[String],
-                              host: Option[String],
-                              tpe: Type.Name,
-                              ctorCall: Term.New,
-                              tracing: Boolean): List[Defn] = {
+        def extraConstructors(
+            tracingName: Option[String],
+            schemes: List[String],
+            host: Option[String],
+            tpe: Type.Name,
+            ctorCall: Term.New,
+            tracing: Boolean): List[Defn] = {
           val iec = param"implicit ec: ExecutionContext"
           val imat = param"implicit mat: Materializer"
           val tracingParams: List[Term.Param] = if (tracing) {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpClientGenerator.scala
@@ -23,7 +23,7 @@ object AkkaHttpClientGenerator {
 
     private[this] def toDashedCase(s: String): String = {
       val lowercased =
-        "^[A-Z]".r.replaceAllIn(s, m => m.group(1).toLowerCase(Locale.US))
+        "^([A-Z])".r.replaceAllIn(s, m => m.group(1).toLowerCase(Locale.US))
       "([A-Z])".r
         .replaceAllIn(lowercased, m => '-' +: m.group(1).toLowerCase(Locale.US))
     }
@@ -44,8 +44,7 @@ object AkkaHttpClientGenerator {
         .fold(param"host: String")(v => param"host: String = ${Lit.String(v)}")
 
     def apply[T](term: ClientTerm[T]): Target[T] = term match {
-      case GenerateClientOperation(className, RouteMeta(pathStr, httpMethod, operation), tracing, protocolElems, generatorSettings) =>
-        implicit val gs = generatorSettings
+      case GenerateClientOperation(className, RouteMeta(pathStr, httpMethod, operation), tracing, protocolElems) =>
         def generateUrlWithParams(path: String, pathArgs: List[ScalaParameter], qsArgs: List[ScalaParameter]): Target[Term] =
           for {
             _    <- Target.log.debug("generateClientOperation", "generateUrlWithParams")(s"Using $path and ${pathArgs.map(_.argName)}")
@@ -230,72 +229,74 @@ object AkkaHttpClientGenerator {
           """
         }
 
-        for {
-          // Placeholder for when more functions get logging
-          _ <- Target.pure(())
+        Target.getGeneratorSettings.flatMap { implicit gs =>
+          for {
+            // Placeholder for when more functions get logging
+            _ <- Target.pure(())
 
-          consumes = Option(operation.getConsumes)
-            .fold(List.empty[String])(_.asScala.toList)
-          textPlain              = consumes.contains("text/plain")
-          formDataNeedsMultipart = consumes.contains("multipart/form-data")
+            consumes = Option(operation.getConsumes)
+              .fold(List.empty[String])(_.asScala.toList)
+            textPlain              = consumes.contains("text/plain")
+            formDataNeedsMultipart = consumes.contains("multipart/form-data")
 
-          // Get the response type
-          unresolvedResponseTypeRef <- SwaggerUtil.getResponseType(httpMethod, operation)
-          resolvedResponseTypeRef <- SwaggerUtil.ResolvedType
-            .resolve(unresolvedResponseTypeRef, protocolElems)
-          responseTypeRef = resolvedResponseTypeRef.tpe
+            // Get the response type
+            unresolvedResponseTypeRef <- SwaggerUtil.getResponseType(httpMethod, operation)
+            resolvedResponseTypeRef <- SwaggerUtil.ResolvedType
+              .resolve(unresolvedResponseTypeRef, protocolElems)
+            responseTypeRef = resolvedResponseTypeRef.tpe
 
-          // Insert the method parameters
-          httpMethodStr: String = httpMethod.toString.toLowerCase
-          methodName = Option(operation.getOperationId())
-            .map(splitOperationParts)
-            .map(_._2)
-            .getOrElse(s"$httpMethodStr $pathStr")
+            // Insert the method parameters
+            httpMethodStr: String = httpMethod.toString.toLowerCase
+            methodName = Option(operation.getOperationId())
+              .map(splitOperationParts)
+              .map(_._2)
+              .getOrElse(s"$httpMethodStr $pathStr")
 
-          _ <- Target.log.debug("generateClientOperation")(s"Parsing: ${httpMethodStr} ${methodName}")
+            _ <- Target.log.debug("generateClientOperation")(s"Parsing: ${httpMethodStr} ${methodName}")
 
-          allParams <- Option(operation.getParameters)
-            .map(_.asScala.toList)
-            .map(ScalaParameter.fromParameters(protocolElems))
-            .getOrElse(Target.pure(List.empty[ScalaParameter]))
-          _ <- Target.log.debug("generateClientOperation")(s"Unfiltered params: ${allParams}")
+            allParams <- Option(operation.getParameters)
+              .map(_.asScala.toList)
+              .map(ScalaParameter.fromParameters(protocolElems))
+              .getOrElse(Target.pure(List.empty[ScalaParameter]))
+            _ <- Target.log.debug("generateClientOperation")(s"Unfiltered params: ${allParams}")
 
-          filterParamBy = ScalaParameter.filterParams(allParams)
-          headerArgs    = filterParamBy("header")
-          pathArgs      = filterParamBy("path")
-          qsArgs        = filterParamBy("query")
-          bodyArgs      = filterParamBy("body").headOption
-          formArgs      = filterParamBy("formData")
+            filterParamBy = ScalaParameter.filterParams(allParams)
+            headerArgs    = filterParamBy("header")
+            pathArgs      = filterParamBy("path")
+            qsArgs        = filterParamBy("query")
+            bodyArgs      = filterParamBy("body").headOption
+            formArgs      = filterParamBy("formData")
 
-          _ <- Target.log.debug("generateClientOperation")(s"pathArgs: $pathArgs")
+            _ <- Target.log.debug("generateClientOperation")(s"pathArgs: $pathArgs")
 
-          // Generate the url with path, query parameters
-          urlWithParams <- generateUrlWithParams(pathStr, pathArgs, qsArgs)
+            // Generate the url with path, query parameters
+            urlWithParams <- generateUrlWithParams(pathStr, pathArgs, qsArgs)
 
-          _ <- Target.log.debug("generateClientOperation")(s"Generated: $urlWithParams")
-          // Generate FormData arguments
-          formDataParams = generateFormDataParams(formArgs, formDataNeedsMultipart)
-          // Generate header arguments
-          headerParams = generateHeaderParams(headerArgs)
+            _ <- Target.log.debug("generateClientOperation")(s"Generated: $urlWithParams")
+            // Generate FormData arguments
+            formDataParams = generateFormDataParams(formArgs, formDataNeedsMultipart)
+            // Generate header arguments
+            headerParams = generateHeaderParams(headerArgs)
 
-          tracingArgsPre = if (tracing)
-            List(ScalaParameter.fromParam(param"traceBuilder: TraceBuilder"))
-          else List.empty
-          tracingArgsPost = if (tracing)
-            List(ScalaParameter.fromParam(param"methodName: String = ${Lit.String(toDashedCase(methodName))}"))
-          else List.empty
-          extraImplicits = List.empty
-          defn = build(methodName, httpMethod, urlWithParams, formDataParams, textPlain, formDataNeedsMultipart, headerParams, responseTypeRef, tracing)(
-            tracingArgsPre,
-            tracingArgsPost,
-            pathArgs,
-            qsArgs,
-            formArgs,
-            bodyArgs,
-            headerArgs,
-            extraImplicits
-          )
-        } yield defn
+            tracingArgsPre = if (tracing)
+              List(ScalaParameter.fromParam(param"traceBuilder: TraceBuilder"))
+            else List.empty
+            tracingArgsPost = if (tracing)
+              List(ScalaParameter.fromParam(param"methodName: String = ${Lit.String(toDashedCase(methodName))}"))
+            else List.empty
+            extraImplicits = List.empty
+            defn = build(methodName, httpMethod, urlWithParams, formDataParams, textPlain, formDataNeedsMultipart, headerParams, responseTypeRef, tracing)(
+              tracingArgsPre,
+              tracingArgsPost,
+              pathArgs,
+              qsArgs,
+              formArgs,
+              bodyArgs,
+              headerArgs,
+              extraImplicits
+            )
+          } yield defn
+        }
 
       case GetImports(tracing) => Target.pure(List.empty)
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpClientGenerator.scala
@@ -45,7 +45,12 @@ object AkkaHttpClientGenerator {
         .fold(param"host: String")(v => param"host: String = ${Lit.String(v)}")
 
     def apply[T](term: ClientTerm[T]): Target[T] = term match {
-      case GenerateClientOperation(className, RouteMeta(pathStr, httpMethod, operation), tracing, protocolElems) =>
+      case GenerateClientOperation(className,
+                                   RouteMeta(pathStr, httpMethod, operation),
+                                   tracing,
+                                   protocolElems,
+                                   generatorSettings) =>
+        implicit val gs = generatorSettings
         def generateUrlWithParams(
             path: String,
             pathArgs: List[ScalaParameter],

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpGenerator.scala
@@ -31,6 +31,7 @@ object AkkaHttpGenerator {
             q"import akka.stream.{IOResult, Materializer}",
             q"import akka.stream.scaladsl.{FileIO, Keep, Sink, Source}",
             q"import akka.util.ByteString",
+            q"import cats.{Functor, Id}",
             q"import cats.data.EitherT",
             q"import cats.implicits._",
             q"import scala.concurrent.{ExecutionContext, Future}",

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpGenerator.scala
@@ -116,7 +116,7 @@ object AkkaHttpGenerator {
             }
 
             def SafeUnmarshaller[T, U](ev: Unmarshaller[T, U])(implicit mat: Materializer): Unmarshaller[T, Either[Throwable, U]] = Unmarshaller { implicit executionContext => entity =>
-              ev.apply(entity).transform { t => Success(t.toEither) }
+              ev.apply(entity).map[Either[Throwable, U]](Right(_)).recover({ case t => Left(t) })
             }
 
             def StaticUnmarshaller[T](value: T)(implicit mat: Materializer): Unmarshaller[Multipart.FormData.BodyPart, T] = Unmarshaller { _ => part =>

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpGenerator.scala
@@ -40,7 +40,8 @@ object AkkaHttpGenerator {
             q"import java.security.MessageDigest",
             q"import java.util.concurrent.atomic.AtomicReference",
             q"import scala.util.{Failure, Success}"
-          ))
+          )
+        )
 
       case GetFrameworkImplicits(generatorSettings) =>
         val jsonEncoderTypeclass: Type = t"io.circe.Encoder"

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
@@ -522,7 +522,7 @@ object AkkaHttpServerGenerator {
         value <- OptionT.liftF({
           (params
             .traverse {
-              case ScalaParameter(a, param, paramName, argName, argType) =>
+              case rawParameter@ScalaParameter(a, param, paramName, argName, argType) =>
                 val containerName = new Binding(paramName.value)
                 val unmarshallerName = new Binding(s"Unmarshall${paramName.value}part")
                 val binding = new Binding(paramName.value)
@@ -543,7 +543,7 @@ object AkkaHttpServerGenerator {
                       q"""
                         val ${unmarshallerName.toVar}: Unmarshaller[Multipart.FormData.BodyPart, ${Type
                         .Select(partsTerm, containerName.toType)}] = (
-                            handler.${Term.Name(s"${operationId}UnmarshalToFile")}(None, handler.${Term.Name(s"${operationId}MapFileField")}(_, _, _))
+                            handler.${Term.Name(s"${operationId}UnmarshalToFile")}(${rawParameter.hashAlgorithm.fold[Term](q"None")(x => q"Option(${Lit.String(x)})")}, handler.${Term.Name(s"${operationId}MapFileField")}(_, _, _))
                               .map(${Term.Select(partsTerm, containerName.toTerm)}.apply)
                             )
                       """,

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
@@ -578,8 +578,11 @@ object AkkaHttpServerGenerator {
                     (
                       q"""
                         val ${unmarshallerName.toVar}: Unmarshaller[Multipart.FormData.BodyPart, ${Type
-                        .Select(partsTerm, containerName.toType)}] = Unmarshaller { implicit executionContext => part =>
-                          implicitly[Unmarshaller[Multipart.FormData.BodyPart, ${realType}]].apply(part).map(${Term
+                        .Select(partsTerm, containerName.toType)}] = Unmarshaller.withMaterializer { implicit executionContext => materializer => part =>
+                          Unmarshaller.firstOf(
+                            implicitly[Unmarshaller[Multipart.FormData.BodyPart, ${realType}]],
+                            MFDBPviaFSU(Unmarshaller.stringUnmarshaller, materializer)
+                          ).apply(part).map(${Term
                         .Select(partsTerm, containerName.toTerm)}.apply)
                         }
                       """,

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
@@ -17,6 +17,16 @@ import scala.collection.JavaConverters._
 import scala.meta._
 
 object AkkaHttpServerGenerator {
+  implicit class ExtendedUnzip[T1, T2, T3, T4, T5, T6, T7](xs: NonEmptyList[(T1, T2, T3, T4, T5, T6, T7)]) {
+    def unzip7: (List[T1], List[T2], List[T3], List[T4], List[T5], List[T6], List[T7]) =
+      xs.foldLeft(
+        (List.empty[T1], List.empty[T2], List.empty[T3], List.empty[T4], List.empty[T5], List.empty[T6], List.empty[T7])
+      ) {
+        case ((v1a, v2a, v3a, v4a, v5a, v6a, v7a), (v1, v2, v3, v4, v5, v6, v7)) =>
+          (v1a :+ v1, v2a :+ v2, v3a :+ v3, v4a :+ v4, v5a :+ v5, v6a :+ v6, v7a :+ v7)
+      }
+  }
+
   object HttpHelper {
     def apply(code: String): Option[(Int, String)] =
       code match {
@@ -591,24 +601,12 @@ object AkkaHttpServerGenerator {
 
                 Target.pure((partContainer, unmarshaller, caseMatch, (binding, collected), unpacker, argType, grabHead))
             })
-            .map(
-              _.foldLeft(
-                (List.empty[Defn.Class],
-                 List.empty[Defn.Val],
-                 List.empty[Case],
-                 (List.empty[Binding], List.empty[Binding]),
-                 List.empty[Enumerator.Generator],
-                 List.empty[Type],
-                 List.empty[Defn.Val])
-              ) {
-                case ((v1a, v2a, v3a, (v4a1, v4a2), v5a, v6a, v7a), (v1, v2, v3, (v41, v42), v5, v6, v7)) =>
-                  (v1a :+ v1, v2a :+ v2, v3a :+ v3, (v4a1 :+ v41, v4a2 :+ v42), v5a :+ v5, v6a :+ v6, v7a :+ v7)
-              }
-            )
+            .map(_.unzip7)
         })
       } yield {
-        val (partContainers, unmarshallers, matchers, (termPatterns, optionalTermPatterns), unpacks, termTypes, grabHeads) = value
-        val optionalTuple                                                                                                  = p"(..${optionalTermPatterns.map(_.toPat)})"
+        val (partContainers, unmarshallers, matchers, _terms, unpacks, termTypes, grabHeads) = value
+        val (termPatterns, optionalTermPatterns)                                             = _terms.unzip
+        val optionalTuple                                                                    = p"(..${optionalTermPatterns.map(_.toPat)})"
 
         val _trait              = q"sealed trait Part"
         val ignoredPart         = q"case class IgnoredPart(unit: Unit) extends Part"

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
@@ -424,18 +424,18 @@ object AkkaHttpServerGenerator {
           case ScalaParameter(_, param, _, argName, argType) =>
             param match {
               case param"$_: Option[Iterable[$tpe]]" =>
-                multiOpt(Lit.String(argName.value))(tpe)
+                multiOpt(argName.toLit)(tpe)
               case param"$_: Option[Iterable[$tpe]] = $_" =>
-                multiOpt(Lit.String(argName.value))(tpe)
+                multiOpt(argName.toLit)(tpe)
               case param"$_: Option[$tpe]" =>
-                optional(Lit.String(argName.value))(tpe)
+                optional(argName.toLit)(tpe)
               case param"$_: Option[$tpe] = $_" =>
-                optional(Lit.String(argName.value))(tpe)
+                optional(argName.toLit)(tpe)
               case param"$_: Iterable[$tpe]" =>
-                multi(Lit.String(argName.value))(tpe)
+                multi(argName.toLit)(tpe)
               case param"$_: Iterable[$tpe] = $_" =>
-                multi(Lit.String(argName.value))(tpe)
-              case _ => required(Lit.String(argName.value))(argType)
+                multi(argName.toLit)(tpe)
+              case _ => required(argName.toLit)(argType)
             }
         }
       } yield

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
@@ -138,7 +138,8 @@ object AkkaHttpServerGenerator {
           className = pkg.map(_ ++ opPkg).getOrElse(opPkg)
         } yield className
 
-      case BuildTracingFields(operation, resourceName, tracing) =>
+      case BuildTracingFields(operation, resourceName, tracing, generatorSettings) =>
+        implicit val gs = generatorSettings
         for {
           _ <- Target.log.debug("AkkaHttpServerGenerator", "server")(
             s"buildTracingFields(${operation}, ${resourceName}, ${tracing})")

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4s.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4s.scala
@@ -12,14 +12,14 @@ import ScalaGenerator._
 import SwaggerGenerator._
 
 object Http4s extends FunctionK[CodegenApplication, Target] {
-  val interpSP: CodegenApplicationSP ~> Target = ProtocolSupportTermInterp or ServerTermInterp
-  val interpMSP: CodegenApplicationMSP ~> Target = ModelProtocolTermInterp or interpSP
-  val interpEMSP: CodegenApplicationEMSP ~> Target = EnumProtocolTermInterp or interpMSP
-  val interpCEMSP: CodegenApplicationCEMSP ~> Target = ClientTermInterp or interpEMSP
-  val interpACEMSP: CodegenApplicationACEMSP ~> Target = AliasProtocolTermInterp or interpCEMSP
-  val interpACEMSSP: CodegenApplicationACEMSSP ~> Target = ScalaInterp or interpACEMSP
-  val interpACEMSSPR: CodegenApplicationACEMSSPR ~> Target = ArrayProtocolTermInterp or interpACEMSSP
-  val interpACEMSSPRS: CodegenApplicationACEMSSPRS ~> Target = SwaggerInterp or interpACEMSSPR
+  val interpSP: CodegenApplicationSP ~> Target                 = ProtocolSupportTermInterp or ServerTermInterp
+  val interpMSP: CodegenApplicationMSP ~> Target               = ModelProtocolTermInterp or interpSP
+  val interpEMSP: CodegenApplicationEMSP ~> Target             = EnumProtocolTermInterp or interpMSP
+  val interpCEMSP: CodegenApplicationCEMSP ~> Target           = ClientTermInterp or interpEMSP
+  val interpACEMSP: CodegenApplicationACEMSP ~> Target         = AliasProtocolTermInterp or interpCEMSP
+  val interpACEMSSP: CodegenApplicationACEMSSP ~> Target       = ScalaInterp or interpACEMSP
+  val interpACEMSSPR: CodegenApplicationACEMSSPR ~> Target     = ArrayProtocolTermInterp or interpACEMSSP
+  val interpACEMSSPRS: CodegenApplicationACEMSSPRS ~> Target   = SwaggerInterp or interpACEMSSPR
   val interpACEMSSPRSF: CodegenApplicationACEMSSPRSF ~> Target = FrameworkInterp or interpACEMSSPRS
-  def apply[T](x: CodegenApplication[T]): Target[T] = interpACEMSSPRSF.apply(x)
+  def apply[T](x: CodegenApplication[T]): Target[T]            = interpACEMSSPRSF.apply(x)
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sClientGenerator.scala
@@ -91,10 +91,10 @@ object Http4sClientGenerator {
             None
           } else if (needsMultipart) {
             def liftOptionFileTerm(tParamName: Term.Name, tName: RawParameterName) =
-              q"$tParamName.map(v => Part.formData[F](${tName.toLit}, v))"
+              q"$tParamName.map(v => Part.fileData[F](${tName.toLit}, v))"
 
             def liftFileTerm(tParamName: Term.Name, tName: RawParameterName) =
-              q"Some(Part.formData[F](${tName.toLit}, $tParamName))"
+              q"Some(Part.fileData[F](${tName.toLit}, ${tParamName}))"
 
             def liftOptionTerm(tParamName: Term.Name, tName: RawParameterName) =
               q"$tParamName.map(v => Part.formData[F](${tName.toLit}, Formatter.show(v)))"

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sClientGenerator.scala
@@ -50,9 +50,10 @@ object Http4sClientGenerator {
 
     def apply[T](term: ClientTerm[T]): Target[T] = term match {
       case GenerateClientOperation(className, RouteMeta(pathStr, httpMethod, operation), tracing, protocolElems) => {
-        def generateUrlWithParams(path: String,
-                                  pathArgs: List[ScalaParameter],
-                                  qsArgs: List[ScalaParameter]): Target[Term] = {
+        def generateUrlWithParams(
+            path: String,
+            pathArgs: List[ScalaParameter],
+            qsArgs: List[ScalaParameter]): Target[Term] = {
           for {
             _ <- Target.log.debug("generateClientOperation", "generateUrlWithParams")(
               s"Using ${path} and ${pathArgs.map(_.argName)}")
@@ -153,21 +154,23 @@ object Http4sClientGenerator {
           q"List[Option[Header]](..$args).flatten"
         }
 
-        def build(methodName: String,
-                  httpMethod: HttpMethod,
-                  urlWithParams: Term,
-                  formDataParams: Option[Term],
-                  formDataNeedsMultipart: Boolean,
-                  headerParams: Term,
-                  responseTypeRef: Type,
-                  tracing: Boolean)(tracingArgsPre: List[ScalaParameter],
-                                    tracingArgsPost: List[ScalaParameter],
-                                    pathArgs: List[ScalaParameter],
-                                    qsArgs: List[ScalaParameter],
-                                    formArgs: List[ScalaParameter],
-                                    body: Option[ScalaParameter],
-                                    headerArgs: List[ScalaParameter],
-                                    extraImplicits: List[Term.Param]): Defn = {
+        def build(
+            methodName: String,
+            httpMethod: HttpMethod,
+            urlWithParams: Term,
+            formDataParams: Option[Term],
+            formDataNeedsMultipart: Boolean,
+            headerParams: Term,
+            responseTypeRef: Type,
+            tracing: Boolean)(
+            tracingArgsPre: List[ScalaParameter],
+            tracingArgsPost: List[ScalaParameter],
+            pathArgs: List[ScalaParameter],
+            qsArgs: List[ScalaParameter],
+            formArgs: List[ScalaParameter],
+            body: Option[ScalaParameter],
+            headerArgs: List[ScalaParameter],
+            extraImplicits: List[Term.Param]): Defn = {
           val implicitParams = Option(extraImplicits).filter(_.nonEmpty)
           val defaultHeaders = param"headers: List[Header] = List.empty"
           val safeBody: Option[(Term, Type)] =
@@ -301,12 +304,13 @@ object Http4sClientGenerator {
                List(ief, ihc)))
 
       case BuildCompanion(clientName, tracingName, schemes, host, ctorArgs, tracing) =>
-        def extraConstructors(tracingName: Option[String],
-                              schemes: List[String],
-                              host: Option[String],
-                              tpe: Type.Name,
-                              ctorCall: Term.New,
-                              tracing: Boolean): List[Defn] = {
+        def extraConstructors(
+            tracingName: Option[String],
+            schemes: List[String],
+            host: Option[String],
+            tpe: Type.Name,
+            ctorCall: Term.New,
+            tracing: Boolean): List[Defn] = {
           val tracingParams: List[Term.Param] = if (tracing) {
             List(formatClientName(tracingName))
           } else {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sGenerator.scala
@@ -32,7 +32,8 @@ object Http4sGenerator {
             q"import org.http4s.dsl.io.Path",
             q"import org.http4s.multipart._",
             q"import scala.language.implicitConversions"
-          ))
+          )
+        )
 
       case GetFrameworkImplicits(generatorSettings) =>
         val jsonEncoderTypeclass: Type = t"io.circe.Encoder"

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sGenerator.scala
@@ -35,7 +35,7 @@ object Http4sGenerator {
           )
         )
 
-      case GetFrameworkImplicits(generatorSettings) =>
+      case GetFrameworkImplicits() =>
         val jsonEncoderTypeclass: Type = t"io.circe.Encoder"
         val jsonDecoderTypeclass: Type = t"io.circe.Decoder"
         Target.pure(q"""
@@ -69,7 +69,7 @@ object Http4sGenerator {
         """)
 
       case GetGeneratorSettings() =>
-        Target.pure(new GeneratorSettings(t"java.io.File", t"io.circe.Json"))
+        Target.getGeneratorSettings
     }
   }
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sGenerator.scala
@@ -34,8 +34,7 @@ object Http4sGenerator {
             q"import scala.language.implicitConversions"
           ))
 
-      case GetFrameworkImplicits() =>
-        val jsonType: Type = t"io.circe.Json"
+      case GetFrameworkImplicits(generatorSettings) =>
         val jsonEncoderTypeclass: Type = t"io.circe.Encoder"
         val jsonDecoderTypeclass: Type = t"io.circe.Decoder"
         Target.pure(q"""
@@ -67,6 +66,9 @@ object Http4sGenerator {
             }
           }
         """)
+
+      case GetGeneratorSettings() =>
+        Target.pure(new GeneratorSettings(t"java.io.File", t"io.circe.Json"))
     }
   }
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaParameter.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaParameter.scala
@@ -18,6 +18,9 @@ class ScalaParameter private[generators] (val in: Option[String],
                                           val required: Boolean) {
   override def toString: String =
     s"ScalaParameter(${in}, ${param}, ${paramName}, ${argName}, ${argType})"
+
+  def withType(newArgType: Type): ScalaParameter =
+    new ScalaParameter(in, param, paramName, argName, newArgType, required, hashAlgorithm)
 }
 object ScalaParameter {
   def unapply(param: ScalaParameter): Option[(Option[String], Term.Param, Term.Name, RawParameterName, Type)] =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaParameter.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaParameter.scala
@@ -32,12 +32,12 @@ object ScalaParameter {
   def unapply(param: ScalaParameter): Option[(Option[String], Term.Param, Term.Name, RawParameterName, Type)] =
     Some((param.in, param.param, param.paramName, param.argName, param.argType))
 
-  def fromParam: Term.Param => ScalaParameter = { param =>
+  def fromParam(param: Term.Param)(implicit gs: GeneratorSettings): ScalaParameter = {
     fromParam(param.name.value)(param)
   }
-  def fromParam(argName: String): Term.Param => ScalaParameter =
-    fromParam(RawParameterName(argName))
-  def fromParam(argName: RawParameterName): Term.Param => ScalaParameter = {
+  def fromParam(argName: String)(param: Term.Param)(implicit gs: GeneratorSettings): ScalaParameter =
+    fromParam(RawParameterName(argName))(param)
+  def fromParam(argName: RawParameterName)(param: Term.Param)(implicit gs: GeneratorSettings): ScalaParameter = param match {
     case param @ Term.Param(mods, name, decltype, default) =>
       val (tpe, innerTpe, required): (Type, Type, Boolean) = decltype
         .flatMap({
@@ -55,7 +55,7 @@ object ScalaParameter {
                          tpe,
                          required,
                          None,
-                         innerTpe == t"BodyPartEntity") // TODO: Get GeneratorSettings in here so we can test properly
+                         innerTpe == gs.fileType)
   }
 
   def fromParameter(protocolElems: List[StrictProtocolElems])(

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaParameter.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaParameter.scala
@@ -10,12 +10,13 @@ import cats.instances.all._
 case class RawParameterName private[generators] (value: String) {
   def toLit: Lit.String = Lit.String(value)
 }
-class ScalaParameter private[generators] (val in: Option[String],
-                                          val param: Term.Param,
-                                          val paramName: Term.Name,
-                                          val argName: RawParameterName,
-                                          val argType: Type,
-                                          val required: Boolean) {
+class ScalaParameter private[generators] (
+    val in: Option[String],
+    val param: Term.Param,
+    val paramName: Term.Name,
+    val argName: RawParameterName,
+    val argType: Type,
+    val required: Boolean) {
   override def toString: String =
     s"ScalaParameter(${in}, ${param}, ${paramName}, ${argName}, ${argType})"
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/SwaggerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/SwaggerGenerator.scala
@@ -42,8 +42,7 @@ object SwaggerGenerator {
             .map(_.split('.').toVector)
             .orElse({
               Option(operation.getTags).map { tags =>
-                println(
-                  s"Warning: Using `tags` to define package membership is deprecated in favor of the `x-scala-package` vendor extension")
+                println(s"Warning: Using `tags` to define package membership is deprecated in favor of the `x-scala-package` vendor extension")
                 tags.asScala
               }
             })

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
@@ -1,7 +1,7 @@
 package com.twilio
 
 import cats.{ Applicative, Id }
-import cats.data.{ EitherK, EitherT, NonEmptyList, WriterT }
+import cats.data.{ EitherK, EitherT, NonEmptyList, ReaderT, WriterT }
 import cats.instances.all._
 import cats.syntax.applicative._
 import cats.syntax.either._
@@ -10,6 +10,7 @@ import com.twilio.guardrail.protocol.terms.protocol._
 import com.twilio.guardrail.protocol.terms.server.ServerTerm
 import com.twilio.guardrail.terms.{ ScalaTerm, SwaggerTerm }
 import com.twilio.guardrail.terms.framework.FrameworkTerm
+import com.twilio.guardrail.generators.GeneratorSettings
 
 import scala.meta._
 import com.twilio.swagger.core.StructuredLogger
@@ -20,24 +21,27 @@ package guardrail {
   object Target {
     val A                              = Applicative[Target]
     def pure[T](x: T): Target[T]       = A.pure(x)
-    def error[T](x: String): Target[T] = EitherT.left[T](x.pure[Logger])
+    def error[T](x: String): Target[T] = EitherT.fromEither(Left(x))
     def fromOption[T](x: Option[T], default: => String): Target[T] =
       EitherT.fromOption(x, default)
-    def unsafeExtract[T](x: Target[T]): T =
+    def unsafeExtract[T](x: Target[T], generatorSettings: GeneratorSettings): T =
       x.valueOr({ err =>
           throw new Exception(err.toString)
         })
+        .run(generatorSettings)
         .value
+    def getGeneratorSettings: Target[GeneratorSettings] =
+      EitherT.liftF(ReaderT.ask)
 
     object log {
       def debug(name: String, names: String*)(message: String): Target[Unit] =
-        EitherT.right(WriterT.tell(StructuredLogger.debug(NonEmptyList(name, names.toList), message)))
+        EitherT.right(ReaderT(_ => WriterT.tell(StructuredLogger.debug(NonEmptyList(name, names.toList), message))))
       def info(name: String, names: String*)(message: String): Target[Unit] =
-        EitherT.right(WriterT.tell(StructuredLogger.info(NonEmptyList(name, names.toList), message)))
+        EitherT.right(ReaderT(_ => WriterT.tell(StructuredLogger.info(NonEmptyList(name, names.toList), message))))
       def warning(name: String, names: String*)(message: String): Target[Unit] =
-        EitherT.right(WriterT.tell(StructuredLogger.warning(NonEmptyList(name, names.toList), message)))
+        EitherT.right(ReaderT(_ => WriterT.tell(StructuredLogger.warning(NonEmptyList(name, names.toList), message))))
       def error(name: String, names: String*)(message: String): Target[Unit] =
-        EitherT.right(WriterT.tell(StructuredLogger.error(NonEmptyList(name, names.toList), message)))
+        EitherT.right(ReaderT(_ => WriterT.tell(StructuredLogger.error(NonEmptyList(name, names.toList), message))))
     }
   }
 
@@ -45,7 +49,7 @@ package guardrail {
     def pure[T](x: T): CoreTarget[T] = x.pure[CoreTarget]
     def fromOption[T](x: Option[T], default: => Error): CoreTarget[T] =
       EitherT.fromOption(x, default)
-    def error[T](x: Error): CoreTarget[T] = EitherT.left[T](x.pure[Logger])
+    def error[T](x: Error): CoreTarget[T] = EitherT.fromEither(Left(x))
     def unsafeExtract[T](x: CoreTarget[T]): T =
       x.valueOr({ err =>
           throw new Exception(err.toString)
@@ -86,6 +90,7 @@ package object guardrail {
   type CodegenApplication[T] = CodegenApplicationACEMSSPRSF[T]
 
   type Logger[T]     = WriterT[Id, StructuredLogger, T]
-  type Target[A]     = EitherT[Logger, String, A]
+  type Settings[T]   = ReaderT[Logger, GeneratorSettings, T]
+  type Target[A]     = EitherT[Settings, String, A]
   type CoreTarget[A] = EitherT[Logger, Error, A]
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
@@ -1,14 +1,14 @@
 package com.twilio
 
-import cats.{Applicative, Id}
-import cats.data.{EitherK, EitherT, NonEmptyList, WriterT}
+import cats.{ Applicative, Id }
+import cats.data.{ EitherK, EitherT, NonEmptyList, WriterT }
 import cats.instances.all._
 import cats.syntax.applicative._
 import cats.syntax.either._
 import com.twilio.guardrail.protocol.terms.client.ClientTerm
 import com.twilio.guardrail.protocol.terms.protocol._
 import com.twilio.guardrail.protocol.terms.server.ServerTerm
-import com.twilio.guardrail.terms.{ScalaTerm, SwaggerTerm}
+import com.twilio.guardrail.terms.{ ScalaTerm, SwaggerTerm }
 import com.twilio.guardrail.terms.framework.FrameworkTerm
 
 import scala.meta._
@@ -18,8 +18,8 @@ package guardrail {
   case class CodegenDefinitions(clients: List[Client], servers: List[Server])
 
   object Target {
-    val A = Applicative[Target]
-    def pure[T](x: T): Target[T] = A.pure(x)
+    val A                              = Applicative[Target]
+    def pure[T](x: T): Target[T]       = A.pure(x)
     def error[T](x: String): Target[T] = EitherT.left[T](x.pure[Logger])
     def fromOption[T](x: Option[T], default: => String): Target[T] =
       EitherT.fromOption(x, default)
@@ -85,7 +85,7 @@ package object guardrail {
     EitherK[FrameworkTerm, CodegenApplicationACEMSSPRS, T]
   type CodegenApplication[T] = CodegenApplicationACEMSSPRSF[T]
 
-  type Logger[T] = WriterT[Id, StructuredLogger, T]
-  type Target[A] = EitherT[Logger, String, A]
+  type Logger[T]     = WriterT[Id, StructuredLogger, T]
+  type Target[A]     = EitherT[Logger, String, A]
   type CoreTarget[A] = EitherT[Logger, Error, A]
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientGeneratorTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientGeneratorTerm.scala
@@ -7,32 +7,28 @@ import com.twilio.guardrail.generators.GeneratorSettings
 import scala.meta._
 
 sealed trait ClientTerm[T]
-case class GenerateClientOperation(
-    className: List[String],
-    route: RouteMeta,
-    tracing: Boolean,
-    protocolElems: List[StrictProtocolElems],
-    generatorSettings: GeneratorSettings)
+case class GenerateClientOperation(className: List[String],
+                                   route: RouteMeta,
+                                   tracing: Boolean,
+                                   protocolElems: List[StrictProtocolElems],
+                                   generatorSettings: GeneratorSettings)
     extends ClientTerm[Defn]
-case class GetImports(tracing: Boolean) extends ClientTerm[List[Import]]
-case class GetExtraImports(tracing: Boolean) extends ClientTerm[List[Import]]
-case class ClientClsArgs(tracingName: Option[String], schemes: List[String], host: Option[String], tracing: Boolean)
-    extends ClientTerm[List[List[Term.Param]]]
-case class BuildCompanion(
-    clientName: String,
-    tracingName: Option[String],
-    schemes: List[String],
-    host: Option[String],
-    ctorArgs: List[List[Term.Param]],
-    tracing: Boolean)
+case class GetImports(tracing: Boolean)                                                                              extends ClientTerm[List[Import]]
+case class GetExtraImports(tracing: Boolean)                                                                         extends ClientTerm[List[Import]]
+case class ClientClsArgs(tracingName: Option[String], schemes: List[String], host: Option[String], tracing: Boolean) extends ClientTerm[List[List[Term.Param]]]
+case class BuildCompanion(clientName: String,
+                          tracingName: Option[String],
+                          schemes: List[String],
+                          host: Option[String],
+                          ctorArgs: List[List[Term.Param]],
+                          tracing: Boolean)
     extends ClientTerm[Defn.Object]
-case class BuildClient(
-    clientName: String,
-    tracingName: Option[String],
-    schemes: List[String],
-    host: Option[String],
-    basePath: Option[String],
-    ctorArgs: List[List[Term.Param]],
-    clientCalls: List[Defn],
-    tracing: Boolean)
+case class BuildClient(clientName: String,
+                       tracingName: Option[String],
+                       schemes: List[String],
+                       host: Option[String],
+                       basePath: Option[String],
+                       ctorArgs: List[List[Term.Param]],
+                       clientCalls: List[Defn],
+                       tracing: Boolean)
     extends ClientTerm[Defn.Class]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientGeneratorTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientGeneratorTerm.scala
@@ -2,6 +2,7 @@ package com.twilio.guardrail.protocol.terms.client
 
 import com.twilio.guardrail.StrictProtocolElems
 import com.twilio.guardrail.terms.RouteMeta
+import com.twilio.guardrail.generators.GeneratorSettings
 
 import scala.meta._
 
@@ -10,7 +11,8 @@ case class GenerateClientOperation(
     className: List[String],
     route: RouteMeta,
     tracing: Boolean,
-    protocolElems: List[StrictProtocolElems])
+    protocolElems: List[StrictProtocolElems],
+    generatorSettings: GeneratorSettings)
     extends ClientTerm[Defn]
 case class GetImports(tracing: Boolean) extends ClientTerm[List[Import]]
 case class GetExtraImports(tracing: Boolean) extends ClientTerm[List[Import]]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientGeneratorTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientGeneratorTerm.scala
@@ -6,28 +6,31 @@ import com.twilio.guardrail.terms.RouteMeta
 import scala.meta._
 
 sealed trait ClientTerm[T]
-case class GenerateClientOperation(className: List[String],
-                                   route: RouteMeta,
-                                   tracing: Boolean,
-                                   protocolElems: List[StrictProtocolElems])
+case class GenerateClientOperation(
+    className: List[String],
+    route: RouteMeta,
+    tracing: Boolean,
+    protocolElems: List[StrictProtocolElems])
     extends ClientTerm[Defn]
 case class GetImports(tracing: Boolean) extends ClientTerm[List[Import]]
 case class GetExtraImports(tracing: Boolean) extends ClientTerm[List[Import]]
 case class ClientClsArgs(tracingName: Option[String], schemes: List[String], host: Option[String], tracing: Boolean)
     extends ClientTerm[List[List[Term.Param]]]
-case class BuildCompanion(clientName: String,
-                          tracingName: Option[String],
-                          schemes: List[String],
-                          host: Option[String],
-                          ctorArgs: List[List[Term.Param]],
-                          tracing: Boolean)
+case class BuildCompanion(
+    clientName: String,
+    tracingName: Option[String],
+    schemes: List[String],
+    host: Option[String],
+    ctorArgs: List[List[Term.Param]],
+    tracing: Boolean)
     extends ClientTerm[Defn.Object]
-case class BuildClient(clientName: String,
-                       tracingName: Option[String],
-                       schemes: List[String],
-                       host: Option[String],
-                       basePath: Option[String],
-                       ctorArgs: List[List[Term.Param]],
-                       clientCalls: List[Defn],
-                       tracing: Boolean)
+case class BuildClient(
+    clientName: String,
+    tracingName: Option[String],
+    schemes: List[String],
+    host: Option[String],
+    basePath: Option[String],
+    ctorArgs: List[List[Term.Param]],
+    clientCalls: List[Defn],
+    tracing: Boolean)
     extends ClientTerm[Defn.Class]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientGeneratorTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientGeneratorTerm.scala
@@ -7,11 +7,7 @@ import com.twilio.guardrail.generators.GeneratorSettings
 import scala.meta._
 
 sealed trait ClientTerm[T]
-case class GenerateClientOperation(className: List[String],
-                                   route: RouteMeta,
-                                   tracing: Boolean,
-                                   protocolElems: List[StrictProtocolElems],
-                                   generatorSettings: GeneratorSettings)
+case class GenerateClientOperation(className: List[String], route: RouteMeta, tracing: Boolean, protocolElems: List[StrictProtocolElems])
     extends ClientTerm[Defn]
 case class GetImports(tracing: Boolean)                                                                              extends ClientTerm[List[Import]]
 case class GetExtraImports(tracing: Boolean)                                                                         extends ClientTerm[List[Import]]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientGeneratorTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientGeneratorTerms.scala
@@ -9,10 +9,10 @@ import com.twilio.guardrail.generators.GeneratorSettings
 import scala.meta._
 
 class ClientTerms[F[_]](implicit I: InjectK[ClientTerm, F]) {
-  def generateClientOperation(className: List[String], tracing: Boolean, protocolElems: List[StrictProtocolElems], generatorSettings: GeneratorSettings)(
+  def generateClientOperation(className: List[String], tracing: Boolean, protocolElems: List[StrictProtocolElems])(
       route: RouteMeta
   ): Free[F, Defn] =
-    Free.inject[ClientTerm, F](GenerateClientOperation(className, route, tracing, protocolElems, generatorSettings))
+    Free.inject[ClientTerm, F](GenerateClientOperation(className, route, tracing, protocolElems))
   def getImports(tracing: Boolean): Free[F, List[Import]] =
     Free.inject[ClientTerm, F](GetImports(tracing))
   def getExtraImports(tracing: Boolean): Free[F, List[Import]] =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientGeneratorTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientGeneratorTerms.scala
@@ -15,26 +15,29 @@ class ClientTerms[F[_]](implicit I: InjectK[ClientTerm, F]) {
     Free.inject[ClientTerm, F](GetImports(tracing))
   def getExtraImports(tracing: Boolean): Free[F, List[Import]] =
     Free.inject[ClientTerm, F](GetExtraImports(tracing))
-  def clientClsArgs(tracingName: Option[String],
-                    schemes: List[String],
-                    host: Option[String],
-                    tracing: Boolean): Free[F, List[List[Term.Param]]] =
+  def clientClsArgs(
+      tracingName: Option[String],
+      schemes: List[String],
+      host: Option[String],
+      tracing: Boolean): Free[F, List[List[Term.Param]]] =
     Free.inject[ClientTerm, F](ClientClsArgs(tracingName, schemes, host, tracing))
-  def buildCompanion(clientName: String,
-                     tracingName: Option[String],
-                     schemes: List[String],
-                     host: Option[String],
-                     ctorArgs: List[List[Term.Param]],
-                     tracing: Boolean): Free[F, Defn.Object] =
+  def buildCompanion(
+      clientName: String,
+      tracingName: Option[String],
+      schemes: List[String],
+      host: Option[String],
+      ctorArgs: List[List[Term.Param]],
+      tracing: Boolean): Free[F, Defn.Object] =
     Free.inject[ClientTerm, F](BuildCompanion(clientName, tracingName, schemes, host, ctorArgs, tracing))
-  def buildClient(clientName: String,
-                  tracingName: Option[String],
-                  schemes: List[String],
-                  host: Option[String],
-                  basePath: Option[String],
-                  ctorArgs: List[List[Term.Param]],
-                  clientCalls: List[Defn],
-                  tracing: Boolean): Free[F, Defn.Class] =
+  def buildClient(
+      clientName: String,
+      tracingName: Option[String],
+      schemes: List[String],
+      host: Option[String],
+      basePath: Option[String],
+      ctorArgs: List[List[Term.Param]],
+      clientCalls: List[Defn],
+      tracing: Boolean): Free[F, Defn.Class] =
     Free.inject[ClientTerm, F](
       BuildClient(clientName, tracingName, schemes, host, basePath, ctorArgs, clientCalls, tracing))
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientGeneratorTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientGeneratorTerms.scala
@@ -9,41 +9,32 @@ import com.twilio.guardrail.generators.GeneratorSettings
 import scala.meta._
 
 class ClientTerms[F[_]](implicit I: InjectK[ClientTerm, F]) {
-  def generateClientOperation(
-      className: List[String],
-      tracing: Boolean,
-      protocolElems: List[StrictProtocolElems],
-      generatorSettings: GeneratorSettings)(route: RouteMeta): Free[F, Defn] =
+  def generateClientOperation(className: List[String], tracing: Boolean, protocolElems: List[StrictProtocolElems], generatorSettings: GeneratorSettings)(
+      route: RouteMeta
+  ): Free[F, Defn] =
     Free.inject[ClientTerm, F](GenerateClientOperation(className, route, tracing, protocolElems, generatorSettings))
   def getImports(tracing: Boolean): Free[F, List[Import]] =
     Free.inject[ClientTerm, F](GetImports(tracing))
   def getExtraImports(tracing: Boolean): Free[F, List[Import]] =
     Free.inject[ClientTerm, F](GetExtraImports(tracing))
-  def clientClsArgs(
-      tracingName: Option[String],
-      schemes: List[String],
-      host: Option[String],
-      tracing: Boolean): Free[F, List[List[Term.Param]]] =
+  def clientClsArgs(tracingName: Option[String], schemes: List[String], host: Option[String], tracing: Boolean): Free[F, List[List[Term.Param]]] =
     Free.inject[ClientTerm, F](ClientClsArgs(tracingName, schemes, host, tracing))
-  def buildCompanion(
-      clientName: String,
-      tracingName: Option[String],
-      schemes: List[String],
-      host: Option[String],
-      ctorArgs: List[List[Term.Param]],
-      tracing: Boolean): Free[F, Defn.Object] =
+  def buildCompanion(clientName: String,
+                     tracingName: Option[String],
+                     schemes: List[String],
+                     host: Option[String],
+                     ctorArgs: List[List[Term.Param]],
+                     tracing: Boolean): Free[F, Defn.Object] =
     Free.inject[ClientTerm, F](BuildCompanion(clientName, tracingName, schemes, host, ctorArgs, tracing))
-  def buildClient(
-      clientName: String,
-      tracingName: Option[String],
-      schemes: List[String],
-      host: Option[String],
-      basePath: Option[String],
-      ctorArgs: List[List[Term.Param]],
-      clientCalls: List[Defn],
-      tracing: Boolean): Free[F, Defn.Class] =
-    Free.inject[ClientTerm, F](
-      BuildClient(clientName, tracingName, schemes, host, basePath, ctorArgs, clientCalls, tracing))
+  def buildClient(clientName: String,
+                  tracingName: Option[String],
+                  schemes: List[String],
+                  host: Option[String],
+                  basePath: Option[String],
+                  ctorArgs: List[List[Term.Param]],
+                  clientCalls: List[Defn],
+                  tracing: Boolean): Free[F, Defn.Class] =
+    Free.inject[ClientTerm, F](BuildClient(clientName, tracingName, schemes, host, basePath, ctorArgs, clientCalls, tracing))
 }
 
 object ClientTerms {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientGeneratorTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientGeneratorTerms.scala
@@ -4,13 +4,17 @@ import cats.InjectK
 import cats.free.Free
 import com.twilio.guardrail.StrictProtocolElems
 import com.twilio.guardrail.terms.RouteMeta
+import com.twilio.guardrail.generators.GeneratorSettings
 
 import scala.meta._
 
 class ClientTerms[F[_]](implicit I: InjectK[ClientTerm, F]) {
-  def generateClientOperation(className: List[String], tracing: Boolean, protocolElems: List[StrictProtocolElems])(
-      route: RouteMeta): Free[F, Defn] =
-    Free.inject[ClientTerm, F](GenerateClientOperation(className, route, tracing, protocolElems))
+  def generateClientOperation(
+      className: List[String],
+      tracing: Boolean,
+      protocolElems: List[StrictProtocolElems],
+      generatorSettings: GeneratorSettings)(route: RouteMeta): Free[F, Defn] =
+    Free.inject[ClientTerm, F](GenerateClientOperation(className, route, tracing, protocolElems, generatorSettings))
   def getImports(tracing: Boolean): Free[F, List[Import]] =
     Free.inject[ClientTerm, F](GetImports(tracing))
   def getExtraImports(tracing: Boolean): Free[F, List[Import]] =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ArrayProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ArrayProtocolTerm.scala
@@ -6,5 +6,4 @@ import com.twilio.guardrail.generators.GeneratorSettings
 import scala.meta._
 
 sealed trait ArrayProtocolTerm[T]
-case class ExtractArrayType(arr: ArrayModel, concreteTypes: List[PropMeta], generatorSettings: GeneratorSettings)
-    extends ArrayProtocolTerm[Type]
+case class ExtractArrayType(arr: ArrayModel, concreteTypes: List[PropMeta], generatorSettings: GeneratorSettings) extends ArrayProtocolTerm[Type]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ArrayProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ArrayProtocolTerm.scala
@@ -6,4 +6,4 @@ import com.twilio.guardrail.generators.GeneratorSettings
 import scala.meta._
 
 sealed trait ArrayProtocolTerm[T]
-case class ExtractArrayType(arr: ArrayModel, concreteTypes: List[PropMeta], generatorSettings: GeneratorSettings) extends ArrayProtocolTerm[Type]
+case class ExtractArrayType(arr: ArrayModel, concreteTypes: List[PropMeta]) extends ArrayProtocolTerm[Type]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ArrayProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ArrayProtocolTerm.scala
@@ -1,8 +1,10 @@
 package com.twilio.guardrail.protocol.terms.protocol
 
 import _root_.io.swagger.models.ArrayModel
+import com.twilio.guardrail.generators.GeneratorSettings
 
 import scala.meta._
 
 sealed trait ArrayProtocolTerm[T]
-case class ExtractArrayType(arr: ArrayModel, concreteTypes: List[PropMeta]) extends ArrayProtocolTerm[Type]
+case class ExtractArrayType(arr: ArrayModel, concreteTypes: List[PropMeta], generatorSettings: GeneratorSettings)
+    extends ArrayProtocolTerm[Type]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ArrayProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ArrayProtocolTerms.scala
@@ -3,12 +3,16 @@ package com.twilio.guardrail.protocol.terms.protocol
 import _root_.io.swagger.models.ArrayModel
 import cats.InjectK
 import cats.free.Free
+import com.twilio.guardrail.generators.GeneratorSettings
 
 import scala.meta._
 
 class ArrayProtocolTerms[F[_]](implicit I: InjectK[ArrayProtocolTerm, F]) {
-  def extractArrayType(arr: ArrayModel, concreteTypes: List[PropMeta]): Free[F, Type] =
-    Free.inject[ArrayProtocolTerm, F](ExtractArrayType(arr, concreteTypes))
+  def extractArrayType(
+      arr: ArrayModel,
+      concreteTypes: List[PropMeta],
+      generatorSettings: GeneratorSettings): Free[F, Type] =
+    Free.inject[ArrayProtocolTerm, F](ExtractArrayType(arr, concreteTypes, generatorSettings))
 }
 
 object ArrayProtocolTerms {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ArrayProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ArrayProtocolTerms.scala
@@ -8,10 +8,7 @@ import com.twilio.guardrail.generators.GeneratorSettings
 import scala.meta._
 
 class ArrayProtocolTerms[F[_]](implicit I: InjectK[ArrayProtocolTerm, F]) {
-  def extractArrayType(
-      arr: ArrayModel,
-      concreteTypes: List[PropMeta],
-      generatorSettings: GeneratorSettings): Free[F, Type] =
+  def extractArrayType(arr: ArrayModel, concreteTypes: List[PropMeta], generatorSettings: GeneratorSettings): Free[F, Type] =
     Free.inject[ArrayProtocolTerm, F](ExtractArrayType(arr, concreteTypes, generatorSettings))
 }
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ArrayProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ArrayProtocolTerms.scala
@@ -8,8 +8,8 @@ import com.twilio.guardrail.generators.GeneratorSettings
 import scala.meta._
 
 class ArrayProtocolTerms[F[_]](implicit I: InjectK[ArrayProtocolTerm, F]) {
-  def extractArrayType(arr: ArrayModel, concreteTypes: List[PropMeta], generatorSettings: GeneratorSettings): Free[F, Type] =
-    Free.inject[ArrayProtocolTerm, F](ExtractArrayType(arr, concreteTypes, generatorSettings))
+  def extractArrayType(arr: ArrayModel, concreteTypes: List[PropMeta]): Free[F, Type] =
+    Free.inject[ArrayProtocolTerm, F](ExtractArrayType(arr, concreteTypes))
 }
 
 object ArrayProtocolTerms {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/EnumProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/EnumProtocolTerm.scala
@@ -11,10 +11,11 @@ case class RenderMembers(clsName: String, elems: List[(String, Term.Name, Term)]
 case class EncodeEnum(clsName: String) extends EnumProtocolTerm[Defn.Val]
 case class DecodeEnum(clsName: String) extends EnumProtocolTerm[Defn.Val]
 case class RenderClass(clsName: String, tpe: Type) extends EnumProtocolTerm[Defn.Class]
-case class RenderCompanion(clsName: String,
-                           members: Defn.Object,
-                           accessors: List[meta.Defn.Val],
-                           values: meta.Defn.Val,
-                           encoder: Defn.Val,
-                           decoder: Defn.Val)
+case class RenderCompanion(
+    clsName: String,
+    members: Defn.Object,
+    accessors: List[meta.Defn.Val],
+    values: meta.Defn.Val,
+    encoder: Defn.Val,
+    decoder: Defn.Val)
     extends EnumProtocolTerm[Defn.Object]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/EnumProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/EnumProtocolTerm.scala
@@ -6,18 +6,11 @@ import com.twilio.guardrail.generators.GeneratorSettings
 import scala.meta._
 
 sealed trait EnumProtocolTerm[T]
-case class ExtractEnum(swagger: ModelImpl) extends EnumProtocolTerm[Either[String, List[String]]]
-case class ExtractType(swagger: ModelImpl, generatorSettings: GeneratorSettings)
-    extends EnumProtocolTerm[Either[String, Type]]
+case class ExtractEnum(swagger: ModelImpl)                                        extends EnumProtocolTerm[Either[String, List[String]]]
+case class ExtractType(swagger: ModelImpl, generatorSettings: GeneratorSettings)  extends EnumProtocolTerm[Either[String, Type]]
 case class RenderMembers(clsName: String, elems: List[(String, Term.Name, Term)]) extends EnumProtocolTerm[Defn.Object]
-case class EncodeEnum(clsName: String) extends EnumProtocolTerm[Defn.Val]
-case class DecodeEnum(clsName: String) extends EnumProtocolTerm[Defn.Val]
-case class RenderClass(clsName: String, tpe: Type) extends EnumProtocolTerm[Defn.Class]
-case class RenderCompanion(
-    clsName: String,
-    members: Defn.Object,
-    accessors: List[meta.Defn.Val],
-    values: meta.Defn.Val,
-    encoder: Defn.Val,
-    decoder: Defn.Val)
+case class EncodeEnum(clsName: String)                                            extends EnumProtocolTerm[Defn.Val]
+case class DecodeEnum(clsName: String)                                            extends EnumProtocolTerm[Defn.Val]
+case class RenderClass(clsName: String, tpe: Type)                                extends EnumProtocolTerm[Defn.Class]
+case class RenderCompanion(clsName: String, members: Defn.Object, accessors: List[meta.Defn.Val], values: meta.Defn.Val, encoder: Defn.Val, decoder: Defn.Val)
     extends EnumProtocolTerm[Defn.Object]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/EnumProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/EnumProtocolTerm.scala
@@ -1,12 +1,14 @@
 package com.twilio.guardrail.protocol.terms.protocol
 
 import _root_.io.swagger.models.ModelImpl
+import com.twilio.guardrail.generators.GeneratorSettings
 
 import scala.meta._
 
 sealed trait EnumProtocolTerm[T]
 case class ExtractEnum(swagger: ModelImpl) extends EnumProtocolTerm[Either[String, List[String]]]
-case class ExtractType(swagger: ModelImpl) extends EnumProtocolTerm[Either[String, Type]]
+case class ExtractType(swagger: ModelImpl, generatorSettings: GeneratorSettings)
+    extends EnumProtocolTerm[Either[String, Type]]
 case class RenderMembers(clsName: String, elems: List[(String, Term.Name, Term)]) extends EnumProtocolTerm[Defn.Object]
 case class EncodeEnum(clsName: String) extends EnumProtocolTerm[Defn.Val]
 case class DecodeEnum(clsName: String) extends EnumProtocolTerm[Defn.Val]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/EnumProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/EnumProtocolTerm.scala
@@ -7,7 +7,7 @@ import scala.meta._
 
 sealed trait EnumProtocolTerm[T]
 case class ExtractEnum(swagger: ModelImpl)                                        extends EnumProtocolTerm[Either[String, List[String]]]
-case class ExtractType(swagger: ModelImpl, generatorSettings: GeneratorSettings)  extends EnumProtocolTerm[Either[String, Type]]
+case class ExtractType(swagger: ModelImpl)                                        extends EnumProtocolTerm[Either[String, Type]]
 case class RenderMembers(clsName: String, elems: List[(String, Term.Name, Term)]) extends EnumProtocolTerm[Defn.Object]
 case class EncodeEnum(clsName: String)                                            extends EnumProtocolTerm[Defn.Val]
 case class DecodeEnum(clsName: String)                                            extends EnumProtocolTerm[Defn.Val]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/EnumProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/EnumProtocolTerms.scala
@@ -3,14 +3,15 @@ package com.twilio.guardrail.protocol.terms.protocol
 import _root_.io.swagger.models.ModelImpl
 import cats.InjectK
 import cats.free.Free
+import com.twilio.guardrail.generators.GeneratorSettings
 
 import scala.meta._
 
 class EnumProtocolTerms[F[_]](implicit I: InjectK[EnumProtocolTerm, F]) {
   def extractEnum(swagger: ModelImpl): Free[F, Either[String, List[String]]] =
     Free.inject[EnumProtocolTerm, F](ExtractEnum(swagger))
-  def extractType(swagger: ModelImpl): Free[F, Either[String, Type]] =
-    Free.inject[EnumProtocolTerm, F](ExtractType(swagger))
+  def extractType(swagger: ModelImpl, generatorSettings: GeneratorSettings): Free[F, Either[String, Type]] =
+    Free.inject[EnumProtocolTerm, F](ExtractType(swagger, generatorSettings))
   def renderMembers(clsName: String, elems: List[(String, Term.Name, Term)]): Free[F, Defn.Object] =
     Free.inject[EnumProtocolTerm, F](RenderMembers(clsName, elems))
   def encodeEnum(clsName: String): Free[F, Defn.Val] =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/EnumProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/EnumProtocolTerms.scala
@@ -20,13 +20,12 @@ class EnumProtocolTerms[F[_]](implicit I: InjectK[EnumProtocolTerm, F]) {
     Free.inject[EnumProtocolTerm, F](DecodeEnum(clsName))
   def renderClass(clsName: String, tpe: Type): Free[F, Defn.Class] =
     Free.inject[EnumProtocolTerm, F](RenderClass(clsName, tpe))
-  def renderCompanion(
-      clsName: String,
-      members: Defn.Object,
-      accessors: List[Defn.Val],
-      values: Defn.Val,
-      encoder: Defn.Val,
-      decoder: Defn.Val): Free[F, Defn.Object] =
+  def renderCompanion(clsName: String,
+                      members: Defn.Object,
+                      accessors: List[Defn.Val],
+                      values: Defn.Val,
+                      encoder: Defn.Val,
+                      decoder: Defn.Val): Free[F, Defn.Object] =
     Free.inject[EnumProtocolTerm, F](RenderCompanion(clsName, members, accessors, values, encoder, decoder))
 }
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/EnumProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/EnumProtocolTerms.scala
@@ -19,12 +19,13 @@ class EnumProtocolTerms[F[_]](implicit I: InjectK[EnumProtocolTerm, F]) {
     Free.inject[EnumProtocolTerm, F](DecodeEnum(clsName))
   def renderClass(clsName: String, tpe: Type): Free[F, Defn.Class] =
     Free.inject[EnumProtocolTerm, F](RenderClass(clsName, tpe))
-  def renderCompanion(clsName: String,
-                      members: Defn.Object,
-                      accessors: List[Defn.Val],
-                      values: Defn.Val,
-                      encoder: Defn.Val,
-                      decoder: Defn.Val): Free[F, Defn.Object] =
+  def renderCompanion(
+      clsName: String,
+      members: Defn.Object,
+      accessors: List[Defn.Val],
+      values: Defn.Val,
+      encoder: Defn.Val,
+      decoder: Defn.Val): Free[F, Defn.Object] =
     Free.inject[EnumProtocolTerm, F](RenderCompanion(clsName, members, accessors, values, encoder, decoder))
 }
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/EnumProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/EnumProtocolTerms.scala
@@ -10,8 +10,8 @@ import scala.meta._
 class EnumProtocolTerms[F[_]](implicit I: InjectK[EnumProtocolTerm, F]) {
   def extractEnum(swagger: ModelImpl): Free[F, Either[String, List[String]]] =
     Free.inject[EnumProtocolTerm, F](ExtractEnum(swagger))
-  def extractType(swagger: ModelImpl, generatorSettings: GeneratorSettings): Free[F, Either[String, Type]] =
-    Free.inject[EnumProtocolTerm, F](ExtractType(swagger, generatorSettings))
+  def extractType(swagger: ModelImpl): Free[F, Either[String, Type]] =
+    Free.inject[EnumProtocolTerm, F](ExtractType(swagger))
   def renderMembers(clsName: String, elems: List[(String, Term.Name, Term)]): Free[F, Defn.Object] =
     Free.inject[EnumProtocolTerm, F](RenderMembers(clsName, elems))
   def encodeEnum(clsName: String): Free[F, Defn.Val] =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerm.scala
@@ -9,18 +9,14 @@ import scala.meta._
 
 sealed trait ModelProtocolTerm[T]
 case class ExtractProperties(swagger: ModelImpl) extends ModelProtocolTerm[Either[String, List[(String, Property)]]]
-case class TransformProperty(
-    clsName: String,
-    name: String,
-    prop: Property,
-    needCamelSnakeConversion: Boolean,
-    concreteTypes: List[PropMeta],
-    generatorSettings: GeneratorSettings)
+case class TransformProperty(clsName: String,
+                             name: String,
+                             prop: Property,
+                             needCamelSnakeConversion: Boolean,
+                             concreteTypes: List[PropMeta],
+                             generatorSettings: GeneratorSettings)
     extends ModelProtocolTerm[ProtocolParameter]
-case class RenderDTOClass(clsName: String, terms: List[Term.Param]) extends ModelProtocolTerm[Defn.Class]
-case class EncodeModel(clsName: String, needCamelSnakeConversion: Boolean, params: List[ProtocolParameter])
-    extends ModelProtocolTerm[Stat]
-case class DecodeModel(clsName: String, needCamelSnakeConversion: Boolean, params: List[ProtocolParameter])
-    extends ModelProtocolTerm[Stat]
-case class RenderDTOCompanion(clsName: String, deps: List[Term.Name], encoder: Stat, decoder: Stat)
-    extends ModelProtocolTerm[Defn.Object]
+case class RenderDTOClass(clsName: String, terms: List[Term.Param])                                         extends ModelProtocolTerm[Defn.Class]
+case class EncodeModel(clsName: String, needCamelSnakeConversion: Boolean, params: List[ProtocolParameter]) extends ModelProtocolTerm[Stat]
+case class DecodeModel(clsName: String, needCamelSnakeConversion: Boolean, params: List[ProtocolParameter]) extends ModelProtocolTerm[Stat]
+case class RenderDTOCompanion(clsName: String, deps: List[Term.Name], encoder: Stat, decoder: Stat)         extends ModelProtocolTerm[Defn.Object]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerm.scala
@@ -8,11 +8,12 @@ import scala.meta._
 
 sealed trait ModelProtocolTerm[T]
 case class ExtractProperties(swagger: ModelImpl) extends ModelProtocolTerm[Either[String, List[(String, Property)]]]
-case class TransformProperty(clsName: String,
-                             name: String,
-                             prop: Property,
-                             needCamelSnakeConversion: Boolean,
-                             concreteTypes: List[PropMeta])
+case class TransformProperty(
+    clsName: String,
+    name: String,
+    prop: Property,
+    needCamelSnakeConversion: Boolean,
+    concreteTypes: List[PropMeta])
     extends ModelProtocolTerm[ProtocolParameter]
 case class RenderDTOClass(clsName: String, terms: List[Term.Param]) extends ModelProtocolTerm[Defn.Class]
 case class EncodeModel(clsName: String, needCamelSnakeConversion: Boolean, params: List[ProtocolParameter])

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerm.scala
@@ -9,12 +9,7 @@ import scala.meta._
 
 sealed trait ModelProtocolTerm[T]
 case class ExtractProperties(swagger: ModelImpl) extends ModelProtocolTerm[Either[String, List[(String, Property)]]]
-case class TransformProperty(clsName: String,
-                             name: String,
-                             prop: Property,
-                             needCamelSnakeConversion: Boolean,
-                             concreteTypes: List[PropMeta],
-                             generatorSettings: GeneratorSettings)
+case class TransformProperty(clsName: String, name: String, prop: Property, needCamelSnakeConversion: Boolean, concreteTypes: List[PropMeta])
     extends ModelProtocolTerm[ProtocolParameter]
 case class RenderDTOClass(clsName: String, terms: List[Term.Param])                                         extends ModelProtocolTerm[Defn.Class]
 case class EncodeModel(clsName: String, needCamelSnakeConversion: Boolean, params: List[ProtocolParameter]) extends ModelProtocolTerm[Stat]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerm.scala
@@ -3,6 +3,7 @@ package com.twilio.guardrail.protocol.terms.protocol
 import _root_.io.swagger.models.ModelImpl
 import _root_.io.swagger.models.properties.Property
 import com.twilio.guardrail.ProtocolParameter
+import com.twilio.guardrail.generators.GeneratorSettings
 
 import scala.meta._
 
@@ -13,7 +14,8 @@ case class TransformProperty(
     name: String,
     prop: Property,
     needCamelSnakeConversion: Boolean,
-    concreteTypes: List[PropMeta])
+    concreteTypes: List[PropMeta],
+    generatorSettings: GeneratorSettings)
     extends ModelProtocolTerm[ProtocolParameter]
 case class RenderDTOClass(clsName: String, terms: List[Term.Param]) extends ModelProtocolTerm[Defn.Class]
 case class EncodeModel(clsName: String, needCamelSnakeConversion: Boolean, params: List[ProtocolParameter])

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerms.scala
@@ -5,16 +5,20 @@ import _root_.io.swagger.models.properties.Property
 import cats.InjectK
 import cats.free.Free
 import com.twilio.guardrail.ProtocolParameter
+import com.twilio.guardrail.generators.GeneratorSettings
 
 import scala.meta._
 
 class ModelProtocolTerms[F[_]](implicit I: InjectK[ModelProtocolTerm, F]) {
   def extractProperties(swagger: ModelImpl): Free[F, Either[String, List[(String, Property)]]] =
     Free.inject[ModelProtocolTerm, F](ExtractProperties(swagger))
-  def transformProperty(clsName: String, needCamelSnakeConversion: Boolean, concreteTypes: List[PropMeta])(
-      name: String,
-      prop: Property): Free[F, ProtocolParameter] =
-    Free.inject[ModelProtocolTerm, F](TransformProperty(clsName, name, prop, needCamelSnakeConversion, concreteTypes))
+  def transformProperty(
+      clsName: String,
+      needCamelSnakeConversion: Boolean,
+      concreteTypes: List[PropMeta],
+      generatorSettings: GeneratorSettings)(name: String, prop: Property): Free[F, ProtocolParameter] =
+    Free.inject[ModelProtocolTerm, F](
+      TransformProperty(clsName, name, prop, needCamelSnakeConversion, concreteTypes, generatorSettings))
   def renderDTOClass(clsName: String, terms: List[Term.Param]): Free[F, Defn.Class] =
     Free.inject[ModelProtocolTerm, F](RenderDTOClass(clsName, terms))
   def encodeModel(clsName: String, needCamelSnakeConversion: Boolean, params: List[ProtocolParameter]): Free[F, Stat] =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerms.scala
@@ -12,11 +12,11 @@ import scala.meta._
 class ModelProtocolTerms[F[_]](implicit I: InjectK[ModelProtocolTerm, F]) {
   def extractProperties(swagger: ModelImpl): Free[F, Either[String, List[(String, Property)]]] =
     Free.inject[ModelProtocolTerm, F](ExtractProperties(swagger))
-  def transformProperty(clsName: String, needCamelSnakeConversion: Boolean, concreteTypes: List[PropMeta], generatorSettings: GeneratorSettings)(
+  def transformProperty(clsName: String, needCamelSnakeConversion: Boolean, concreteTypes: List[PropMeta])(
       name: String,
       prop: Property
   ): Free[F, ProtocolParameter] =
-    Free.inject[ModelProtocolTerm, F](TransformProperty(clsName, name, prop, needCamelSnakeConversion, concreteTypes, generatorSettings))
+    Free.inject[ModelProtocolTerm, F](TransformProperty(clsName, name, prop, needCamelSnakeConversion, concreteTypes))
   def renderDTOClass(clsName: String, terms: List[Term.Param]): Free[F, Defn.Class] =
     Free.inject[ModelProtocolTerm, F](RenderDTOClass(clsName, terms))
   def encodeModel(clsName: String, needCamelSnakeConversion: Boolean, params: List[ProtocolParameter]): Free[F, Stat] =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerms.scala
@@ -12,13 +12,11 @@ import scala.meta._
 class ModelProtocolTerms[F[_]](implicit I: InjectK[ModelProtocolTerm, F]) {
   def extractProperties(swagger: ModelImpl): Free[F, Either[String, List[(String, Property)]]] =
     Free.inject[ModelProtocolTerm, F](ExtractProperties(swagger))
-  def transformProperty(
-      clsName: String,
-      needCamelSnakeConversion: Boolean,
-      concreteTypes: List[PropMeta],
-      generatorSettings: GeneratorSettings)(name: String, prop: Property): Free[F, ProtocolParameter] =
-    Free.inject[ModelProtocolTerm, F](
-      TransformProperty(clsName, name, prop, needCamelSnakeConversion, concreteTypes, generatorSettings))
+  def transformProperty(clsName: String, needCamelSnakeConversion: Boolean, concreteTypes: List[PropMeta], generatorSettings: GeneratorSettings)(
+      name: String,
+      prop: Property
+  ): Free[F, ProtocolParameter] =
+    Free.inject[ModelProtocolTerm, F](TransformProperty(clsName, name, prop, needCamelSnakeConversion, concreteTypes, generatorSettings))
   def renderDTOClass(clsName: String, terms: List[Term.Param]): Free[F, Defn.Class] =
     Free.inject[ModelProtocolTerm, F](RenderDTOClass(clsName, terms))
   def encodeModel(clsName: String, needCamelSnakeConversion: Boolean, params: List[ProtocolParameter]): Free[F, Stat] =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ProtocolSupportTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ProtocolSupportTerm.scala
@@ -7,8 +7,7 @@ import scala.meta._
 
 case class PropMeta(clsName: String, tpe: Type)
 sealed trait ProtocolSupportTerm[T]
-case class ExtractConcreteTypes(models: List[(String, Model)], generatorSettings: GeneratorSettings)
-    extends ProtocolSupportTerm[List[PropMeta]]
-case class ProtocolImports() extends ProtocolSupportTerm[List[Import]]
-case class PackageObjectImports() extends ProtocolSupportTerm[List[Import]]
-case class PackageObjectContents() extends ProtocolSupportTerm[List[Stat]]
+case class ExtractConcreteTypes(models: List[(String, Model)], generatorSettings: GeneratorSettings) extends ProtocolSupportTerm[List[PropMeta]]
+case class ProtocolImports()                                                                         extends ProtocolSupportTerm[List[Import]]
+case class PackageObjectImports()                                                                    extends ProtocolSupportTerm[List[Import]]
+case class PackageObjectContents()                                                                   extends ProtocolSupportTerm[List[Stat]]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ProtocolSupportTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ProtocolSupportTerm.scala
@@ -1,13 +1,12 @@
 package com.twilio.guardrail.protocol.terms.protocol
 
 import _root_.io.swagger.models.Model
-import com.twilio.guardrail.generators.GeneratorSettings
 
 import scala.meta._
 
 case class PropMeta(clsName: String, tpe: Type)
 sealed trait ProtocolSupportTerm[T]
-case class ExtractConcreteTypes(models: List[(String, Model)], generatorSettings: GeneratorSettings) extends ProtocolSupportTerm[List[PropMeta]]
-case class ProtocolImports()                                                                         extends ProtocolSupportTerm[List[Import]]
-case class PackageObjectImports()                                                                    extends ProtocolSupportTerm[List[Import]]
-case class PackageObjectContents()                                                                   extends ProtocolSupportTerm[List[Stat]]
+case class ExtractConcreteTypes(models: List[(String, Model)]) extends ProtocolSupportTerm[List[PropMeta]]
+case class ProtocolImports()                                   extends ProtocolSupportTerm[List[Import]]
+case class PackageObjectImports()                              extends ProtocolSupportTerm[List[Import]]
+case class PackageObjectContents()                             extends ProtocolSupportTerm[List[Stat]]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ProtocolSupportTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ProtocolSupportTerm.scala
@@ -1,12 +1,14 @@
 package com.twilio.guardrail.protocol.terms.protocol
 
 import _root_.io.swagger.models.Model
+import com.twilio.guardrail.generators.GeneratorSettings
 
 import scala.meta._
 
 case class PropMeta(clsName: String, tpe: Type)
 sealed trait ProtocolSupportTerm[T]
-case class ExtractConcreteTypes(models: List[(String, Model)]) extends ProtocolSupportTerm[List[PropMeta]]
+case class ExtractConcreteTypes(models: List[(String, Model)], generatorSettings: GeneratorSettings)
+    extends ProtocolSupportTerm[List[PropMeta]]
 case class ProtocolImports() extends ProtocolSupportTerm[List[Import]]
 case class PackageObjectImports() extends ProtocolSupportTerm[List[Import]]
 case class PackageObjectContents() extends ProtocolSupportTerm[List[Stat]]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ProtocolSupportTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ProtocolSupportTerms.scala
@@ -3,12 +3,15 @@ package com.twilio.guardrail.protocol.terms.protocol
 import _root_.io.swagger.models.Model
 import cats.InjectK
 import cats.free.Free
+import com.twilio.guardrail.generators.GeneratorSettings
 
 import scala.meta._
 
 class ProtocolSupportTerms[F[_]](implicit I: InjectK[ProtocolSupportTerm, F]) {
-  def extractConcreteTypes(models: List[(String, Model)]): Free[F, List[PropMeta]] =
-    Free.inject[ProtocolSupportTerm, F](ExtractConcreteTypes(models))
+  def extractConcreteTypes(
+      models: List[(String, Model)],
+      generatorSettings: GeneratorSettings): Free[F, List[PropMeta]] =
+    Free.inject[ProtocolSupportTerm, F](ExtractConcreteTypes(models, generatorSettings))
   def protocolImports(): Free[F, List[Import]] =
     Free.inject[ProtocolSupportTerm, F](ProtocolImports())
   def packageObjectImports(): Free[F, List[Import]] =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ProtocolSupportTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ProtocolSupportTerms.scala
@@ -3,13 +3,12 @@ package com.twilio.guardrail.protocol.terms.protocol
 import _root_.io.swagger.models.Model
 import cats.InjectK
 import cats.free.Free
-import com.twilio.guardrail.generators.GeneratorSettings
 
 import scala.meta._
 
 class ProtocolSupportTerms[F[_]](implicit I: InjectK[ProtocolSupportTerm, F]) {
-  def extractConcreteTypes(models: List[(String, Model)], generatorSettings: GeneratorSettings): Free[F, List[PropMeta]] =
-    Free.inject[ProtocolSupportTerm, F](ExtractConcreteTypes(models, generatorSettings))
+  def extractConcreteTypes(models: List[(String, Model)]): Free[F, List[PropMeta]] =
+    Free.inject[ProtocolSupportTerm, F](ExtractConcreteTypes(models))
   def protocolImports(): Free[F, List[Import]] =
     Free.inject[ProtocolSupportTerm, F](ProtocolImports())
   def packageObjectImports(): Free[F, List[Import]] =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ProtocolSupportTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ProtocolSupportTerms.scala
@@ -8,9 +8,7 @@ import com.twilio.guardrail.generators.GeneratorSettings
 import scala.meta._
 
 class ProtocolSupportTerms[F[_]](implicit I: InjectK[ProtocolSupportTerm, F]) {
-  def extractConcreteTypes(
-      models: List[(String, Model)],
-      generatorSettings: GeneratorSettings): Free[F, List[PropMeta]] =
+  def extractConcreteTypes(models: List[(String, Model)], generatorSettings: GeneratorSettings): Free[F, List[PropMeta]] =
     Free.inject[ProtocolSupportTerm, F](ExtractConcreteTypes(models, generatorSettings))
   def protocolImports(): Free[F, List[Import]] =
     Free.inject[ProtocolSupportTerm, F](ProtocolImports())

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerm.scala
@@ -1,7 +1,7 @@
 package com.twilio.guardrail.protocol.terms.server
 
 import _root_.io.swagger.models.{Operation, Path}
-import com.twilio.guardrail.generators.ScalaParameter
+import com.twilio.guardrail.generators.{GeneratorSettings, ScalaParameter}
 import com.twilio.guardrail.{RenderedRoute, ServerRoute, StrictProtocolElems}
 
 import scala.meta._
@@ -18,10 +18,14 @@ case class GenerateRoute(
     route: ServerRoute,
     tracingFields: Option[(ScalaParameter, Term)],
     responseDefinitions: List[Defn],
-    protocolElems: List[StrictProtocolElems])
+    protocolElems: List[StrictProtocolElems],
+    generatorSettings: GeneratorSettings)
     extends ServerTerm[RenderedRoute]
 case class GetExtraRouteParams(tracing: Boolean) extends ServerTerm[List[Term.Param]]
-case class GenerateResponseDefinitions(operation: Operation, protocolElems: List[StrictProtocolElems])
+case class GenerateResponseDefinitions(
+    operation: Operation,
+    protocolElems: List[StrictProtocolElems],
+    generatorSettings: GeneratorSettings)
     extends ServerTerm[List[Defn]]
 case class RenderClass(
     className: String,

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerm.scala
@@ -1,8 +1,8 @@
 package com.twilio.guardrail.protocol.terms.server
 
-import _root_.io.swagger.models.{Operation, Path}
-import com.twilio.guardrail.generators.{GeneratorSettings, ScalaParameter}
-import com.twilio.guardrail.{RenderedRoute, ServerRoute, StrictProtocolElems}
+import _root_.io.swagger.models.{ Operation, Path }
+import com.twilio.guardrail.generators.{ GeneratorSettings, ScalaParameter }
+import com.twilio.guardrail.{ RenderedRoute, ServerRoute, StrictProtocolElems }
 
 import scala.meta._
 
@@ -12,30 +12,24 @@ case class ExtractOperations(paths: List[(String, Path)]) extends ServerTerm[Lis
 case class GetClassName(operation: Operation) extends ServerTerm[List[String]]
 case class BuildTracingFields(operation: Operation, className: List[String], tracing: Boolean, generatorSettings: GeneratorSettings)
     extends ServerTerm[Option[(ScalaParameter, Term)]]
-case class GenerateRoute(
-    resourceName: String,
-    basePath: Option[String],
-    route: ServerRoute,
-    tracingFields: Option[(ScalaParameter, Term)],
-    responseDefinitions: List[Defn],
-    protocolElems: List[StrictProtocolElems],
-    generatorSettings: GeneratorSettings)
+case class GenerateRoute(resourceName: String,
+                         basePath: Option[String],
+                         route: ServerRoute,
+                         tracingFields: Option[(ScalaParameter, Term)],
+                         responseDefinitions: List[Defn],
+                         protocolElems: List[StrictProtocolElems],
+                         generatorSettings: GeneratorSettings)
     extends ServerTerm[RenderedRoute]
 case class GetExtraRouteParams(tracing: Boolean) extends ServerTerm[List[Term.Param]]
-case class GenerateResponseDefinitions(
-    operation: Operation,
-    protocolElems: List[StrictProtocolElems],
-    generatorSettings: GeneratorSettings)
+case class GenerateResponseDefinitions(operation: Operation, protocolElems: List[StrictProtocolElems], generatorSettings: GeneratorSettings)
     extends ServerTerm[List[Defn]]
-case class RenderClass(
-    className: String,
-    handlerName: String,
-    combinedRouteTerms: Term,
-    extraRouteParams: List[Term.Param],
-    responseDefinitions: List[Defn],
-    supportDefinitions: List[Defn])
+case class RenderClass(className: String,
+                       handlerName: String,
+                       combinedRouteTerms: Term,
+                       extraRouteParams: List[Term.Param],
+                       responseDefinitions: List[Defn],
+                       supportDefinitions: List[Defn])
     extends ServerTerm[Stat]
-case class RenderHandler(handlerName: String, methodSigs: List[Decl.Def], handlerDefinitions: List[Stat])
-    extends ServerTerm[Stat]
-case class CombineRouteTerms(terms: List[Term]) extends ServerTerm[Term]
-case class GetExtraImports(tracing: Boolean) extends ServerTerm[List[Import]]
+case class RenderHandler(handlerName: String, methodSigs: List[Decl.Def], handlerDefinitions: List[Stat]) extends ServerTerm[Stat]
+case class CombineRouteTerms(terms: List[Term])                                                           extends ServerTerm[Term]
+case class GetExtraImports(tracing: Boolean)                                                              extends ServerTerm[List[Import]]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerm.scala
@@ -32,8 +32,10 @@ case class RenderClass(
     handlerName: String,
     combinedRouteTerms: Term,
     extraRouteParams: List[Term.Param],
-    responseDefinitions: List[Defn])
+    responseDefinitions: List[Defn],
+    supportDefinitions: List[Defn])
     extends ServerTerm[Stat]
-case class RenderHandler(handlerName: String, methodSigs: List[Decl.Def]) extends ServerTerm[Stat]
+case class RenderHandler(handlerName: String, methodSigs: List[Decl.Def], handlerDefinitions: List[Stat])
+    extends ServerTerm[Stat]
 case class CombineRouteTerms(terms: List[Term]) extends ServerTerm[Term]
 case class GetExtraImports(tracing: Boolean) extends ServerTerm[List[Import]]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerm.scala
@@ -10,7 +10,7 @@ sealed trait ServerTerm[T]
 case class ExtractOperations(paths: List[(String, Path)]) extends ServerTerm[List[ServerRoute]]
 
 case class GetClassName(operation: Operation) extends ServerTerm[List[String]]
-case class BuildTracingFields(operation: Operation, className: List[String], tracing: Boolean)
+case class BuildTracingFields(operation: Operation, className: List[String], tracing: Boolean, generatorSettings: GeneratorSettings)
     extends ServerTerm[Option[(ScalaParameter, Term)]]
 case class GenerateRoute(
     resourceName: String,

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerm.scala
@@ -12,21 +12,23 @@ case class ExtractOperations(paths: List[(String, Path)]) extends ServerTerm[Lis
 case class GetClassName(operation: Operation) extends ServerTerm[List[String]]
 case class BuildTracingFields(operation: Operation, className: List[String], tracing: Boolean)
     extends ServerTerm[Option[(ScalaParameter, Term)]]
-case class GenerateRoute(resourceName: String,
-                         basePath: Option[String],
-                         route: ServerRoute,
-                         tracingFields: Option[(ScalaParameter, Term)],
-                         responseDefinitions: List[Defn],
-                         protocolElems: List[StrictProtocolElems])
+case class GenerateRoute(
+    resourceName: String,
+    basePath: Option[String],
+    route: ServerRoute,
+    tracingFields: Option[(ScalaParameter, Term)],
+    responseDefinitions: List[Defn],
+    protocolElems: List[StrictProtocolElems])
     extends ServerTerm[RenderedRoute]
 case class GetExtraRouteParams(tracing: Boolean) extends ServerTerm[List[Term.Param]]
 case class GenerateResponseDefinitions(operation: Operation, protocolElems: List[StrictProtocolElems])
     extends ServerTerm[List[Defn]]
-case class RenderClass(className: String,
-                       handlerName: String,
-                       combinedRouteTerms: Term,
-                       extraRouteParams: List[Term.Param],
-                       responseDefinitions: List[Defn])
+case class RenderClass(
+    className: String,
+    handlerName: String,
+    combinedRouteTerms: Term,
+    extraRouteParams: List[Term.Param],
+    responseDefinitions: List[Defn])
     extends ServerTerm[Stat]
 case class RenderHandler(handlerName: String, methodSigs: List[Decl.Def]) extends ServerTerm[Stat]
 case class CombineRouteTerms(terms: List[Term]) extends ServerTerm[Term]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerm.scala
@@ -9,20 +9,17 @@ import scala.meta._
 sealed trait ServerTerm[T]
 case class ExtractOperations(paths: List[(String, Path)]) extends ServerTerm[List[ServerRoute]]
 
-case class GetClassName(operation: Operation) extends ServerTerm[List[String]]
-case class BuildTracingFields(operation: Operation, className: List[String], tracing: Boolean, generatorSettings: GeneratorSettings)
-    extends ServerTerm[Option[(ScalaParameter, Term)]]
+case class GetClassName(operation: Operation)                                                  extends ServerTerm[List[String]]
+case class BuildTracingFields(operation: Operation, className: List[String], tracing: Boolean) extends ServerTerm[Option[(ScalaParameter, Term)]]
 case class GenerateRoute(resourceName: String,
                          basePath: Option[String],
                          route: ServerRoute,
                          tracingFields: Option[(ScalaParameter, Term)],
                          responseDefinitions: List[Defn],
-                         protocolElems: List[StrictProtocolElems],
-                         generatorSettings: GeneratorSettings)
+                         protocolElems: List[StrictProtocolElems])
     extends ServerTerm[RenderedRoute]
-case class GetExtraRouteParams(tracing: Boolean) extends ServerTerm[List[Term.Param]]
-case class GenerateResponseDefinitions(operation: Operation, protocolElems: List[StrictProtocolElems], generatorSettings: GeneratorSettings)
-    extends ServerTerm[List[Defn]]
+case class GetExtraRouteParams(tracing: Boolean)                                                       extends ServerTerm[List[Term.Param]]
+case class GenerateResponseDefinitions(operation: Operation, protocolElems: List[StrictProtocolElems]) extends ServerTerm[List[Defn]]
 case class RenderClass(className: String,
                        handlerName: String,
                        combinedRouteTerms: Term,

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerms.scala
@@ -13,22 +13,18 @@ class ServerTerms[F[_]](implicit I: InjectK[ServerTerm, F]) {
     Free.inject(ExtractOperations(paths))
   def getClassName(operation: Operation): Free[F, List[String]] =
     Free.inject(GetClassName(operation))
-  def buildTracingFields(operation: Operation,
-                         className: List[String],
-                         tracing: Boolean,
-                         generatorSettings: GeneratorSettings): Free[F, Option[(ScalaParameter, Term)]] =
-    Free.inject(BuildTracingFields(operation, className, tracing, generatorSettings))
+  def buildTracingFields(operation: Operation, className: List[String], tracing: Boolean): Free[F, Option[(ScalaParameter, Term)]] =
+    Free.inject(BuildTracingFields(operation, className, tracing))
   def generateRoute(resourceName: String,
                     basePath: Option[String],
                     tracingFields: Option[(ScalaParameter, Term)],
                     responseDefinitions: List[Defn],
-                    protocolElems: List[StrictProtocolElems],
-                    generatorSettings: GeneratorSettings)(route: ServerRoute): Free[F, RenderedRoute] =
-    Free.inject(GenerateRoute(resourceName, basePath, route, tracingFields, responseDefinitions, protocolElems, generatorSettings))
+                    protocolElems: List[StrictProtocolElems])(route: ServerRoute): Free[F, RenderedRoute] =
+    Free.inject(GenerateRoute(resourceName, basePath, route, tracingFields, responseDefinitions, protocolElems))
   def getExtraRouteParams(tracing: Boolean): Free[F, List[Term.Param]] =
     Free.inject(GetExtraRouteParams(tracing))
-  def generateResponseDefinitions(operation: Operation, protocolElems: List[StrictProtocolElems], generatorSettings: GeneratorSettings): Free[F, List[Defn]] =
-    Free.inject(GenerateResponseDefinitions(operation, protocolElems, generatorSettings))
+  def generateResponseDefinitions(operation: Operation, protocolElems: List[StrictProtocolElems]): Free[F, List[Defn]] =
+    Free.inject(GenerateResponseDefinitions(operation, protocolElems))
   def renderClass(resourceName: String,
                   handlerName: String,
                   combinedRouteTerms: Term,

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerms.scala
@@ -1,10 +1,10 @@
 package com.twilio.guardrail.protocol.terms.server
 
-import _root_.io.swagger.models.{Operation, Path}
+import _root_.io.swagger.models.{ Operation, Path }
 import cats.InjectK
 import cats.free.Free
-import com.twilio.guardrail.generators.{GeneratorSettings, ScalaParameter}
-import com.twilio.guardrail.{RenderedRoute, ServerRoute, StrictProtocolElems}
+import com.twilio.guardrail.generators.{ GeneratorSettings, ScalaParameter }
+import com.twilio.guardrail.{ RenderedRoute, ServerRoute, StrictProtocolElems }
 
 import scala.meta._
 
@@ -13,47 +13,29 @@ class ServerTerms[F[_]](implicit I: InjectK[ServerTerm, F]) {
     Free.inject(ExtractOperations(paths))
   def getClassName(operation: Operation): Free[F, List[String]] =
     Free.inject(GetClassName(operation))
-  def buildTracingFields(
-      operation: Operation,
-      className: List[String],
-      tracing: Boolean, generatorSettings: GeneratorSettings): Free[F, Option[(ScalaParameter, Term)]] =
+  def buildTracingFields(operation: Operation,
+                         className: List[String],
+                         tracing: Boolean,
+                         generatorSettings: GeneratorSettings): Free[F, Option[(ScalaParameter, Term)]] =
     Free.inject(BuildTracingFields(operation, className, tracing, generatorSettings))
-  def generateRoute(
-      resourceName: String,
-      basePath: Option[String],
-      tracingFields: Option[(ScalaParameter, Term)],
-      responseDefinitions: List[Defn],
-      protocolElems: List[StrictProtocolElems],
-      generatorSettings: GeneratorSettings)(route: ServerRoute): Free[F, RenderedRoute] =
-    Free.inject(
-      GenerateRoute(resourceName,
-                    basePath,
-                    route,
-                    tracingFields,
-                    responseDefinitions,
-                    protocolElems,
-                    generatorSettings))
+  def generateRoute(resourceName: String,
+                    basePath: Option[String],
+                    tracingFields: Option[(ScalaParameter, Term)],
+                    responseDefinitions: List[Defn],
+                    protocolElems: List[StrictProtocolElems],
+                    generatorSettings: GeneratorSettings)(route: ServerRoute): Free[F, RenderedRoute] =
+    Free.inject(GenerateRoute(resourceName, basePath, route, tracingFields, responseDefinitions, protocolElems, generatorSettings))
   def getExtraRouteParams(tracing: Boolean): Free[F, List[Term.Param]] =
     Free.inject(GetExtraRouteParams(tracing))
-  def generateResponseDefinitions(
-      operation: Operation,
-      protocolElems: List[StrictProtocolElems],
-      generatorSettings: GeneratorSettings): Free[F, List[Defn]] =
+  def generateResponseDefinitions(operation: Operation, protocolElems: List[StrictProtocolElems], generatorSettings: GeneratorSettings): Free[F, List[Defn]] =
     Free.inject(GenerateResponseDefinitions(operation, protocolElems, generatorSettings))
-  def renderClass(
-      resourceName: String,
-      handlerName: String,
-      combinedRouteTerms: Term,
-      extraRouteParams: List[Term.Param],
-      responseDefinitions: List[Defn],
-      supportDefinitions: List[Defn]): Free[F, Stat] =
-    Free.inject(
-      RenderClass(resourceName,
-                  handlerName,
-                  combinedRouteTerms,
-                  extraRouteParams,
-                  responseDefinitions,
-                  supportDefinitions))
+  def renderClass(resourceName: String,
+                  handlerName: String,
+                  combinedRouteTerms: Term,
+                  extraRouteParams: List[Term.Param],
+                  responseDefinitions: List[Defn],
+                  supportDefinitions: List[Defn]): Free[F, Stat] =
+    Free.inject(RenderClass(resourceName, handlerName, combinedRouteTerms, extraRouteParams, responseDefinitions, supportDefinitions))
   def renderHandler(handlerName: String, methodSigs: List[Decl.Def], handlerDefinitions: List[Stat]) =
     Free.inject(RenderHandler(handlerName, methodSigs, handlerDefinitions))
   def combineRouteTerms(terms: List[Term]): Free[F, Term] =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerms.scala
@@ -45,10 +45,17 @@ class ServerTerms[F[_]](implicit I: InjectK[ServerTerm, F]) {
       handlerName: String,
       combinedRouteTerms: Term,
       extraRouteParams: List[Term.Param],
-      responseDefinitions: List[Defn]): Free[F, Stat] =
-    Free.inject(RenderClass(resourceName, handlerName, combinedRouteTerms, extraRouteParams, responseDefinitions))
-  def renderHandler(handlerName: String, methodSigs: List[Decl.Def]) =
-    Free.inject(RenderHandler(handlerName, methodSigs))
+      responseDefinitions: List[Defn],
+      supportDefinitions: List[Defn]): Free[F, Stat] =
+    Free.inject(
+      RenderClass(resourceName,
+                  handlerName,
+                  combinedRouteTerms,
+                  extraRouteParams,
+                  responseDefinitions,
+                  supportDefinitions))
+  def renderHandler(handlerName: String, methodSigs: List[Decl.Def], handlerDefinitions: List[Stat]) =
+    Free.inject(RenderHandler(handlerName, methodSigs, handlerDefinitions))
   def combineRouteTerms(terms: List[Term]): Free[F, Term] =
     Free.inject(CombineRouteTerms(terms))
   def getExtraImports(tracing: Boolean): Free[F, List[Import]] =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerms.scala
@@ -13,25 +13,28 @@ class ServerTerms[F[_]](implicit I: InjectK[ServerTerm, F]) {
     Free.inject(ExtractOperations(paths))
   def getClassName(operation: Operation): Free[F, List[String]] =
     Free.inject(GetClassName(operation))
-  def buildTracingFields(operation: Operation,
-                         className: List[String],
-                         tracing: Boolean): Free[F, Option[(ScalaParameter, Term)]] =
+  def buildTracingFields(
+      operation: Operation,
+      className: List[String],
+      tracing: Boolean): Free[F, Option[(ScalaParameter, Term)]] =
     Free.inject(BuildTracingFields(operation, className, tracing))
-  def generateRoute(resourceName: String,
-                    basePath: Option[String],
-                    tracingFields: Option[(ScalaParameter, Term)],
-                    responseDefinitions: List[Defn],
-                    protocolElems: List[StrictProtocolElems])(route: ServerRoute): Free[F, RenderedRoute] =
+  def generateRoute(
+      resourceName: String,
+      basePath: Option[String],
+      tracingFields: Option[(ScalaParameter, Term)],
+      responseDefinitions: List[Defn],
+      protocolElems: List[StrictProtocolElems])(route: ServerRoute): Free[F, RenderedRoute] =
     Free.inject(GenerateRoute(resourceName, basePath, route, tracingFields, responseDefinitions, protocolElems))
   def getExtraRouteParams(tracing: Boolean): Free[F, List[Term.Param]] =
     Free.inject(GetExtraRouteParams(tracing))
   def generateResponseDefinitions(operation: Operation, protocolElems: List[StrictProtocolElems]): Free[F, List[Defn]] =
     Free.inject(GenerateResponseDefinitions(operation, protocolElems))
-  def renderClass(resourceName: String,
-                  handlerName: String,
-                  combinedRouteTerms: Term,
-                  extraRouteParams: List[Term.Param],
-                  responseDefinitions: List[Defn]): Free[F, Stat] =
+  def renderClass(
+      resourceName: String,
+      handlerName: String,
+      combinedRouteTerms: Term,
+      extraRouteParams: List[Term.Param],
+      responseDefinitions: List[Defn]): Free[F, Stat] =
     Free.inject(RenderClass(resourceName, handlerName, combinedRouteTerms, extraRouteParams, responseDefinitions))
   def renderHandler(handlerName: String, methodSigs: List[Decl.Def]) =
     Free.inject(RenderHandler(handlerName, methodSigs))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerms.scala
@@ -16,8 +16,8 @@ class ServerTerms[F[_]](implicit I: InjectK[ServerTerm, F]) {
   def buildTracingFields(
       operation: Operation,
       className: List[String],
-      tracing: Boolean): Free[F, Option[(ScalaParameter, Term)]] =
-    Free.inject(BuildTracingFields(operation, className, tracing))
+      tracing: Boolean, generatorSettings: GeneratorSettings): Free[F, Option[(ScalaParameter, Term)]] =
+    Free.inject(BuildTracingFields(operation, className, tracing, generatorSettings))
   def generateRoute(
       resourceName: String,
       basePath: Option[String],

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerms.scala
@@ -3,7 +3,7 @@ package com.twilio.guardrail.protocol.terms.server
 import _root_.io.swagger.models.{Operation, Path}
 import cats.InjectK
 import cats.free.Free
-import com.twilio.guardrail.generators.ScalaParameter
+import com.twilio.guardrail.generators.{GeneratorSettings, ScalaParameter}
 import com.twilio.guardrail.{RenderedRoute, ServerRoute, StrictProtocolElems}
 
 import scala.meta._
@@ -23,12 +23,23 @@ class ServerTerms[F[_]](implicit I: InjectK[ServerTerm, F]) {
       basePath: Option[String],
       tracingFields: Option[(ScalaParameter, Term)],
       responseDefinitions: List[Defn],
-      protocolElems: List[StrictProtocolElems])(route: ServerRoute): Free[F, RenderedRoute] =
-    Free.inject(GenerateRoute(resourceName, basePath, route, tracingFields, responseDefinitions, protocolElems))
+      protocolElems: List[StrictProtocolElems],
+      generatorSettings: GeneratorSettings)(route: ServerRoute): Free[F, RenderedRoute] =
+    Free.inject(
+      GenerateRoute(resourceName,
+                    basePath,
+                    route,
+                    tracingFields,
+                    responseDefinitions,
+                    protocolElems,
+                    generatorSettings))
   def getExtraRouteParams(tracing: Boolean): Free[F, List[Term.Param]] =
     Free.inject(GetExtraRouteParams(tracing))
-  def generateResponseDefinitions(operation: Operation, protocolElems: List[StrictProtocolElems]): Free[F, List[Defn]] =
-    Free.inject(GenerateResponseDefinitions(operation, protocolElems))
+  def generateResponseDefinitions(
+      operation: Operation,
+      protocolElems: List[StrictProtocolElems],
+      generatorSettings: GeneratorSettings): Free[F, List[Defn]] =
+    Free.inject(GenerateResponseDefinitions(operation, protocolElems, generatorSettings))
   def renderClass(
       resourceName: String,
       handlerName: String,

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/CoreTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/CoreTerm.scala
@@ -4,10 +4,12 @@ package terms
 import cats.arrow.FunctionK
 import cats.data.NonEmptyList
 import scala.meta._
+import com.twilio.guardrail.generators.GeneratorSettings
 
 sealed trait CoreTerm[T]
 case object GetDefaultFramework                                                               extends CoreTerm[String]
 case class ExtractGenerator(context: Context)                                                 extends CoreTerm[FunctionK[CodegenApplication, Target]]
+case class ExtractGeneratorSettings(context: Context)                                         extends CoreTerm[GeneratorSettings]
 case class ParseArgs(args: Array[String], defaultFramework: String)                           extends CoreTerm[List[Args]]
 case class ValidateArgs(parsed: List[Args])                                                   extends CoreTerm[NonEmptyList[Args]]
 case class ProcessArgSet(targetInterpreter: FunctionK[CodegenApplication, Target], arg: Args) extends CoreTerm[ReadSwagger[Target[List[WriteTree]]]]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/CoreTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/CoreTerm.scala
@@ -6,9 +6,8 @@ import cats.data.NonEmptyList
 import scala.meta._
 
 sealed trait CoreTerm[T]
-case object GetDefaultFramework extends CoreTerm[String]
-case class ExtractGenerator(context: Context) extends CoreTerm[FunctionK[CodegenApplication, Target]]
-case class ParseArgs(args: Array[String], defaultFramework: String) extends CoreTerm[List[Args]]
-case class ValidateArgs(parsed: List[Args]) extends CoreTerm[NonEmptyList[Args]]
-case class ProcessArgSet(targetInterpreter: FunctionK[CodegenApplication, Target], arg: Args)
-    extends CoreTerm[ReadSwagger[Target[List[WriteTree]]]]
+case object GetDefaultFramework                                                               extends CoreTerm[String]
+case class ExtractGenerator(context: Context)                                                 extends CoreTerm[FunctionK[CodegenApplication, Target]]
+case class ParseArgs(args: Array[String], defaultFramework: String)                           extends CoreTerm[List[Args]]
+case class ValidateArgs(parsed: List[Args])                                                   extends CoreTerm[NonEmptyList[Args]]
+case class ProcessArgSet(targetInterpreter: FunctionK[CodegenApplication, Target], arg: Args) extends CoreTerm[ReadSwagger[Target[List[WriteTree]]]]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/CoreTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/CoreTerms.scala
@@ -5,7 +5,7 @@ import cats.InjectK
 import cats.arrow.FunctionK
 import cats.data.NonEmptyList
 import cats.free.Free
-import com.twilio.guardrail.{CodegenApplication, Target}
+import com.twilio.guardrail.{ CodegenApplication, Target }
 
 import scala.meta._
 
@@ -18,8 +18,7 @@ class CoreTerms[F[_]](implicit I: InjectK[CoreTerm, F]) {
     Free.inject[CoreTerm, F](ParseArgs(args, defaultFramework))
   def validateArgs(parsed: List[Args]): Free[F, NonEmptyList[Args]] =
     Free.inject[CoreTerm, F](ValidateArgs(parsed))
-  def processArgSet(targetInterpreter: FunctionK[CodegenApplication, Target])(
-      args: Args): Free[F, ReadSwagger[Target[List[WriteTree]]]] =
+  def processArgSet(targetInterpreter: FunctionK[CodegenApplication, Target])(args: Args): Free[F, ReadSwagger[Target[List[WriteTree]]]] =
     Free.inject[CoreTerm, F](ProcessArgSet(targetInterpreter, args))
 }
 object CoreTerms {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/CoreTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/CoreTerms.scala
@@ -6,6 +6,7 @@ import cats.arrow.FunctionK
 import cats.data.NonEmptyList
 import cats.free.Free
 import com.twilio.guardrail.{ CodegenApplication, Target }
+import com.twilio.guardrail.generators.GeneratorSettings
 
 import scala.meta._
 
@@ -14,6 +15,8 @@ class CoreTerms[F[_]](implicit I: InjectK[CoreTerm, F]) {
     Free.inject[CoreTerm, F](GetDefaultFramework)
   def extractGenerator(context: Context): Free[F, FunctionK[CodegenApplication, Target]] =
     Free.inject[CoreTerm, F](ExtractGenerator(context))
+  def extractGeneratorSettings(context: Context): Free[F, GeneratorSettings] =
+    Free.inject[CoreTerm, F](ExtractGeneratorSettings(context))
   def parseArgs(args: Array[String], defaultFramework: String): Free[F, List[Args]] =
     Free.inject[CoreTerm, F](ParseArgs(args, defaultFramework))
   def validateArgs(parsed: List[Args]): Free[F, NonEmptyList[Args]] =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerm.scala
@@ -4,15 +4,7 @@ package terms
 import scala.meta._
 
 sealed trait ScalaTerm[T]
-case class RenderImplicits(
-    pkgName: List[String],
-    frameworkImports: List[Import],
-    jsonImports: List[Import],
-    customImports: List[Import])
+case class RenderImplicits(pkgName: List[String], frameworkImports: List[Import], jsonImports: List[Import], customImports: List[Import])
     extends ScalaTerm[Source]
-case class RenderFrameworkImplicits(
-    pkgName: List[String],
-    frameworkImports: List[Import],
-    jsonImports: List[Import],
-    frameworkImplicits: Defn.Object)
+case class RenderFrameworkImplicits(pkgName: List[String], frameworkImports: List[Import], jsonImports: List[Import], frameworkImplicits: Defn.Object)
     extends ScalaTerm[Source]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerm.scala
@@ -4,13 +4,15 @@ package terms
 import scala.meta._
 
 sealed trait ScalaTerm[T]
-case class RenderImplicits(pkgName: List[String],
-                           frameworkImports: List[Import],
-                           jsonImports: List[Import],
-                           customImports: List[Import])
+case class RenderImplicits(
+    pkgName: List[String],
+    frameworkImports: List[Import],
+    jsonImports: List[Import],
+    customImports: List[Import])
     extends ScalaTerm[Source]
-case class RenderFrameworkImplicits(pkgName: List[String],
-                                    frameworkImports: List[Import],
-                                    jsonImports: List[Import],
-                                    frameworkImplicits: Defn.Object)
+case class RenderFrameworkImplicits(
+    pkgName: List[String],
+    frameworkImports: List[Import],
+    jsonImports: List[Import],
+    frameworkImplicits: Defn.Object)
     extends ScalaTerm[Source]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerms.scala
@@ -7,15 +7,17 @@ import cats.free.Free
 import scala.meta._
 
 class ScalaTerms[F[_]](implicit I: InjectK[ScalaTerm, F]) {
-  def renderImplicits(pkgName: List[String],
-                      frameworkImports: List[Import],
-                      jsonImports: List[Import],
-                      customImports: List[Import]): Free[F, Source] =
+  def renderImplicits(
+      pkgName: List[String],
+      frameworkImports: List[Import],
+      jsonImports: List[Import],
+      customImports: List[Import]): Free[F, Source] =
     Free.inject[ScalaTerm, F](RenderImplicits(pkgName, frameworkImports, jsonImports, customImports))
-  def renderFrameworkImplicits(pkgName: List[String],
-                               frameworkImports: List[Import],
-                               jsonImports: List[Import],
-                               frameworkImplicits: Defn.Object): Free[F, Source] =
+  def renderFrameworkImplicits(
+      pkgName: List[String],
+      frameworkImports: List[Import],
+      jsonImports: List[Import],
+      frameworkImplicits: Defn.Object): Free[F, Source] =
     Free.inject[ScalaTerm, F](RenderFrameworkImplicits(pkgName, frameworkImports, jsonImports, frameworkImplicits))
 }
 object ScalaTerms {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerms.scala
@@ -7,17 +7,12 @@ import cats.free.Free
 import scala.meta._
 
 class ScalaTerms[F[_]](implicit I: InjectK[ScalaTerm, F]) {
-  def renderImplicits(
-      pkgName: List[String],
-      frameworkImports: List[Import],
-      jsonImports: List[Import],
-      customImports: List[Import]): Free[F, Source] =
+  def renderImplicits(pkgName: List[String], frameworkImports: List[Import], jsonImports: List[Import], customImports: List[Import]): Free[F, Source] =
     Free.inject[ScalaTerm, F](RenderImplicits(pkgName, frameworkImports, jsonImports, customImports))
-  def renderFrameworkImplicits(
-      pkgName: List[String],
-      frameworkImports: List[Import],
-      jsonImports: List[Import],
-      frameworkImplicits: Defn.Object): Free[F, Source] =
+  def renderFrameworkImplicits(pkgName: List[String],
+                               frameworkImports: List[Import],
+                               jsonImports: List[Import],
+                               frameworkImplicits: Defn.Object): Free[F, Source] =
     Free.inject[ScalaTerm, F](RenderFrameworkImplicits(pkgName, frameworkImports, jsonImports, frameworkImplicits))
 }
 object ScalaTerms {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
@@ -8,4 +8,4 @@ case class RouteMeta(path: String, method: HttpMethod, operation: Operation)
 
 sealed trait SwaggerTerm[T]
 case class ExtractOperations(paths: List[(String, Path)]) extends SwaggerTerm[List[RouteMeta]]
-case class GetClassName(operation: Operation) extends SwaggerTerm[List[String]]
+case class GetClassName(operation: Operation)             extends SwaggerTerm[List[String]]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerms.scala
@@ -1,7 +1,7 @@
 package com.twilio.guardrail
 package terms
 
-import _root_.io.swagger.models.{ModelImpl, Operation, Path}
+import _root_.io.swagger.models.{ ModelImpl, Operation, Path }
 import cats.InjectK
 import cats.free.Free
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/framework/FrameworkTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/framework/FrameworkTerm.scala
@@ -1,8 +1,10 @@
 package com.twilio.guardrail
 package terms.framework
+import com.twilio.guardrail.generators.GeneratorSettings
 
 import scala.meta._
 
 sealed trait FrameworkTerm[T]
 case class GetFrameworkImports(tracing: Boolean) extends FrameworkTerm[List[Import]]
-case class GetFrameworkImplicits() extends FrameworkTerm[Defn.Object]
+case class GetFrameworkImplicits(generatorSettings: GeneratorSettings) extends FrameworkTerm[Defn.Object]
+case class GetGeneratorSettings() extends FrameworkTerm[GeneratorSettings]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/framework/FrameworkTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/framework/FrameworkTerm.scala
@@ -5,6 +5,6 @@ import com.twilio.guardrail.generators.GeneratorSettings
 import scala.meta._
 
 sealed trait FrameworkTerm[T]
-case class GetFrameworkImports(tracing: Boolean) extends FrameworkTerm[List[Import]]
+case class GetFrameworkImports(tracing: Boolean)                       extends FrameworkTerm[List[Import]]
 case class GetFrameworkImplicits(generatorSettings: GeneratorSettings) extends FrameworkTerm[Defn.Object]
-case class GetGeneratorSettings() extends FrameworkTerm[GeneratorSettings]
+case class GetGeneratorSettings()                                      extends FrameworkTerm[GeneratorSettings]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/framework/FrameworkTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/framework/FrameworkTerm.scala
@@ -5,6 +5,6 @@ import com.twilio.guardrail.generators.GeneratorSettings
 import scala.meta._
 
 sealed trait FrameworkTerm[T]
-case class GetFrameworkImports(tracing: Boolean)                       extends FrameworkTerm[List[Import]]
-case class GetFrameworkImplicits(generatorSettings: GeneratorSettings) extends FrameworkTerm[Defn.Object]
-case class GetGeneratorSettings()                                      extends FrameworkTerm[GeneratorSettings]
+case class GetFrameworkImports(tracing: Boolean) extends FrameworkTerm[List[Import]]
+case class GetFrameworkImplicits()               extends FrameworkTerm[Defn.Object]
+case class GetGeneratorSettings()                extends FrameworkTerm[GeneratorSettings]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/framework/FrameworkTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/framework/FrameworkTerms.scala
@@ -10,8 +10,8 @@ import com.twilio.guardrail.generators.GeneratorSettings
 class FrameworkTerms[F[_]](implicit I: InjectK[FrameworkTerm, F]) {
   def getFrameworkImports(tracing: Boolean): Free[F, List[Import]] =
     Free.inject(GetFrameworkImports(tracing))
-  def getFrameworkImplicits(generatorSettings: GeneratorSettings): Free[F, Defn.Object] =
-    Free.inject(GetFrameworkImplicits(generatorSettings))
+  def getFrameworkImplicits(): Free[F, Defn.Object] =
+    Free.inject(GetFrameworkImplicits())
   def getGeneratorSettings(): Free[F, GeneratorSettings] =
     Free.inject(GetGeneratorSettings())
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/framework/FrameworkTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/framework/FrameworkTerms.scala
@@ -5,12 +5,15 @@ import cats.InjectK
 import cats.free.Free
 
 import scala.meta._
+import com.twilio.guardrail.generators.GeneratorSettings
 
 class FrameworkTerms[F[_]](implicit I: InjectK[FrameworkTerm, F]) {
   def getFrameworkImports(tracing: Boolean): Free[F, List[Import]] =
     Free.inject(GetFrameworkImports(tracing))
-  def getFrameworkImplicits(): Free[F, Defn.Object] =
-    Free.inject(GetFrameworkImplicits())
+  def getFrameworkImplicits(generatorSettings: GeneratorSettings): Free[F, Defn.Object] =
+    Free.inject(GetFrameworkImplicits(generatorSettings))
+  def getGeneratorSettings(): Free[F, GeneratorSettings] =
+    Free.inject(GetGeneratorSettings())
 }
 
 object FrameworkTerms {

--- a/modules/sample/src/main/resources/petstore.json
+++ b/modules/sample/src/main/resources/petstore.json
@@ -486,6 +486,14 @@
             "description": "file to upload",
             "required": true,
             "type": "file"
+          },
+          {
+            "name": "file3",
+            "in": "formData",
+            "description": "file to upload",
+            "required": true,
+            "type": "file",
+            "x-scala-file-hash": "SHA-256"
           }
         ],
         "responses": {

--- a/modules/sample/src/main/resources/petstore.json
+++ b/modules/sample/src/main/resources/petstore.json
@@ -478,8 +478,14 @@
             "in": "formData",
             "description": "file to upload",
             "required": false,
-            "FIXME: type": "file",
-            "type": "string"
+            "type": "file"
+          },
+          {
+            "name": "file2",
+            "in": "formData",
+            "description": "file to upload",
+            "required": true,
+            "type": "file"
           }
         ],
         "responses": {

--- a/modules/sample/src/test/scala/core/RawServer.scala
+++ b/modules/sample/src/test/scala/core/RawServer.scala
@@ -1,9 +1,9 @@
 package swagger
 
-import org.scalatest.{EitherValues, FunSuite, Matchers}
+import org.scalatest.{ EitherValues, FunSuite, Matchers }
 import org.scalatest.concurrent.ScalaFutures
-import _root_.raw.server.foo.{FooHandler, FooResource}
-import _root_.raw.server.{definitions => sdefs}
+import _root_.raw.server.foo.{ FooHandler, FooResource }
+import _root_.raw.server.{ definitions => sdefs }
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.server._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
@@ -13,9 +13,8 @@ import akka.http.scaladsl.marshalling.Marshal
 class RawServerTest extends FunSuite with Matchers with EitherValues with ScalaFutures with ScalatestRouteTest {
   test("raw server response") {
     FooResource.routes(new FooHandler {
-      def doFoo(respond: FooResource.doFooResponse.type)(): scala.concurrent.Future[HttpResponse] = {
+      def doFoo(respond: FooResource.doFooResponse.type)(): scala.concurrent.Future[HttpResponse] =
         Marshal(respond.Created(sdefs.Foo(1234L))).to[HttpResponse]
-      }
     })
   }
 }

--- a/modules/sample/src/test/scala/core/RoundTrip.scala
+++ b/modules/sample/src/test/scala/core/RoundTrip.scala
@@ -34,52 +34,70 @@ class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaF
 
   test("round-trip: definition query, unit response") {
     val httpClient = Route.asyncHandler(PetResource.routes(new PetHandler {
-      def addPet(respond: PetResource.addPetResponse.type)(body: sdefs.Pet): Future[PetResource.addPetResponse] = body match {
-        case sdefs.Pet(
-            `id`,
-            Some(sdefs.Category(`categoryId`, `categoryName`)),
-            `name`,
-            `photoUrls`,
-            None,
-            Some(sdefs.PetStatus.Pending)
-          ) => Future.successful(respond.Created)
-        case _ => failTest("Parameters didn't match")
-      }
-      def deletePet(respond: PetResource.deletePetResponse.type)(_petId: Long, includeChildren: Option[Boolean], status: Option[sdefs.PetStatus], _apiKey: Option[String] = None) = ???
+      def addPet(respond: PetResource.addPetResponse.type)(body: sdefs.Pet): Future[PetResource.addPetResponse] =
+        body match {
+          case sdefs.Pet(
+              `id`,
+              Some(sdefs.Category(`categoryId`, `categoryName`)),
+              `name`,
+              `photoUrls`,
+              None,
+              Some(sdefs.PetStatus.Pending)
+              ) =>
+            Future.successful(respond.Created)
+          case _ => failTest("Parameters didn't match")
+        }
+      def deletePet(respond: PetResource.deletePetResponse.type)(
+          _petId: Long,
+          includeChildren: Option[Boolean],
+          status: Option[sdefs.PetStatus],
+          _apiKey: Option[String] = None) = ???
       def findPetsByStatus(respond: PetResource.findPetsByStatusResponse.type)(status: Iterable[String]) = ???
       def findPetsByStatusEnum(respond: PetResource.findPetsByStatusEnumResponse.type)(status: sdefs.PetStatus) = ???
       def findPetsByTags(respond: PetResource.findPetsByTagsResponse.type)(tags: Iterable[String]) = ???
       def getPetById(respond: PetResource.getPetByIdResponse.type)(petId: Long) = ???
       def updatePet(respond: PetResource.updatePetResponse.type)(body: sdefs.Pet) = ???
-      def updatePetWithForm(respond: PetResource.updatePetWithFormResponse.type)(petId: Long, name: Option[String] = None, status: Option[String] = None) = ???
-      def uploadFile(respond: PetResource.uploadFileResponse.type)(petId: Long, additionalMetadata: Option[String] = None, file: Option[String] = None) = ???
+      def updatePetWithForm(respond: PetResource.updatePetWithFormResponse.type)(
+          petId: Long,
+          name: Option[String] = None,
+          status: Option[String] = None) = ???
+      def uploadFile(respond: PetResource.uploadFileResponse.type)(
+          petId: Long,
+          additionalMetadata: Option[String] = None,
+          file: Option[String] = None) = ???
     }))
 
     val petClient = PetClient.httpClient(httpClient)
 
-    petClient.addPet(cdefs.Pet(
-      id=id,
-      category=Some(cdefs.Category(categoryId, categoryName)),
-      name=name,
-      photoUrls=photoUrls,
-      tags=None,
-      status=Some(cdefs.PetStatus.Pending)
-    )).value.futureValue should be(Right(IgnoredEntity.empty))
+    petClient
+      .addPet(
+        cdefs.Pet(
+          id = id,
+          category = Some(cdefs.Category(categoryId, categoryName)),
+          name = name,
+          photoUrls = photoUrls,
+          tags = None,
+          status = Some(cdefs.PetStatus.Pending)
+        ))
+      .value
+      .futureValue should be(Right(IgnoredEntity.empty))
   }
 
   test("round-trip: enum query, Vector of definition response") {
     val httpClient = Route.asyncHandler(PetResource.routes(new PetHandler {
-      def findPetsByStatusEnum(respond: PetResource.findPetsByStatusEnumResponse.type)(_status: sdefs.PetStatus): Future[PetResource.findPetsByStatusEnumResponse] = {
+      def findPetsByStatusEnum(respond: PetResource.findPetsByStatusEnumResponse.type)(
+          _status: sdefs.PetStatus): Future[PetResource.findPetsByStatusEnumResponse] = {
         Future.successful(petStatus.fold(IndexedSeq.empty[sdefs.Pet])({ value =>
           if (_status.value == value) {
-            IndexedSeq(sdefs.Pet(
-              id=id,
-              category=Some(sdefs.Category(categoryId, categoryName)),
-              name=name,
-              photoUrls=photoUrls,
-              tags=None,
-              status=sdefs.PetStatus.parse(value)
-            ))
+            IndexedSeq(
+              sdefs.Pet(
+                id = id,
+                category = Some(sdefs.Category(categoryId, categoryName)),
+                name = name,
+                photoUrls = photoUrls,
+                tags = None,
+                status = sdefs.PetStatus.parse(value)
+              ))
           } else {
             failTest("Parameters didn't match!")
           }
@@ -87,41 +105,65 @@ class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaF
       }
 
       def addPet(respond: PetResource.addPetResponse.type)(body: sdefs.Pet) = ???
-      def deletePet(respond: PetResource.deletePetResponse.type)(_petId: Long, includeChildren: Option[Boolean], status: Option[sdefs.PetStatus], _apiKey: Option[String] = None) = ???
+      def deletePet(respond: PetResource.deletePetResponse.type)(
+          _petId: Long,
+          includeChildren: Option[Boolean],
+          status: Option[sdefs.PetStatus],
+          _apiKey: Option[String] = None) = ???
       def findPetsByStatus(respond: PetResource.findPetsByStatusResponse.type)(status: Iterable[String]) = ???
       def findPetsByTags(respond: PetResource.findPetsByTagsResponse.type)(tags: Iterable[String]) = ???
       def getPetById(respond: PetResource.getPetByIdResponse.type)(petId: Long) = ???
       def updatePet(respond: PetResource.updatePetResponse.type)(body: sdefs.Pet) = ???
-      def updatePetWithForm(respond: PetResource.updatePetWithFormResponse.type)(petId: Long, name: Option[String] = None, status: Option[String] = None) = ???
-      def uploadFile(respond: PetResource.uploadFileResponse.type)(petId: Long, additionalMetadata: Option[String] = None, file: Option[String] = None) = ???
+      def updatePetWithForm(respond: PetResource.updatePetWithFormResponse.type)(
+          petId: Long,
+          name: Option[String] = None,
+          status: Option[String] = None) = ???
+      def uploadFile(respond: PetResource.uploadFileResponse.type)(
+          petId: Long,
+          additionalMetadata: Option[String] = None,
+          file: Option[String] = None) = ???
     }))
 
     val petClient = PetClient.httpClient(httpClient)
 
-    petClient.findPetsByStatusEnum(cdefs.PetStatus.Pending).value.futureValue should be(Right(Vector(cdefs.Pet(
-      id=id,
-      category=Some(cdefs.Category(categoryId, categoryName)),
-      name=name,
-      photoUrls=photoUrls,
-      tags=None,
-      status=Some(cdefs.PetStatus.Pending)
-    ))))
+    petClient.findPetsByStatusEnum(cdefs.PetStatus.Pending).value.futureValue should be(
+      Right(
+        Vector(
+          cdefs.Pet(
+            id = id,
+            category = Some(cdefs.Category(categoryId, categoryName)),
+            name = name,
+            photoUrls = photoUrls,
+            tags = None,
+            status = Some(cdefs.PetStatus.Pending)
+          ))))
   }
 
   test("round-trip: 404 response") {
     val httpClient = Route.asyncHandler(PetResource.routes(new PetHandler {
-      def findPetsByStatus(respond: PetResource.findPetsByStatusResponse.type)(status: Iterable[String]): Future[PetResource.findPetsByStatusResponse] = {
+      def findPetsByStatus(respond: PetResource.findPetsByStatusResponse.type)(
+          status: Iterable[String]): Future[PetResource.findPetsByStatusResponse] = {
         Future.successful(respond.NotFound)
       }
 
       def addPet(respond: PetResource.addPetResponse.type)(body: sdefs.Pet) = ???
-      def deletePet(respond: PetResource.deletePetResponse.type)(_petId: Long, includeChildren: Option[Boolean], status: Option[sdefs.PetStatus], _apiKey: Option[String] = None) = ???
+      def deletePet(respond: PetResource.deletePetResponse.type)(
+          _petId: Long,
+          includeChildren: Option[Boolean],
+          status: Option[sdefs.PetStatus],
+          _apiKey: Option[String] = None) = ???
       def findPetsByStatusEnum(respond: PetResource.findPetsByStatusEnumResponse.type)(status: sdefs.PetStatus) = ???
       def findPetsByTags(respond: PetResource.findPetsByTagsResponse.type)(tags: Iterable[String]) = ???
       def getPetById(respond: PetResource.getPetByIdResponse.type)(petId: Long) = ???
       def updatePet(respond: PetResource.updatePetResponse.type)(body: sdefs.Pet) = ???
-      def updatePetWithForm(respond: PetResource.updatePetWithFormResponse.type)(petId: Long, name: Option[String] = None, status: Option[String] = None) = ???
-      def uploadFile(respond: PetResource.uploadFileResponse.type)(petId: Long, additionalMetadata: Option[String] = None, file: Option[String] = None) = ???
+      def updatePetWithForm(respond: PetResource.updatePetWithFormResponse.type)(
+          petId: Long,
+          name: Option[String] = None,
+          status: Option[String] = None) = ???
+      def uploadFile(respond: PetResource.uploadFileResponse.type)(
+          petId: Long,
+          additionalMetadata: Option[String] = None,
+          file: Option[String] = None) = ???
     }))
 
     val petClient = PetClient.httpClient(httpClient)
@@ -134,8 +176,13 @@ class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaF
     val petId: Long = 123L
     val apiKey: String = "foobar"
     val httpClient = Route.asyncHandler(PetResource.routes(new PetHandler {
-      def deletePet(respond: PetResource.deletePetResponse.type)(_petId: Long, includeChildren: Option[Boolean], status: Option[sdefs.PetStatus], _apiKey: Option[String] = None): Future[PetResource.deletePetResponse] = {
-        if (_petId == petId && _apiKey.contains(apiKey) && status.contains(sdefs.PetStatus.Pending)) Future.successful(respond.OK)
+      def deletePet(respond: PetResource.deletePetResponse.type)(
+          _petId: Long,
+          includeChildren: Option[Boolean],
+          status: Option[sdefs.PetStatus],
+          _apiKey: Option[String] = None): Future[PetResource.deletePetResponse] = {
+        if (_petId == petId && _apiKey.contains(apiKey) && status.contains(sdefs.PetStatus.Pending))
+          Future.successful(respond.OK)
         else Future.successful(respond.NotFound)
       }
 
@@ -145,8 +192,14 @@ class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaF
       def findPetsByTags(respond: PetResource.findPetsByTagsResponse.type)(tags: Iterable[String]) = ???
       def getPetById(respond: PetResource.getPetByIdResponse.type)(petId: Long) = ???
       def updatePet(respond: PetResource.updatePetResponse.type)(body: sdefs.Pet) = ???
-      def updatePetWithForm(respond: PetResource.updatePetWithFormResponse.type)(petId: Long, name: Option[String] = None, status: Option[String] = None) = ???
-      def uploadFile(respond: PetResource.uploadFileResponse.type)(petId: Long, additionalMetadata: Option[String] = None, file: Option[String] = None) = ???
+      def updatePetWithForm(respond: PetResource.updatePetWithFormResponse.type)(
+          petId: Long,
+          name: Option[String] = None,
+          status: Option[String] = None) = ???
+      def uploadFile(respond: PetResource.uploadFileResponse.type)(
+          petId: Long,
+          additionalMetadata: Option[String] = None,
+          file: Option[String] = None) = ???
     }))
 
     val petClient = PetClient.httpClient(httpClient)
@@ -155,6 +208,6 @@ class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaF
     result
       .fold({ err =>
         failTest(err.toString)
-      }, { _ == IgnoredEntity.empty})
+      }, { _ == IgnoredEntity.empty })
   }
 }

--- a/modules/sample/src/test/scala/core/RoundTrip.scala
+++ b/modules/sample/src/test/scala/core/RoundTrip.scala
@@ -61,10 +61,13 @@ class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaF
           petId: Long,
           name: Option[String] = None,
           status: Option[String] = None) = ???
+      def uploadFileMapFileField(fieldName: String, fileName: Option[String], contentType: ContentType) =
+        java.io.File.createTempFile("download_", ".dat", new java.io.File("/tmp"))
       def uploadFile(respond: PetResource.uploadFileResponse.type)(
           petId: Long,
-          additionalMetadata: Option[String] = None,
-          file: Option[String] = None) = ???
+          additionalMetadata: Option[String],
+          file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType, Option[String])],
+          file2: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, Option[String])) = ???
     }))
 
     val petClient = PetClient.httpClient(httpClient)
@@ -118,10 +121,13 @@ class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaF
           petId: Long,
           name: Option[String] = None,
           status: Option[String] = None) = ???
+      def uploadFileMapFileField(fieldName: String, fileName: Option[String], contentType: ContentType) =
+        java.io.File.createTempFile("download_", ".dat", new java.io.File("/tmp"))
       def uploadFile(respond: PetResource.uploadFileResponse.type)(
           petId: Long,
-          additionalMetadata: Option[String] = None,
-          file: Option[String] = None) = ???
+          additionalMetadata: Option[String],
+          file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType, Option[String])],
+          file2: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, Option[String])) = ???
     }))
 
     val petClient = PetClient.httpClient(httpClient)
@@ -160,10 +166,13 @@ class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaF
           petId: Long,
           name: Option[String] = None,
           status: Option[String] = None) = ???
+      def uploadFileMapFileField(fieldName: String, fileName: Option[String], contentType: ContentType) =
+        java.io.File.createTempFile("download_", ".dat", new java.io.File("/tmp"))
       def uploadFile(respond: PetResource.uploadFileResponse.type)(
           petId: Long,
-          additionalMetadata: Option[String] = None,
-          file: Option[String] = None) = ???
+          additionalMetadata: Option[String],
+          file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType, Option[String])],
+          file2: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, Option[String])) = ???
     }))
 
     val petClient = PetClient.httpClient(httpClient)
@@ -196,10 +205,13 @@ class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaF
           petId: Long,
           name: Option[String] = None,
           status: Option[String] = None) = ???
+      def uploadFileMapFileField(fieldName: String, fileName: Option[String], contentType: ContentType) =
+        java.io.File.createTempFile("download_", ".dat", new java.io.File("/tmp"))
       def uploadFile(respond: PetResource.uploadFileResponse.type)(
           petId: Long,
-          additionalMetadata: Option[String] = None,
-          file: Option[String] = None) = ???
+          additionalMetadata: Option[String],
+          file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType, Option[String])],
+          file2: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, Option[String])) = ???
     }))
 
     val petClient = PetClient.httpClient(httpClient)

--- a/modules/sample/src/test/scala/core/RoundTrip.scala
+++ b/modules/sample/src/test/scala/core/RoundTrip.scala
@@ -1,10 +1,10 @@
 package swagger
 
 import _root_.clients.akkaHttp.pet.PetClient
-import _root_.clients.akkaHttp.{definitions => cdefs}
+import _root_.clients.akkaHttp.{ definitions => cdefs }
 import _root_.clients.akkaHttp.Implicits.IgnoredEntity
-import _root_.servers.pet.{PetHandler, PetResource}
-import _root_.servers.{definitions => sdefs}
+import _root_.servers.pet.{ PetHandler, PetResource }
+import _root_.servers.{ definitions => sdefs }
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.server._
@@ -12,25 +12,25 @@ import akka.http.scaladsl.testkit.ScalatestRouteTest
 import cats.instances.future._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.SpanSugar._
-import org.scalatest.{EitherValues, FunSuite, Matchers}
+import org.scalatest.{ EitherValues, FunSuite, Matchers }
 import scala.concurrent.Future
 
 class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaFutures with ScalatestRouteTest {
   override implicit val patienceConfig = PatienceConfig(1000 millis, 1000 millis)
 
   // Placeholder until property testing
-  val id: Option[Long] = None
-  val categoryId: Option[Long] = None
-  val categoryName: Option[String] = None
-  val name: String = ""
+  val id: Option[Long]              = None
+  val categoryId: Option[Long]      = None
+  val categoryName: Option[String]  = None
+  val name: String                  = ""
   val photoUrls: IndexedSeq[String] = IndexedSeq.empty
-  val tag1id: Option[Long] = None
-  val tag1name: Option[String] = None
-  val tag2id: Option[Long] = None
-  val tag2name: Option[String] = None
-  val tag3id: Option[Long] = None
-  val tag3name: Option[String] = None
-  val petStatus: Option[String] = Some("pending")
+  val tag1id: Option[Long]          = None
+  val tag1name: Option[String]      = None
+  val tag2id: Option[Long]          = None
+  val tag2name: Option[String]      = None
+  val tag3id: Option[Long]          = None
+  val tag3name: Option[String]      = None
+  val petStatus: Option[String]     = Some("pending")
 
   test("round-trip: definition query, unit response") {
     val httpClient = Route.asyncHandler(PetResource.routes(new PetHandler {
@@ -47,28 +47,23 @@ class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaF
             Future.successful(respond.Created)
           case _ => failTest("Parameters didn't match")
         }
-      def deletePet(respond: PetResource.deletePetResponse.type)(
-          _petId: Long,
-          includeChildren: Option[Boolean],
-          status: Option[sdefs.PetStatus],
-          _apiKey: Option[String] = None) = ???
-      def findPetsByStatus(respond: PetResource.findPetsByStatusResponse.type)(status: Iterable[String]) = ???
-      def findPetsByStatusEnum(respond: PetResource.findPetsByStatusEnumResponse.type)(status: sdefs.PetStatus) = ???
-      def findPetsByTags(respond: PetResource.findPetsByTagsResponse.type)(tags: Iterable[String]) = ???
-      def getPetById(respond: PetResource.getPetByIdResponse.type)(petId: Long) = ???
-      def updatePet(respond: PetResource.updatePetResponse.type)(body: sdefs.Pet) = ???
-      def updatePetWithForm(respond: PetResource.updatePetWithFormResponse.type)(
-          petId: Long,
-          name: Option[String] = None,
-          status: Option[String] = None) = ???
+      def deletePet(respond: PetResource.deletePetResponse.type)(_petId: Long,
+                                                                 includeChildren: Option[Boolean],
+                                                                 status: Option[sdefs.PetStatus],
+                                                                 _apiKey: Option[String] = None)                                                          = ???
+      def findPetsByStatus(respond: PetResource.findPetsByStatusResponse.type)(status: Iterable[String])                                                  = ???
+      def findPetsByStatusEnum(respond: PetResource.findPetsByStatusEnumResponse.type)(status: sdefs.PetStatus)                                           = ???
+      def findPetsByTags(respond: PetResource.findPetsByTagsResponse.type)(tags: Iterable[String])                                                        = ???
+      def getPetById(respond: PetResource.getPetByIdResponse.type)(petId: Long)                                                                           = ???
+      def updatePet(respond: PetResource.updatePetResponse.type)(body: sdefs.Pet)                                                                         = ???
+      def updatePetWithForm(respond: PetResource.updatePetWithFormResponse.type)(petId: Long, name: Option[String] = None, status: Option[String] = None) = ???
       def uploadFileMapFileField(fieldName: String, fileName: Option[String], contentType: ContentType) =
         java.io.File.createTempFile("download_", ".dat", new java.io.File("/tmp"))
-      def uploadFile(respond: PetResource.uploadFileResponse.type)(
-          petId: Long,
-          additionalMetadata: Option[String],
-          file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType)],
-          file2: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType),
-          file3: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, String)) = ???
+      def uploadFile(respond: PetResource.uploadFileResponse.type)(petId: Long,
+                                                                   additionalMetadata: Option[String],
+                                                                   file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType)],
+                                                                   file2: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType),
+                                                                   file3: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, String)) = ???
     }))
 
     val petClient = PetClient.httpClient(httpClient)
@@ -82,15 +77,17 @@ class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaF
           photoUrls = photoUrls,
           tags = None,
           status = Some(cdefs.PetStatus.Pending)
-        ))
+        )
+      )
       .value
       .futureValue should be(Right(IgnoredEntity.empty))
   }
 
   test("round-trip: enum query, Vector of definition response") {
     val httpClient = Route.asyncHandler(PetResource.routes(new PetHandler {
-      def findPetsByStatusEnum(respond: PetResource.findPetsByStatusEnumResponse.type)(
-          _status: sdefs.PetStatus): Future[PetResource.findPetsByStatusEnumResponse] = {
+      def findPetsByStatusEnum(
+          respond: PetResource.findPetsByStatusEnumResponse.type
+      )(_status: sdefs.PetStatus): Future[PetResource.findPetsByStatusEnumResponse] =
         Future.successful(petStatus.fold(IndexedSeq.empty[sdefs.Pet])({ value =>
           if (_status.value == value) {
             IndexedSeq(
@@ -101,35 +98,30 @@ class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaF
                 photoUrls = photoUrls,
                 tags = None,
                 status = sdefs.PetStatus.parse(value)
-              ))
+              )
+            )
           } else {
             failTest("Parameters didn't match!")
           }
         }))
-      }
 
       def addPet(respond: PetResource.addPetResponse.type)(body: sdefs.Pet) = ???
-      def deletePet(respond: PetResource.deletePetResponse.type)(
-          _petId: Long,
-          includeChildren: Option[Boolean],
-          status: Option[sdefs.PetStatus],
-          _apiKey: Option[String] = None) = ???
-      def findPetsByStatus(respond: PetResource.findPetsByStatusResponse.type)(status: Iterable[String]) = ???
-      def findPetsByTags(respond: PetResource.findPetsByTagsResponse.type)(tags: Iterable[String]) = ???
-      def getPetById(respond: PetResource.getPetByIdResponse.type)(petId: Long) = ???
-      def updatePet(respond: PetResource.updatePetResponse.type)(body: sdefs.Pet) = ???
-      def updatePetWithForm(respond: PetResource.updatePetWithFormResponse.type)(
-          petId: Long,
-          name: Option[String] = None,
-          status: Option[String] = None) = ???
+      def deletePet(respond: PetResource.deletePetResponse.type)(_petId: Long,
+                                                                 includeChildren: Option[Boolean],
+                                                                 status: Option[sdefs.PetStatus],
+                                                                 _apiKey: Option[String] = None)                                                          = ???
+      def findPetsByStatus(respond: PetResource.findPetsByStatusResponse.type)(status: Iterable[String])                                                  = ???
+      def findPetsByTags(respond: PetResource.findPetsByTagsResponse.type)(tags: Iterable[String])                                                        = ???
+      def getPetById(respond: PetResource.getPetByIdResponse.type)(petId: Long)                                                                           = ???
+      def updatePet(respond: PetResource.updatePetResponse.type)(body: sdefs.Pet)                                                                         = ???
+      def updatePetWithForm(respond: PetResource.updatePetWithFormResponse.type)(petId: Long, name: Option[String] = None, status: Option[String] = None) = ???
       def uploadFileMapFileField(fieldName: String, fileName: Option[String], contentType: ContentType) =
         java.io.File.createTempFile("download_", ".dat", new java.io.File("/tmp"))
-      def uploadFile(respond: PetResource.uploadFileResponse.type)(
-          petId: Long,
-          additionalMetadata: Option[String],
-          file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType)],
-          file2: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType),
-          file3: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, String)) = ???
+      def uploadFile(respond: PetResource.uploadFileResponse.type)(petId: Long,
+                                                                   additionalMetadata: Option[String],
+                                                                   file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType)],
+                                                                   file2: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType),
+                                                                   file3: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, String)) = ???
     }))
 
     val petClient = PetClient.httpClient(httpClient)
@@ -144,38 +136,34 @@ class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaF
             photoUrls = photoUrls,
             tags = None,
             status = Some(cdefs.PetStatus.Pending)
-          ))))
+          )
+        )
+      )
+    )
   }
 
   test("round-trip: 404 response") {
     val httpClient = Route.asyncHandler(PetResource.routes(new PetHandler {
-      def findPetsByStatus(respond: PetResource.findPetsByStatusResponse.type)(
-          status: Iterable[String]): Future[PetResource.findPetsByStatusResponse] = {
+      def findPetsByStatus(respond: PetResource.findPetsByStatusResponse.type)(status: Iterable[String]): Future[PetResource.findPetsByStatusResponse] =
         Future.successful(respond.NotFound)
-      }
 
       def addPet(respond: PetResource.addPetResponse.type)(body: sdefs.Pet) = ???
-      def deletePet(respond: PetResource.deletePetResponse.type)(
-          _petId: Long,
-          includeChildren: Option[Boolean],
-          status: Option[sdefs.PetStatus],
-          _apiKey: Option[String] = None) = ???
-      def findPetsByStatusEnum(respond: PetResource.findPetsByStatusEnumResponse.type)(status: sdefs.PetStatus) = ???
-      def findPetsByTags(respond: PetResource.findPetsByTagsResponse.type)(tags: Iterable[String]) = ???
-      def getPetById(respond: PetResource.getPetByIdResponse.type)(petId: Long) = ???
-      def updatePet(respond: PetResource.updatePetResponse.type)(body: sdefs.Pet) = ???
-      def updatePetWithForm(respond: PetResource.updatePetWithFormResponse.type)(
-          petId: Long,
-          name: Option[String] = None,
-          status: Option[String] = None) = ???
+      def deletePet(respond: PetResource.deletePetResponse.type)(_petId: Long,
+                                                                 includeChildren: Option[Boolean],
+                                                                 status: Option[sdefs.PetStatus],
+                                                                 _apiKey: Option[String] = None)                                                          = ???
+      def findPetsByStatusEnum(respond: PetResource.findPetsByStatusEnumResponse.type)(status: sdefs.PetStatus)                                           = ???
+      def findPetsByTags(respond: PetResource.findPetsByTagsResponse.type)(tags: Iterable[String])                                                        = ???
+      def getPetById(respond: PetResource.getPetByIdResponse.type)(petId: Long)                                                                           = ???
+      def updatePet(respond: PetResource.updatePetResponse.type)(body: sdefs.Pet)                                                                         = ???
+      def updatePetWithForm(respond: PetResource.updatePetWithFormResponse.type)(petId: Long, name: Option[String] = None, status: Option[String] = None) = ???
       def uploadFileMapFileField(fieldName: String, fileName: Option[String], contentType: ContentType) =
         java.io.File.createTempFile("download_", ".dat", new java.io.File("/tmp"))
-      def uploadFile(respond: PetResource.uploadFileResponse.type)(
-          petId: Long,
-          additionalMetadata: Option[String],
-          file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType)],
-          file2: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType),
-          file3: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, String)) = ???
+      def uploadFile(respond: PetResource.uploadFileResponse.type)(petId: Long,
+                                                                   additionalMetadata: Option[String],
+                                                                   file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType)],
+                                                                   file2: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType),
+                                                                   file3: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, String)) = ???
     }))
 
     val petClient = PetClient.httpClient(httpClient)
@@ -185,37 +173,31 @@ class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaF
   }
 
   test("round-trip: Raw type parameters") {
-    val petId: Long = 123L
+    val petId: Long    = 123L
     val apiKey: String = "foobar"
     val httpClient = Route.asyncHandler(PetResource.routes(new PetHandler {
-      def deletePet(respond: PetResource.deletePetResponse.type)(
-          _petId: Long,
-          includeChildren: Option[Boolean],
-          status: Option[sdefs.PetStatus],
-          _apiKey: Option[String] = None): Future[PetResource.deletePetResponse] = {
+      def deletePet(respond: PetResource.deletePetResponse.type)(_petId: Long,
+                                                                 includeChildren: Option[Boolean],
+                                                                 status: Option[sdefs.PetStatus],
+                                                                 _apiKey: Option[String] = None): Future[PetResource.deletePetResponse] =
         if (_petId == petId && _apiKey.contains(apiKey) && status.contains(sdefs.PetStatus.Pending))
           Future.successful(respond.OK)
         else Future.successful(respond.NotFound)
-      }
 
-      def addPet(respond: PetResource.addPetResponse.type)(body: sdefs.Pet) = ???
-      def findPetsByStatus(respond: PetResource.findPetsByStatusResponse.type)(status: Iterable[String]) = ???
-      def findPetsByStatusEnum(respond: PetResource.findPetsByStatusEnumResponse.type)(status: sdefs.PetStatus) = ???
-      def findPetsByTags(respond: PetResource.findPetsByTagsResponse.type)(tags: Iterable[String]) = ???
-      def getPetById(respond: PetResource.getPetByIdResponse.type)(petId: Long) = ???
-      def updatePet(respond: PetResource.updatePetResponse.type)(body: sdefs.Pet) = ???
-      def updatePetWithForm(respond: PetResource.updatePetWithFormResponse.type)(
-          petId: Long,
-          name: Option[String] = None,
-          status: Option[String] = None) = ???
+      def addPet(respond: PetResource.addPetResponse.type)(body: sdefs.Pet)                                                                               = ???
+      def findPetsByStatus(respond: PetResource.findPetsByStatusResponse.type)(status: Iterable[String])                                                  = ???
+      def findPetsByStatusEnum(respond: PetResource.findPetsByStatusEnumResponse.type)(status: sdefs.PetStatus)                                           = ???
+      def findPetsByTags(respond: PetResource.findPetsByTagsResponse.type)(tags: Iterable[String])                                                        = ???
+      def getPetById(respond: PetResource.getPetByIdResponse.type)(petId: Long)                                                                           = ???
+      def updatePet(respond: PetResource.updatePetResponse.type)(body: sdefs.Pet)                                                                         = ???
+      def updatePetWithForm(respond: PetResource.updatePetWithFormResponse.type)(petId: Long, name: Option[String] = None, status: Option[String] = None) = ???
       def uploadFileMapFileField(fieldName: String, fileName: Option[String], contentType: ContentType) =
         java.io.File.createTempFile("download_", ".dat", new java.io.File("/tmp"))
-      def uploadFile(respond: PetResource.uploadFileResponse.type)(
-          petId: Long,
-          additionalMetadata: Option[String],
-          file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType)],
-          file2: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType),
-          file3: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, String)) = ???
+      def uploadFile(respond: PetResource.uploadFileResponse.type)(petId: Long,
+                                                                   additionalMetadata: Option[String],
+                                                                   file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType)],
+                                                                   file2: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType),
+                                                                   file3: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, String)) = ???
     }))
 
     val petClient = PetClient.httpClient(httpClient)
@@ -228,43 +210,36 @@ class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaF
   }
 
   test("round-trip: File uploads") {
-    val petId: Long = 123L
+    val petId: Long    = 123L
     val apiKey: String = "foobar"
     val httpClient = Route.asyncHandler(PetResource.routes(new PetHandler {
       def addPet(respond: PetResource.addPetResponse.type)(body: sdefs.Pet) = ???
-      def deletePet(respond: PetResource.deletePetResponse.type)(
-          _petId: Long,
-          includeChildren: Option[Boolean],
-          status: Option[sdefs.PetStatus],
-          _apiKey: Option[String] = None) = ???
-      def findPetsByStatus(respond: PetResource.findPetsByStatusResponse.type)(status: Iterable[String]) = ???
-      def findPetsByStatusEnum(respond: PetResource.findPetsByStatusEnumResponse.type)(status: sdefs.PetStatus) = ???
-      def findPetsByTags(respond: PetResource.findPetsByTagsResponse.type)(tags: Iterable[String]) = ???
-      def getPetById(respond: PetResource.getPetByIdResponse.type)(petId: Long) = ???
-      def updatePet(respond: PetResource.updatePetResponse.type)(body: sdefs.Pet) = ???
-      def updatePetWithForm(respond: PetResource.updatePetWithFormResponse.type)(
-          petId: Long,
-          name: Option[String] = None,
-          status: Option[String] = None) = ???
+      def deletePet(respond: PetResource.deletePetResponse.type)(_petId: Long,
+                                                                 includeChildren: Option[Boolean],
+                                                                 status: Option[sdefs.PetStatus],
+                                                                 _apiKey: Option[String] = None)                                                          = ???
+      def findPetsByStatus(respond: PetResource.findPetsByStatusResponse.type)(status: Iterable[String])                                                  = ???
+      def findPetsByStatusEnum(respond: PetResource.findPetsByStatusEnumResponse.type)(status: sdefs.PetStatus)                                           = ???
+      def findPetsByTags(respond: PetResource.findPetsByTagsResponse.type)(tags: Iterable[String])                                                        = ???
+      def getPetById(respond: PetResource.getPetByIdResponse.type)(petId: Long)                                                                           = ???
+      def updatePet(respond: PetResource.updatePetResponse.type)(body: sdefs.Pet)                                                                         = ???
+      def updatePetWithForm(respond: PetResource.updatePetWithFormResponse.type)(petId: Long, name: Option[String] = None, status: Option[String] = None) = ???
       def uploadFileMapFileField(fieldName: String, fileName: Option[String], contentType: ContentType) =
         java.io.File.createTempFile("download_", ".dat", new java.io.File("/tmp"))
-      def uploadFile(respond: PetResource.uploadFileResponse.type)(
-          petId: Long,
-          additionalMetadata: Option[String],
-          file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType)],
-          file2: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType),
-          file3: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, String)) = {
+      def uploadFile(respond: PetResource.uploadFileResponse.type)(petId: Long,
+                                                                   additionalMetadata: Option[String],
+                                                                   file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType)],
+                                                                   file2: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType),
+                                                                   file3: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, String)) = {
         val f1Length = file.flatMap({ case (f, _, _) => if (f.exists) { Some(f.length) } else None })
         val f2Length = if (file2._1.exists) { Some(file2._1.length) } else None
         val f3Length = if (file3._1.exists) { Some(file3._1.length) } else None
 
-        assert(file3._4 == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-               "Empty file hash does not match")
+        assert(file3._4 == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "Empty file hash does not match")
 
         val code = file.count(_._1.exists) + (if (file2._1.exists) 1 else 0) + (if (file3._1.exists) 1 else 0)
 
-        Future.successful(
-          respond.OK(sdefs.ApiResponse(code = Some(code), message = Some(s"${f1Length} ${f2Length} ${f3Length}"))))
+        Future.successful(respond.OK(sdefs.ApiResponse(code = Some(code), message = Some(s"${f1Length} ${f2Length} ${f3Length}"))))
       }
     }))
 

--- a/modules/sample/src/test/scala/core/RoundTrip.scala
+++ b/modules/sample/src/test/scala/core/RoundTrip.scala
@@ -66,8 +66,8 @@ class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaF
       def uploadFile(respond: PetResource.uploadFileResponse.type)(
           petId: Long,
           additionalMetadata: Option[String],
-          file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType, Option[String])],
-          file2: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, Option[String])) = ???
+          file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType)],
+          file2: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType)) = ???
     }))
 
     val petClient = PetClient.httpClient(httpClient)
@@ -126,8 +126,8 @@ class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaF
       def uploadFile(respond: PetResource.uploadFileResponse.type)(
           petId: Long,
           additionalMetadata: Option[String],
-          file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType, Option[String])],
-          file2: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, Option[String])) = ???
+          file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType)],
+          file2: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType)) = ???
     }))
 
     val petClient = PetClient.httpClient(httpClient)
@@ -171,8 +171,8 @@ class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaF
       def uploadFile(respond: PetResource.uploadFileResponse.type)(
           petId: Long,
           additionalMetadata: Option[String],
-          file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType, Option[String])],
-          file2: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, Option[String])) = ???
+          file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType)],
+          file2: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType)) = ???
     }))
 
     val petClient = PetClient.httpClient(httpClient)
@@ -210,8 +210,8 @@ class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaF
       def uploadFile(respond: PetResource.uploadFileResponse.type)(
           petId: Long,
           additionalMetadata: Option[String],
-          file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType, Option[String])],
-          file2: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, Option[String])) = ???
+          file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType)],
+          file2: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType)) = ???
     }))
 
     val petClient = PetClient.httpClient(httpClient)

--- a/modules/sample/src/test/scala/generators/AkkaHttp/Client/contentType/textPlain.scala
+++ b/modules/sample/src/test/scala/generators/AkkaHttp/Client/contentType/textPlain.scala
@@ -8,19 +8,13 @@ import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import cats.instances.future._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{EitherValues, FunSuite, Matchers}
+import org.scalatest.{ EitherValues, FunSuite, Matchers }
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
 import _root_.tests.scalatest.EitherTValues
 
-class TextPlainTest
-    extends FunSuite
-    with Matchers
-    with EitherValues
-    with EitherTValues
-    with ScalaFutures
-    with ScalatestRouteTest {
+class TextPlainTest extends FunSuite with Matchers with EitherValues with EitherTValues with ScalaFutures with ScalatestRouteTest {
   override implicit val patienceConfig = PatienceConfig(1000.millis, 1000.millis)
   test("Plain text should be emitted for optional parameters") {
     val route: Route = (path("foo") & extractRequestEntity & entity(as[String])) { (entity, value) =>
@@ -33,7 +27,7 @@ class TextPlainTest
       })
     }
     val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
-    val fooClient = FooClient.httpClient(client)
+    val fooClient                                   = FooClient.httpClient(client)
     new EitherTValuable(fooClient.doFoo(Some("sample"))).rightValue.futureValue shouldBe IgnoredEntity.empty
   }
 
@@ -48,7 +42,7 @@ class TextPlainTest
       })
     }
     val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
-    val fooClient = FooClient.httpClient(client)
+    val fooClient                                   = FooClient.httpClient(client)
     new EitherTValuable(fooClient.doBar("sample")).rightValue.futureValue shouldBe IgnoredEntity.empty
   }
 }

--- a/modules/sample/src/test/scala/generators/AkkaHttp/Client/contentType/textPlain.scala
+++ b/modules/sample/src/test/scala/generators/AkkaHttp/Client/contentType/textPlain.scala
@@ -14,7 +14,13 @@ import scala.concurrent.duration._
 
 import _root_.tests.scalatest.EitherTValues
 
-class TextPlainTest extends FunSuite with Matchers with EitherValues with EitherTValues with ScalaFutures with ScalatestRouteTest {
+class TextPlainTest
+    extends FunSuite
+    with Matchers
+    with EitherValues
+    with EitherTValues
+    with ScalaFutures
+    with ScalatestRouteTest {
   override implicit val patienceConfig = PatienceConfig(1000.millis, 1000.millis)
   test("Plain text should be emitted for optional parameters") {
     val route: Route = (path("foo") & extractRequestEntity & entity(as[String])) { (entity, value) =>

--- a/modules/sample/src/test/scala/scalatest/EitherTValues.scala
+++ b/modules/sample/src/test/scala/scalatest/EitherTValues.scala
@@ -4,7 +4,7 @@ import cats.Functor
 import cats.data.EitherT
 import org.scalactic.source
 import org.scalatest._
-import org.scalatest.exceptions.{StackDepthException, TestFailedException}
+import org.scalatest.exceptions.{ StackDepthException, TestFailedException }
 import scala.language.implicitConversions
 
 trait EitherTValues {
@@ -12,16 +12,14 @@ trait EitherTValues {
   implicit def convertEitherTToValuable[F[_]: Functor, L, R](eitherT: EitherT[F, L, R]) = new EitherTValuable(eitherT)
 
   class EitherTValuable[F[_]: Functor, L, R](eitherT: EitherT[F, L, R]) {
-    def leftValue(implicit pos: source.Position): F[L] = {
+    def leftValue(implicit pos: source.Position): F[L] =
       eitherT.fold(identity, { _ =>
         throw new TestFailedException((_: StackDepthException) => Option.empty[String], Option.empty[Throwable], pos)
       })
-    }
 
-    def rightValue(implicit pos: source.Position): F[R] = {
+    def rightValue(implicit pos: source.Position): F[R] =
       eitherT.fold({ _ =>
         throw new TestFailedException((_: StackDepthException) => Option.empty[String], Option.empty[Throwable], pos)
       }, identity)
-    }
   }
 }

--- a/modules/sample/src/test/scala/scalatest/EitherTValues.scala
+++ b/modules/sample/src/test/scala/scalatest/EitherTValues.scala
@@ -25,4 +25,3 @@ trait EitherTValues {
     }
   }
 }
-

--- a/modules/sample/src/test/scala/swagger/Escaping.scala
+++ b/modules/sample/src/test/scala/swagger/Escaping.scala
@@ -1,6 +1,6 @@
 package swagger
 
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.{ FunSuite, Matchers }
 import clients.akkaHttp.Implicits
 import clients.akkaHttp.AkkaHttpImplicits._
 

--- a/src/test/scala/codegen/WritePackageSpec.scala
+++ b/src/test/scala/codegen/WritePackageSpec.scala
@@ -1,6 +1,6 @@
 package codegen
 
-import java.nio.file.{Path, Paths}
+import java.nio.file.{ Path, Paths }
 
 import _root_.io.swagger.models.Swagger
 import _root_.io.swagger.parser.SwaggerParser
@@ -8,7 +8,7 @@ import cats.data.NonEmptyList
 import com.twilio.guardrail._
 import com.twilio.guardrail.core.CoreTermInterp
 import com.twilio.guardrail.terms.CoreTerm
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.{ FunSuite, Matchers }
 
 import scala.meta._
 
@@ -53,8 +53,8 @@ class WritePackageSpec extends FunSuite with Matchers {
   def injectSwagger[T](s: Swagger, rs: ReadSwagger[T]): T = rs.next(s)
 
   def extractPackage(path: Path, results: List[WriteTree]): Term.Ref = {
-    val Some(source"""package ${fooPkg}
-    ..${stats}
+    val Some(source"""package ${fooPkg }
+    ..${stats }
     """) = results.find(_.path == path).headOption.map(_.contents)
     fooPkg
   }

--- a/src/test/scala/codegen/WritePackageSpec.scala
+++ b/src/test/scala/codegen/WritePackageSpec.scala
@@ -9,6 +9,7 @@ import com.twilio.guardrail._
 import com.twilio.guardrail.core.CoreTermInterp
 import com.twilio.guardrail.terms.CoreTerm
 import org.scalatest.{ FunSuite, Matchers }
+import com.twilio.guardrail.generators.GeneratorSettings
 
 import scala.meta._
 
@@ -70,11 +71,12 @@ class WritePackageSpec extends FunSuite with Matchers {
       ),
       List.empty
     )
+    val generatorSettings = new GeneratorSettings(t"BodyPartEntity", t"io.circe.Json")
 
     val result: List[WriteTree] = CoreTarget
       .unsafeExtract(Common.processArgs[CoreTerm](args).foldMap(CoreTermInterp))
       .toList
-      .flatMap(x => Target.unsafeExtract(injectSwagger(swagger, x)))
+      .flatMap({ case (_, x) => Target.unsafeExtract(injectSwagger(swagger, x), generatorSettings) })
 
     val paths = result.map(_.path)
 
@@ -118,11 +120,12 @@ class WritePackageSpec extends FunSuite with Matchers {
       ),
       List.empty
     )
+    val generatorSettings = new GeneratorSettings(t"BodyPartEntity", t"io.circe.Json")
 
     val result: List[WriteTree] = CoreTarget
       .unsafeExtract(Common.processArgs[CoreTerm](args).foldMap(CoreTermInterp))
       .toList
-      .flatMap(x => Target.unsafeExtract(injectSwagger(swagger, x)))
+      .flatMap({ case (_, x) => Target.unsafeExtract(injectSwagger(swagger, x), generatorSettings) })
 
     val paths = result.map(_.path)
 

--- a/src/test/scala/core/issues/Issue61.scala
+++ b/src/test/scala/core/issues/Issue61.scala
@@ -16,6 +16,7 @@ import com.twilio.guardrail.{
   RandomType,
   Target
 }
+import com.twilio.guardrail.tests._
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
@@ -45,7 +46,7 @@ class Issue61 extends FunSuite with Matchers with SwaggerSpecRunner {
       ProtocolDefinitions(RandomType(_, tpe) :: _ :: Nil, _, _, _),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     tpe.structure shouldBe t"IndexedSeq[String]".structure
   }
@@ -55,7 +56,7 @@ class Issue61 extends FunSuite with Matchers with SwaggerSpecRunner {
       ProtocolDefinitions(_ :: RandomType(_, tpe) :: Nil, _, _, _),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     tpe.structure shouldBe t"Long".structure
   }

--- a/src/test/scala/core/issues/Issue61.scala
+++ b/src/test/scala/core/issues/Issue61.scala
@@ -16,7 +16,7 @@ import com.twilio.guardrail.{
   RandomType,
   Target
 }
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._

--- a/src/test/scala/defaults.scala
+++ b/src/test/scala/defaults.scala
@@ -1,0 +1,9 @@
+package com.twilio.guardrail.tests
+
+import scala.meta._
+import com.twilio.guardrail.generators.GeneratorSettings
+
+object defaults {
+  val akkaGeneratorSettings   = new GeneratorSettings(t"BodyPartEntity", t"io.circe.Json")
+  val http4sGeneratorSettings = new GeneratorSettings(t"java.io.File", t"io.circe.Json")
+}

--- a/src/test/scala/support/ScalaMetaMatchers.scala
+++ b/src/test/scala/support/ScalaMetaMatchers.scala
@@ -5,13 +5,12 @@ import org.scalatest.matchers._
 
 trait ScalaMetaMatchers {
   class StructureMatcher(right: Term) extends Matcher[Term] {
-    def apply(left: Term): MatchResult = {
+    def apply(left: Term): MatchResult =
       MatchResult(
         left.structure == right.structure,
         s"""$left did not match structure $right""",
         s"""$left matched structure $right"""
       )
-    }
   }
 
   def matchStructure(right: Term): StructureMatcher =

--- a/src/test/scala/support/SwaggerSpecRunner.scala
+++ b/src/test/scala/support/SwaggerSpecRunner.scala
@@ -9,13 +9,16 @@ trait SwaggerSpecRunner {
   import com.twilio.guardrail._
   import com.twilio.guardrail.terms.framework.FrameworkTerms
   import com.twilio.guardrail.terms.{ ScalaTerms, SwaggerTerms }
+  import com.twilio.guardrail.generators.GeneratorSettings
 
   import scala.collection.JavaConverters._
 
-  def runSwaggerSpec(spec: String)(context: Context, framework: FunctionK[CodegenApplication, Target]): (ProtocolDefinitions, Clients, Servers) =
-    runSwagger(new SwaggerParser().parse(spec))(context, framework)
+  def runSwaggerSpec(
+      spec: String
+  ): (Context, FunctionK[CodegenApplication, Target], GeneratorSettings) => (ProtocolDefinitions, Clients, Servers) =
+    runSwagger(new SwaggerParser().parse(spec)) _
 
-  def runSwagger(swagger: Swagger)(context: Context, framework: FunctionK[CodegenApplication, Target])(
+  def runSwagger(swagger: Swagger)(context: Context, framework: FunctionK[CodegenApplication, Target], generatorSettings: GeneratorSettings)(
       implicit F: FrameworkTerms[CodegenApplication],
       Sc: ScalaTerms[CodegenApplication],
       Sw: SwaggerTerms[CodegenApplication]
@@ -50,7 +53,7 @@ trait SwaggerSpecRunner {
         .fromSwagger[CodegenApplication](context, swagger, frameworkImports)(definitions)
     } yield (protocol, clients, servers)
 
-    Target.unsafeExtract(prog.foldMap(framework))
+    Target.unsafeExtract(prog.foldMap(framework), generatorSettings)
   }
 
 }

--- a/src/test/scala/support/SwaggerSpecRunner.scala
+++ b/src/test/scala/support/SwaggerSpecRunner.scala
@@ -8,19 +8,18 @@ trait SwaggerSpecRunner {
   import cats.implicits._
   import com.twilio.guardrail._
   import com.twilio.guardrail.terms.framework.FrameworkTerms
-  import com.twilio.guardrail.terms.{ScalaTerms, SwaggerTerms}
+  import com.twilio.guardrail.terms.{ ScalaTerms, SwaggerTerms }
 
   import scala.collection.JavaConverters._
 
-  def runSwaggerSpec(spec: String)(
-      context: Context,
-      framework: FunctionK[CodegenApplication, Target]): (ProtocolDefinitions, Clients, Servers) =
+  def runSwaggerSpec(spec: String)(context: Context, framework: FunctionK[CodegenApplication, Target]): (ProtocolDefinitions, Clients, Servers) =
     runSwagger(new SwaggerParser().parse(spec))(context, framework)
 
   def runSwagger(swagger: Swagger)(context: Context, framework: FunctionK[CodegenApplication, Target])(
       implicit F: FrameworkTerms[CodegenApplication],
       Sc: ScalaTerms[CodegenApplication],
-      Sw: SwaggerTerms[CodegenApplication]): (ProtocolDefinitions, Clients, Servers) = {
+      Sw: SwaggerTerms[CodegenApplication]
+  ): (ProtocolDefinitions, Clients, Servers) = {
     import F._
     import Sw._
 
@@ -30,7 +29,7 @@ trait SwaggerSpecRunner {
 
       schemes = Option(swagger.getSchemes)
         .fold(List.empty[String])(_.asScala.to[List].map(_.toValue))
-      host = Option(swagger.getHost)
+      host     = Option(swagger.getHost)
       basePath = Option(swagger.getBasePath)
       paths = Option(swagger.getPaths)
         .map(_.asScala.toList)

--- a/src/test/scala/swagger/VendorExtensionTest.scala
+++ b/src/test/scala/swagger/VendorExtensionTest.scala
@@ -2,7 +2,7 @@ package swagger
 
 import _root_.io.swagger.parser.SwaggerParser
 import com.twilio.guardrail.extract.VendorExtension
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.{ FunSuite, Matchers }
 import scala.collection.JavaConverters._
 
 class VendorExtensionTest extends FunSuite with Matchers {

--- a/src/test/scala/swagger/protocols/BigObjectSpec.scala
+++ b/src/test/scala/swagger/protocols/BigObjectSpec.scala
@@ -5,6 +5,7 @@ import com.twilio.guardrail.generators.AkkaHttp
 import com.twilio.guardrail.{ ClassDefinition, Context, ProtocolDefinitions }
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
+import com.twilio.guardrail.tests._
 
 import scala.meta._
 
@@ -116,7 +117,7 @@ class BigObjectSpec extends FunSuite with Matchers with SwaggerSpecRunner {
 
   test("Big objects can be generated") {
     val (ProtocolDefinitions(ClassDefinition(_, _, cls, cmp) :: Nil, _, _, _), _, _) =
-      runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+      runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     val definition = q"""
       case class BigObject(v1: Option[Int] = None, v2: Option[Int] = None, v3: Option[Int] = None, v4: Option[Int] = None, v5: Option[Int] = None, v6: Option[Int] = None, v7: Option[Int] = None, v8: Option[Int] = None, v9: Option[Int] = None, v10: Option[Int] = None, v11: Option[Int] = None, v12: Option[Int] = None, v13: Option[Int] = None, v14: Option[Int] = None, v15: Option[Int] = None, v16: Option[Int] = None, v17: Option[Int] = None, v18: Option[Int] = None, v19: Option[Int] = None, v20: Option[Int] = None, v21: Option[Int] = None, v22: Option[Int] = None, v23: Option[Int] = None, v24: Option[Int] = None, v25: Option[Int] = None, v26: Option[Int] = None, v27: Option[Int] = None, v28: Option[Int] = None, v29: Option[Int] = None, v30: Option[Int] = None)

--- a/src/test/scala/swagger/protocols/BigObjectSpec.scala
+++ b/src/test/scala/swagger/protocols/BigObjectSpec.scala
@@ -2,8 +2,8 @@ package swagger
 package protocols
 
 import com.twilio.guardrail.generators.AkkaHttp
-import com.twilio.guardrail.{ClassDefinition, Context, ProtocolDefinitions}
-import org.scalatest.{FunSuite, Matchers}
+import com.twilio.guardrail.{ ClassDefinition, Context, ProtocolDefinitions }
+import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._
@@ -121,7 +121,7 @@ class BigObjectSpec extends FunSuite with Matchers with SwaggerSpecRunner {
     val definition = q"""
       case class BigObject(v1: Option[Int] = None, v2: Option[Int] = None, v3: Option[Int] = None, v4: Option[Int] = None, v5: Option[Int] = None, v6: Option[Int] = None, v7: Option[Int] = None, v8: Option[Int] = None, v9: Option[Int] = None, v10: Option[Int] = None, v11: Option[Int] = None, v12: Option[Int] = None, v13: Option[Int] = None, v14: Option[Int] = None, v15: Option[Int] = None, v16: Option[Int] = None, v17: Option[Int] = None, v18: Option[Int] = None, v19: Option[Int] = None, v20: Option[Int] = None, v21: Option[Int] = None, v22: Option[Int] = None, v23: Option[Int] = None, v24: Option[Int] = None, v25: Option[Int] = None, v26: Option[Int] = None, v27: Option[Int] = None, v28: Option[Int] = None, v29: Option[Int] = None, v30: Option[Int] = None)
     """
-    val companion = q"""
+    val companion  = q"""
       object BigObject {
         implicit val encodeBigObject = {
           val readOnlyKeys = Set[String]()

--- a/src/test/scala/tests/core/BacktickTest.scala
+++ b/src/test/scala/tests/core/BacktickTest.scala
@@ -2,7 +2,7 @@ package tests.core
 
 import com.twilio.guardrail._
 import com.twilio.guardrail.generators.AkkaHttp
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._

--- a/src/test/scala/tests/core/BacktickTest.scala
+++ b/src/test/scala/tests/core/BacktickTest.scala
@@ -4,6 +4,7 @@ import com.twilio.guardrail._
 import com.twilio.guardrail.generators.AkkaHttp
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
+import com.twilio.guardrail.tests._
 
 import scala.meta._
 
@@ -69,7 +70,7 @@ class BacktickTest extends FunSuite with Matchers with SwaggerSpecRunner {
       _,
       Clients(Client(tags, className, statements) :: _),
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     tags should equal(Seq("dashy-package"))
 
@@ -129,7 +130,7 @@ class BacktickTest extends FunSuite with Matchers with SwaggerSpecRunner {
       ProtocolDefinitions(ClassDefinition(_, _, cls, cmp) :: _, _, _, _),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     val definition = q"""
     case class ${Type.Name("`dashy-class`")}(${Term.Name("`dashy-param`")}: Option[Long] = None)
@@ -166,7 +167,7 @@ class BacktickTest extends FunSuite with Matchers with SwaggerSpecRunner {
       ProtocolDefinitions(_ :: EnumDefinition(_, _, _, cls, cmp) :: _, _, _, _),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     val definition = q"""
     sealed abstract class ${Type.Name("`dashy-enum`")}(val value: String) {

--- a/src/test/scala/tests/core/DereferencingAliasesSpec.scala
+++ b/src/test/scala/tests/core/DereferencingAliasesSpec.scala
@@ -4,6 +4,7 @@ import com.twilio.guardrail._
 import com.twilio.guardrail.generators.AkkaHttp
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
+import com.twilio.guardrail.tests._
 
 import scala.meta._
 
@@ -65,7 +66,7 @@ class DereferencingAliasesSpec extends FunSuite with Matchers with SwaggerSpecRu
       ProtocolDefinitions(_ :: _ :: _ :: ClassDefinition(_, _, cls, cmp) :: _, _, _, _),
       Clients(Client(_, _, statements) :: _),
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
     val List(clientCmp, clientCls) =
       statements.dropWhile(_.isInstanceOf[Import])
 

--- a/src/test/scala/tests/core/DereferencingAliasesSpec.scala
+++ b/src/test/scala/tests/core/DereferencingAliasesSpec.scala
@@ -2,7 +2,7 @@ package tests.core
 
 import com.twilio.guardrail._
 import com.twilio.guardrail.generators.AkkaHttp
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._

--- a/src/test/scala/tests/core/EscapeTreeSpec.scala
+++ b/src/test/scala/tests/core/EscapeTreeSpec.scala
@@ -1,7 +1,7 @@
 package tests.core
 
 import com.twilio.guardrail.SwaggerUtil
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.{ FunSuite, Matchers }
 
 import scala.meta._
 
@@ -9,7 +9,7 @@ class EscapeTreeSpec extends FunSuite with Matchers {
 
   test("Assume special characters are not escaped") {
     // This test fails as of 1.6.0. If this changes in the future, SwaggerParser.escapeTermTree and friends can all be removed (:yey:)
-    val q"val $x = 3" = q"val `dashy-thing` = 3"
+    val q"val $x = 3"                          = q"val `dashy-thing` = 3"
     val x1 @ Pat.Var(Term.Name("dashy-thing")) = x
     q"val $x1 = 3".toString shouldNot equal("val `dashy-thing` = 3") // shouldNot -> should (!) This is a bug in scala.meta!
   }
@@ -28,14 +28,8 @@ class EscapeTreeSpec extends FunSuite with Matchers {
   List[(Tree, Tree)](
     (Init(Type.Name("dashy-enum"), Name("what"), List()), Init(Type.Name("`dashy-enum`"), Name("what"), List())),
     (Term.Name("dashy-class"), Term.Name("`dashy-class`")),
-    (Term.Param(Nil,
-                Term.Name("dashy-param"),
-                Some(Type.Apply(Type.Name("Option"), List(Type.Name("Long")))),
-                Some(Term.Name("None"))),
-     Term.Param(Nil,
-                Term.Name("`dashy-param`"),
-                Some(Type.Apply(Type.Name("Option"), List(Type.Name("Long")))),
-                Some(Term.Name("None")))),
+    (Term.Param(Nil, Term.Name("dashy-param"), Some(Type.Apply(Type.Name("Option"), List(Type.Name("Long")))), Some(Term.Name("None"))),
+     Term.Param(Nil, Term.Name("`dashy-param`"), Some(Type.Apply(Type.Name("Option"), List(Type.Name("Long")))), Some(Term.Name("None")))),
     (Type.Name("dashy-class"), Type.Name("`dashy-class`"))
   ).foreach {
     case (x, y) =>

--- a/src/test/scala/tests/core/PathParserSpec.scala
+++ b/src/test/scala/tests/core/PathParserSpec.scala
@@ -5,7 +5,7 @@ import com.twilio.guardrail.{ SwaggerUtil, Target }
 import org.scalatest.{ EitherValues, FunSuite, Matchers, OptionValues }
 import support.ScalaMetaMatchers._
 import com.twilio.guardrail.generators.GeneratorSettings
-
+import com.twilio.guardrail.tests._
 import scala.meta._
 
 class PathParserSpec extends FunSuite with Matchers with EitherValues with OptionValues {
@@ -31,7 +31,7 @@ class PathParserSpec extends FunSuite with Matchers with EitherValues with Optio
   ).foreach {
     case (str, expected) =>
       test(s"Client $str") {
-        val gen = Target.unsafeExtract(SwaggerUtil.paths.generateUrlPathParams(str, args))
+        val gen = Target.unsafeExtract(SwaggerUtil.paths.generateUrlPathParams(str, args), defaults.akkaGeneratorSettings)
         gen.toString shouldBe expected.toString
       }
   }
@@ -57,7 +57,7 @@ class PathParserSpec extends FunSuite with Matchers with EitherValues with Optio
   ).foreach {
     case (str, expected) =>
       test(s"Server ${str}") {
-        val gen = Target.unsafeExtract(SwaggerUtil.paths.generateUrlAkkaPathExtractors(str, args))
+        val gen = Target.unsafeExtract(SwaggerUtil.paths.generateUrlAkkaPathExtractors(str, args), defaults.akkaGeneratorSettings)
         gen.toString shouldBe (expected.toString)
       }
   }

--- a/src/test/scala/tests/core/PathParserSpec.scala
+++ b/src/test/scala/tests/core/PathParserSpec.scala
@@ -4,10 +4,13 @@ import com.twilio.guardrail.generators.ScalaParameter
 import com.twilio.guardrail.{SwaggerUtil, Target}
 import org.scalatest.{EitherValues, FunSuite, Matchers, OptionValues}
 import support.ScalaMetaMatchers._
+import com.twilio.guardrail.generators.GeneratorSettings
 
 import scala.meta._
 
 class PathParserSpec extends FunSuite with Matchers with EitherValues with OptionValues {
+
+  implicit val gs = new GeneratorSettings(t"io.circe.Json", t"BodyPartEntity")
 
   val args: List[ScalaParameter] = List(
     ScalaParameter.fromParam(param"foo: Int = 1"),

--- a/src/test/scala/tests/core/PathParserSpec.scala
+++ b/src/test/scala/tests/core/PathParserSpec.scala
@@ -1,8 +1,8 @@
 package tests.core
 
 import com.twilio.guardrail.generators.ScalaParameter
-import com.twilio.guardrail.{SwaggerUtil, Target}
-import org.scalatest.{EitherValues, FunSuite, Matchers, OptionValues}
+import com.twilio.guardrail.{ SwaggerUtil, Target }
+import org.scalatest.{ EitherValues, FunSuite, Matchers, OptionValues }
 import support.ScalaMetaMatchers._
 import com.twilio.guardrail.generators.GeneratorSettings
 
@@ -26,10 +26,8 @@ class PathParserSpec extends FunSuite with Matchers with EitherValues with Optio
     ("/foo/", q""" host + basePath + "/foo/" """),
     ("/{foo}", q""" host + basePath + "/" + Formatter.addPath(foo) """),
     ("/{foo}.json", q""" host + basePath + "/" + Formatter.addPath(foo) + ".json" """),
-    ("/{foo}/{bar}.json",
-     q""" host + basePath + "/" + Formatter.addPath(foo) + "/" + Formatter.addPath(bar) + ".json" """),
-    ("/{foo_bar}/{bar_baz}.json",
-     q""" host + basePath + "/" + Formatter.addPath(fooBar) + "/" + Formatter.addPath(barBaz) + ".json" """)
+    ("/{foo}/{bar}.json", q""" host + basePath + "/" + Formatter.addPath(foo) + "/" + Formatter.addPath(bar) + ".json" """),
+    ("/{foo_bar}/{bar_baz}.json", q""" host + basePath + "/" + Formatter.addPath(fooBar) + "/" + Formatter.addPath(barBaz) + ".json" """)
   ).foreach {
     case (str, expected) =>
       test(s"Client $str") {

--- a/src/test/scala/tests/core/ScalaTypesTest.scala
+++ b/src/test/scala/tests/core/ScalaTypesTest.scala
@@ -4,6 +4,7 @@ import com.twilio.guardrail.generators.AkkaHttp
 import com.twilio.guardrail.{ ClassDefinition, Context, ProtocolDefinitions }
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
+import com.twilio.guardrail.tests._
 
 import scala.meta._
 
@@ -29,7 +30,7 @@ class ScalaTypesTest extends FunSuite with Matchers with SwaggerSpecRunner {
       ProtocolDefinitions(ClassDefinition(_, _, cls, cmp) :: Nil, _, _, _),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     val definition = q"""
       case class Baz(foo: Option[com.twilio.foo.bar.Baz] = None)

--- a/src/test/scala/tests/core/ScalaTypesTest.scala
+++ b/src/test/scala/tests/core/ScalaTypesTest.scala
@@ -1,8 +1,8 @@
 package tests.core
 
 import com.twilio.guardrail.generators.AkkaHttp
-import com.twilio.guardrail.{ClassDefinition, Context, ProtocolDefinitions}
-import org.scalatest.{FunSuite, Matchers}
+import com.twilio.guardrail.{ ClassDefinition, Context, ProtocolDefinitions }
+import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._

--- a/src/test/scala/tests/core/TypesTest.scala
+++ b/src/test/scala/tests/core/TypesTest.scala
@@ -1,8 +1,8 @@
 package tests.core
 
 import com.twilio.guardrail.generators.AkkaHttp
-import com.twilio.guardrail.{ClassDefinition, Context, ProtocolDefinitions}
-import org.scalatest.{FunSuite, Matchers}
+import com.twilio.guardrail.{ ClassDefinition, Context, ProtocolDefinitions }
+import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._

--- a/src/test/scala/tests/core/TypesTest.scala
+++ b/src/test/scala/tests/core/TypesTest.scala
@@ -4,6 +4,7 @@ import com.twilio.guardrail.generators.AkkaHttp
 import com.twilio.guardrail.{ ClassDefinition, Context, ProtocolDefinitions }
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
+import com.twilio.guardrail.tests._
 
 import scala.meta._
 
@@ -64,7 +65,7 @@ class TypesTest extends FunSuite with Matchers with SwaggerSpecRunner {
       ProtocolDefinitions(ClassDefinition(_, _, cls, cmp) :: Nil, _, _, _),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     val definition = q"""
       case class Types(array: Option[IndexedSeq[Boolean]] = Option(IndexedSeq.empty), obj: Option[io.circe.Json] = None, bool: Option[Boolean] = None, string: Option[String] = None, date: Option[java.time.LocalDate] = None, dateTime: Option[java.time.OffsetDateTime] = None, long: Option[Long] = None, int: Option[Int] = None, float: Option[Float] = None, double: Option[Double] = None, number: Option[BigDecimal] = None, integer: Option[BigInt] = None, untyped: Option[io.circe.Json] = None)

--- a/src/test/scala/tests/generators/akkaHttp/AkkaHttpClientGeneratorTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/AkkaHttpClientGeneratorTest.scala
@@ -4,6 +4,7 @@ import com.twilio.guardrail.generators.AkkaHttp
 import com.twilio.guardrail.{ Client, Clients, Context }
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
+import com.twilio.guardrail.tests._
 
 class AkkaHttpClientGeneratorTest extends FunSuite with Matchers with SwaggerSpecRunner {
   import scala.meta._
@@ -113,7 +114,7 @@ class AkkaHttpClientGeneratorTest extends FunSuite with Matchers with SwaggerSpe
       _,
       Clients(Client(tags, className, statements) :: Nil),
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     tags should equal(Seq("store"))
 
@@ -165,7 +166,7 @@ class AkkaHttpClientGeneratorTest extends FunSuite with Matchers with SwaggerSpe
       _,
       Clients(List(Client(tags, className, statements))),
       _
-    ) = runSwaggerSpec(swagger)(Context.empty.copy(framework = Some("akka-http"), tracing = true), AkkaHttp)
+    ) = runSwaggerSpec(swagger)(Context.empty.copy(framework = Some("akka-http"), tracing = true), AkkaHttp, defaults.akkaGeneratorSettings)
 
     tags should equal(Seq("store"))
 

--- a/src/test/scala/tests/generators/akkaHttp/AkkaHttpClientGeneratorTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/AkkaHttpClientGeneratorTest.scala
@@ -1,8 +1,8 @@
 package tests.generators.akkaHttp
 
 import com.twilio.guardrail.generators.AkkaHttp
-import com.twilio.guardrail.{Client, Clients, Context}
-import org.scalatest.{FunSuite, Matchers}
+import com.twilio.guardrail.{ Client, Clients, Context }
+import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 class AkkaHttpClientGeneratorTest extends FunSuite with Matchers with SwaggerSpecRunner {

--- a/src/test/scala/tests/generators/akkaHttp/AkkaHttpServerTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/AkkaHttpServerTest.scala
@@ -4,6 +4,7 @@ import com.twilio.guardrail.generators.AkkaHttp
 import com.twilio.guardrail.{ Context, Server, Servers }
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
+import com.twilio.guardrail.tests._
 
 class AkkaHttpServerTest extends FunSuite with Matchers with SwaggerSpecRunner {
   import scala.meta._
@@ -128,7 +129,7 @@ class AkkaHttpServerTest extends FunSuite with Matchers with SwaggerSpecRunner {
       _,
       _,
       Servers(Server(pkg, extraImports, genHandler :: genResource :: Nil) :: Nil)
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     val handler  = q"""
       trait StoreHandler {
@@ -273,7 +274,7 @@ class AkkaHttpServerTest extends FunSuite with Matchers with SwaggerSpecRunner {
       _,
       _,
       Servers(Server(pkg, extraImports, genHandler :: genResource :: Nil) :: Nil)
-    ) = runSwaggerSpec(swagger)(Context.empty.copy(tracing = true), AkkaHttp)
+    ) = runSwaggerSpec(swagger)(Context.empty.copy(tracing = true), AkkaHttp, defaults.akkaGeneratorSettings)
 
     val handler  = q"""
       trait BazHandler {

--- a/src/test/scala/tests/generators/akkaHttp/AkkaHttpServerTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/AkkaHttpServerTest.scala
@@ -1,8 +1,8 @@
 package tests.generators.akkaHttp
 
 import com.twilio.guardrail.generators.AkkaHttp
-import com.twilio.guardrail.{Context, Server, Servers}
-import org.scalatest.{FunSuite, Matchers}
+import com.twilio.guardrail.{ Context, Server, Servers }
+import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 class AkkaHttpServerTest extends FunSuite with Matchers with SwaggerSpecRunner {
@@ -130,7 +130,7 @@ class AkkaHttpServerTest extends FunSuite with Matchers with SwaggerSpecRunner {
       Servers(Server(pkg, extraImports, genHandler :: genResource :: Nil) :: Nil)
     ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
 
-    val handler = q"""
+    val handler  = q"""
       trait StoreHandler {
         def getRoot(respond: StoreResource.getRootResponse.type)(): scala.concurrent.Future[StoreResource.getRootResponse]
         def getOrderById(respond: StoreResource.getOrderByIdResponse.type)(orderId: Long, status: OrderStatus = OrderStatus.Placed): scala.concurrent.Future[StoreResource.getOrderByIdResponse]
@@ -275,7 +275,7 @@ class AkkaHttpServerTest extends FunSuite with Matchers with SwaggerSpecRunner {
       Servers(Server(pkg, extraImports, genHandler :: genResource :: Nil) :: Nil)
     ) = runSwaggerSpec(swagger)(Context.empty.copy(tracing = true), AkkaHttp)
 
-    val handler = q"""
+    val handler  = q"""
       trait BazHandler {
         def getFoo(bar: Long)(implicit traceBuilder: TraceBuilder): scala.concurrent.Future[Boolean]
       }

--- a/src/test/scala/tests/generators/akkaHttp/DefinitionSpec.scala
+++ b/src/test/scala/tests/generators/akkaHttp/DefinitionSpec.scala
@@ -1,8 +1,8 @@
 package tests.generators.akkaHttp
 
 import com.twilio.guardrail.generators.AkkaHttp
-import com.twilio.guardrail.{ClassDefinition, Context, EnumDefinition, ProtocolDefinitions}
-import org.scalatest.{FunSuite, Matchers}
+import com.twilio.guardrail.{ ClassDefinition, Context, EnumDefinition, ProtocolDefinitions }
+import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._
@@ -77,7 +77,7 @@ class DefinitionSpec extends FunSuite with Matchers with SwaggerSpecRunner {
     val definition = q"""
       case class First(a: Option[Int] = None)
     """
-    val companion = q"""
+    val companion  = q"""
       object First {
         implicit val encodeFirst = {
         val readOnlyKeys = Set[String]()
@@ -103,7 +103,7 @@ class DefinitionSpec extends FunSuite with Matchers with SwaggerSpecRunner {
       override def toString: String = value.toString
     }
     """
-    val companion = q"""
+    val companion  = q"""
     object Third {
       object members {
         case object V1 extends Third("v1")
@@ -137,7 +137,7 @@ class DefinitionSpec extends FunSuite with Matchers with SwaggerSpecRunner {
     val definition = q"""
       case class Fifth(aBCD: Option[Int] = None, bCDE: Option[Int] = None)
     """
-    val companion = q"""
+    val companion  = q"""
       object Fifth {
         implicit val encodeFifth = {
           val readOnlyKeys = Set[String]()
@@ -161,7 +161,7 @@ class DefinitionSpec extends FunSuite with Matchers with SwaggerSpecRunner {
     val definition = q"""
       case class Sixth(defval: Int = 1, defvalOpt: Option[Long] = Option(2L))
     """
-    val companion = q"""
+    val companion  = q"""
       object Sixth {
         implicit val encodeSixth = {
           val readOnlyKeys = Set[String]()

--- a/src/test/scala/tests/generators/akkaHttp/DefinitionSpec.scala
+++ b/src/test/scala/tests/generators/akkaHttp/DefinitionSpec.scala
@@ -4,7 +4,7 @@ import com.twilio.guardrail.generators.AkkaHttp
 import com.twilio.guardrail.{ ClassDefinition, Context, EnumDefinition, ProtocolDefinitions }
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
-
+import com.twilio.guardrail.tests._
 import scala.meta._
 
 class DefinitionSpec extends FunSuite with Matchers with SwaggerSpecRunner {
@@ -72,7 +72,7 @@ class DefinitionSpec extends FunSuite with Matchers with SwaggerSpecRunner {
       ProtocolDefinitions(ClassDefinition(_, _, cls, cmp) :: _, _, _, _),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     val definition = q"""
       case class First(a: Option[Int] = None)
@@ -96,7 +96,7 @@ class DefinitionSpec extends FunSuite with Matchers with SwaggerSpecRunner {
       ProtocolDefinitions(_ :: _ :: EnumDefinition(_, _, _, cls, cmp) :: _, _, _, _),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     val definition = q"""
     sealed abstract class Third(val value: String) {
@@ -132,7 +132,7 @@ class DefinitionSpec extends FunSuite with Matchers with SwaggerSpecRunner {
       ProtocolDefinitions(_ :: _ :: _ :: _ :: ClassDefinition(_, _, cls, cmp) :: _, _, _, _),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     val definition = q"""
       case class Fifth(aBCD: Option[Int] = None, bCDE: Option[Int] = None)
@@ -156,7 +156,7 @@ class DefinitionSpec extends FunSuite with Matchers with SwaggerSpecRunner {
       ProtocolDefinitions(_ :: _ :: _ :: _ :: _ :: ClassDefinition(_, _, cls, cmp) :: _, _, _, _),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     val definition = q"""
       case class Sixth(defval: Int = 1, defvalOpt: Option[Long] = Option(2L))

--- a/src/test/scala/tests/generators/akkaHttp/EnumTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/EnumTest.scala
@@ -4,7 +4,7 @@ import com.twilio.guardrail._
 import com.twilio.guardrail.generators.AkkaHttp
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
-
+import com.twilio.guardrail.tests._
 import scala.meta._
 
 class EnumTest extends FunSuite with Matchers with SwaggerSpecRunner {
@@ -58,7 +58,7 @@ class EnumTest extends FunSuite with Matchers with SwaggerSpecRunner {
       ProtocolDefinitions(EnumDefinition(_, _, _, cls, cmp) :: Nil, _, _, _),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     val definition = q"""
     sealed abstract class Bar(val value: String) {
@@ -94,7 +94,7 @@ class EnumTest extends FunSuite with Matchers with SwaggerSpecRunner {
       _,
       Clients(Client(tags, className, statements) :: _),
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     val List(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])
 

--- a/src/test/scala/tests/generators/akkaHttp/EnumTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/EnumTest.scala
@@ -2,7 +2,7 @@ package tests.generators.akkaHttp
 
 import com.twilio.guardrail._
 import com.twilio.guardrail.generators.AkkaHttp
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._
@@ -65,7 +65,7 @@ class EnumTest extends FunSuite with Matchers with SwaggerSpecRunner {
       override def toString: String = value.toString
     }
     """
-    val companion = q"""
+    val companion  = q"""
     object Bar {
       object members {
         case object V1 extends Bar("v1")

--- a/src/test/scala/tests/generators/akkaHttp/PropertyExtractors.scala
+++ b/src/test/scala/tests/generators/akkaHttp/PropertyExtractors.scala
@@ -1,8 +1,8 @@
 package tests.generators.akkaHttp
 
 import com.twilio.guardrail.generators.AkkaHttp
-import com.twilio.guardrail.{ClassDefinition, Context, ProtocolDefinitions}
-import org.scalatest.{FunSuite, Matchers}
+import com.twilio.guardrail.{ ClassDefinition, Context, ProtocolDefinitions }
+import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._

--- a/src/test/scala/tests/generators/akkaHttp/PropertyExtractors.scala
+++ b/src/test/scala/tests/generators/akkaHttp/PropertyExtractors.scala
@@ -4,7 +4,7 @@ import com.twilio.guardrail.generators.AkkaHttp
 import com.twilio.guardrail.{ ClassDefinition, Context, ProtocolDefinitions }
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
-
+import com.twilio.guardrail.tests._
 import scala.meta._
 
 class PropertyExtractors extends FunSuite with Matchers with SwaggerSpecRunner {
@@ -67,7 +67,7 @@ class PropertyExtractors extends FunSuite with Matchers with SwaggerSpecRunner {
       ProtocolDefinitions(ClassDefinition(_, _, cls, cmp) :: _, _, _, _),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     val definition = q"""
       case class Something(

--- a/src/test/scala/tests/generators/akkaHttp/StaticParametersTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/StaticParametersTest.scala
@@ -4,7 +4,7 @@ import com.twilio.guardrail.generators.AkkaHttp
 import com.twilio.guardrail.{ Context, Server, Servers }
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
-
+import com.twilio.guardrail.tests._
 import scala.meta._
 
 class StaticParametersTest extends FunSuite with Matchers with SwaggerSpecRunner {
@@ -33,7 +33,7 @@ class StaticParametersTest extends FunSuite with Matchers with SwaggerSpecRunner
 
   test("Should produce static parameter constraints") {
     val (_, _, Servers(Server(_, _, genHandler :: genResource :: Nil) :: Nil)) =
-      runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+      runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     val handler = q"""
       trait Handler {

--- a/src/test/scala/tests/generators/akkaHttp/StaticParametersTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/StaticParametersTest.scala
@@ -1,8 +1,8 @@
 package tests.generators.akkaHttp
 
 import com.twilio.guardrail.generators.AkkaHttp
-import com.twilio.guardrail.{Context, Server, Servers}
-import org.scalatest.{FunSuite, Matchers}
+import com.twilio.guardrail.{ Context, Server, Servers }
+import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._

--- a/src/test/scala/tests/generators/akkaHttp/client/AkkaHttpClientTracingTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/client/AkkaHttpClientTracingTest.scala
@@ -1,8 +1,8 @@
 package tests.generators.akkaHttp.client
 
 import com.twilio.guardrail.generators.AkkaHttp
-import com.twilio.guardrail.{Client, Clients, Context}
-import org.scalatest.{FunSuite, Matchers}
+import com.twilio.guardrail.{ Client, Clients, Context }
+import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._

--- a/src/test/scala/tests/generators/akkaHttp/client/AkkaHttpClientTracingTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/client/AkkaHttpClientTracingTest.scala
@@ -4,7 +4,7 @@ import com.twilio.guardrail.generators.AkkaHttp
 import com.twilio.guardrail.{ Client, Clients, Context }
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
-
+import com.twilio.guardrail.tests._
 import scala.meta._
 
 class AkkaHttpClientTracingTest extends FunSuite with Matchers with SwaggerSpecRunner {
@@ -34,7 +34,7 @@ class AkkaHttpClientTracingTest extends FunSuite with Matchers with SwaggerSpecR
       |""".stripMargin
 
     val (_, Clients(Client(_, _, statements) :: _), _) =
-      runSwaggerSpec(swagger)(Context.empty.copy(tracing = true), AkkaHttp)
+      runSwaggerSpec(swagger)(Context.empty.copy(tracing = true), AkkaHttp, defaults.akkaGeneratorSettings)
 
     val List(_, cls) = statements.dropWhile(_.isInstanceOf[Import])
 
@@ -88,7 +88,7 @@ class AkkaHttpClientTracingTest extends FunSuite with Matchers with SwaggerSpecR
       _,
       Clients(Client(tags, className, statements) :: _),
       _
-    ) = runSwaggerSpec(swagger)(Context.empty.copy(tracing = true), AkkaHttp)
+    ) = runSwaggerSpec(swagger)(Context.empty.copy(tracing = true), AkkaHttp, defaults.akkaGeneratorSettings)
 
     val List(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])
 

--- a/src/test/scala/tests/generators/akkaHttp/client/BasicTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/client/BasicTest.scala
@@ -4,7 +4,7 @@ import com.twilio.guardrail.generators.AkkaHttp
 import com.twilio.guardrail._
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
-
+import com.twilio.guardrail.tests._
 import scala.meta._
 
 class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
@@ -73,7 +73,7 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
       ProtocolDefinitions(RandomType(_, tpe) :: _, _, _, _),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     tpe.structure should equal(t"io.circe.Json".structure)
   }
@@ -83,7 +83,7 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
       ProtocolDefinitions(_ :: ClassDefinition(_, _, cls, cmp) :: _, _, _, _),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     val definition = q"""
       case class Blix(map: io.circe.Json)
@@ -108,7 +108,7 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
       _,
       Clients(Client(tags, className, statements) :: _),
       _
-    )                  = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    )                  = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
     val List(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])
 
     val client = q"""

--- a/src/test/scala/tests/generators/akkaHttp/client/BasicTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/client/BasicTest.scala
@@ -2,7 +2,7 @@ package tests.generators.akkaHttp.client
 
 import com.twilio.guardrail.generators.AkkaHttp
 import com.twilio.guardrail._
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._
@@ -108,7 +108,7 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
       _,
       Clients(Client(tags, className, statements) :: _),
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    )                  = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
     val List(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])
 
     val client = q"""

--- a/src/test/scala/tests/generators/akkaHttp/client/DefaultParametersTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/client/DefaultParametersTest.scala
@@ -1,8 +1,8 @@
 package tests.generators.akkaHttp.client
 
 import com.twilio.guardrail.generators.AkkaHttp
-import com.twilio.guardrail.{Client, Clients, Context}
-import org.scalatest.{FunSuite, Matchers}
+import com.twilio.guardrail.{ Client, Clients, Context }
+import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 class DefaultParametersTest extends FunSuite with Matchers with SwaggerSpecRunner {

--- a/src/test/scala/tests/generators/akkaHttp/client/DefaultParametersTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/client/DefaultParametersTest.scala
@@ -4,6 +4,7 @@ import com.twilio.guardrail.generators.AkkaHttp
 import com.twilio.guardrail.{ Client, Clients, Context }
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
+import com.twilio.guardrail.tests._
 
 class DefaultParametersTest extends FunSuite with Matchers with SwaggerSpecRunner {
   import scala.meta._
@@ -124,7 +125,7 @@ class DefaultParametersTest extends FunSuite with Matchers with SwaggerSpecRunne
       _,
       Clients(Client(tags, className, statements) :: _),
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     tags should equal(Seq("store"))
 

--- a/src/test/scala/tests/generators/akkaHttp/client/FormFieldsTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/client/FormFieldsTest.scala
@@ -1,8 +1,8 @@
 package tests.generators.akkaHttp.client
 
 import com.twilio.guardrail.generators.AkkaHttp
-import com.twilio.guardrail.{Client, Clients, Context}
-import org.scalatest.{FunSuite, Matchers}
+import com.twilio.guardrail.{ Client, Clients, Context }
+import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._

--- a/src/test/scala/tests/generators/akkaHttp/client/FormFieldsTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/client/FormFieldsTest.scala
@@ -1,0 +1,79 @@
+package tests.generators.akkaHttp.client
+
+import com.twilio.guardrail.generators.AkkaHttp
+import com.twilio.guardrail.{Client, Clients, Context}
+import org.scalatest.{FunSuite, Matchers}
+import support.SwaggerSpecRunner
+
+import scala.meta._
+
+class FormFieldsTest extends FunSuite with Matchers with SwaggerSpecRunner {
+  val swagger: String = s"""
+    |swagger: "2.0"
+    |info:
+    |  title: Whatever
+    |  version: 1.0.0
+    |host: localhost:1234
+    |schemes:
+    |  - http
+    |paths:
+    |  /foo:
+    |    put:
+    |      operationId: putFoo
+    |      consumes:
+    |        - multipart/form-data
+    |      parameters:
+    |        - name: foo
+    |          in: formData
+    |          type: string
+    |          required: true
+    |        - name: bar
+    |          in: formData
+    |          type: integer
+    |          format: int64
+    |          required: true
+    |        - name: baz
+    |          in: formData
+    |          type: file
+    |          required: true
+    |      responses:
+    |        200:
+    |          description: Success
+    |""".stripMargin
+
+  test("Properly handle all methods") {
+    val (
+      _,
+      Clients(Client(tags, className, statements) :: _),
+      _
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+
+    val Seq(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])
+
+    val client = q"""
+      class Client(host: String = "http://localhost:1234")(implicit httpClient: HttpRequest => Future[HttpResponse], ec: ExecutionContext, mat: Materializer) {
+        val basePath: String = ""
+        private[this] def wrap[T: FromEntityUnmarshaller](resp: Future[HttpResponse]): EitherT[Future, Either[Throwable, HttpResponse], T] = {
+          EitherT(resp.flatMap(resp => if (resp.status.isSuccess) {
+            Unmarshal(resp.entity).to[T].map(Right.apply _)
+          } else {
+            FastFuture.successful(Left(Right(resp)))
+          }).recover({
+            case e: Throwable =>
+              Left(Left(e))
+          }))
+        }
+        def putFoo(foo: String, bar: Long, baz: BodyPartEntity, headers: scala.collection.immutable.Seq[HttpHeader] = Nil): EitherT[Future, Either[Throwable, HttpResponse], IgnoredEntity] = {
+          val allHeaders = headers ++ scala.collection.immutable.Seq[Option[HttpHeader]]().flatten
+          wrap[IgnoredEntity](Marshal(Multipart.FormData(Source.fromIterator {
+            () => List(Some(Multipart.FormData.BodyPart("foo", Formatter.show(foo))), Some(Multipart.FormData.BodyPart("bar", Formatter.show(bar))), Some(Multipart.FormData.BodyPart("baz", baz))).flatten.iterator
+          })).to[RequestEntity].flatMap {
+            entity => httpClient(HttpRequest(method = HttpMethods.PUT, uri = host + basePath + "/foo", entity = entity, headers = allHeaders))
+          })
+        }
+      }
+    """
+
+    cls.structure should equal(client.structure)
+  }
+}

--- a/src/test/scala/tests/generators/akkaHttp/client/FormFieldsTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/client/FormFieldsTest.scala
@@ -4,7 +4,7 @@ import com.twilio.guardrail.generators.AkkaHttp
 import com.twilio.guardrail.{ Client, Clients, Context }
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
-
+import com.twilio.guardrail.tests._
 import scala.meta._
 
 class FormFieldsTest extends FunSuite with Matchers with SwaggerSpecRunner {
@@ -46,7 +46,7 @@ class FormFieldsTest extends FunSuite with Matchers with SwaggerSpecRunner {
       _,
       Clients(Client(tags, className, statements) :: _),
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     val Seq(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])
 

--- a/src/test/scala/tests/generators/akkaHttp/client/HardcodedQSSpec.scala
+++ b/src/test/scala/tests/generators/akkaHttp/client/HardcodedQSSpec.scala
@@ -1,8 +1,8 @@
 package tests.generators.akkaHttp.client
 
 import com.twilio.guardrail.generators.AkkaHttp
-import com.twilio.guardrail.{Client, Clients, Context}
-import org.scalatest.{FunSuite, Matchers}
+import com.twilio.guardrail.{ Client, Clients, Context }
+import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._

--- a/src/test/scala/tests/generators/akkaHttp/client/HardcodedQSSpec.scala
+++ b/src/test/scala/tests/generators/akkaHttp/client/HardcodedQSSpec.scala
@@ -4,7 +4,7 @@ import com.twilio.guardrail.generators.AkkaHttp
 import com.twilio.guardrail.{ Client, Clients, Context }
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
-
+import com.twilio.guardrail.tests._
 import scala.meta._
 
 class HardcodedQSSpec extends FunSuite with Matchers with SwaggerSpecRunner {
@@ -50,7 +50,7 @@ class HardcodedQSSpec extends FunSuite with Matchers with SwaggerSpecRunner {
       _,
       Clients(Client(tags, className, statements) :: _),
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     val Seq(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])
 

--- a/src/test/scala/tests/generators/akkaHttp/client/HttpBodiesTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/client/HttpBodiesTest.scala
@@ -1,8 +1,8 @@
 package tests.generators.akkaHttp.client
 
 import com.twilio.guardrail.generators.AkkaHttp
-import com.twilio.guardrail.{Client, Clients, Context}
-import org.scalatest.{FunSuite, Matchers}
+import com.twilio.guardrail.{ Client, Clients, Context }
+import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._

--- a/src/test/scala/tests/generators/akkaHttp/client/HttpBodiesTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/client/HttpBodiesTest.scala
@@ -4,7 +4,7 @@ import com.twilio.guardrail.generators.AkkaHttp
 import com.twilio.guardrail.{ Client, Clients, Context }
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
-
+import com.twilio.guardrail.tests._
 import scala.meta._
 
 class HttpBodiesTest extends FunSuite with Matchers with SwaggerSpecRunner {
@@ -88,7 +88,7 @@ class HttpBodiesTest extends FunSuite with Matchers with SwaggerSpecRunner {
       _,
       Clients(Client(tags, className, statements) :: _),
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     val Seq(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])
 

--- a/src/test/scala/tests/generators/akkaHttp/client/MultipartTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/client/MultipartTest.scala
@@ -4,7 +4,7 @@ import com.twilio.guardrail.generators.AkkaHttp
 import com.twilio.guardrail.{ Client, Clients, Context }
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
-
+import com.twilio.guardrail.tests._
 import scala.meta._
 
 class MultipartTest extends FunSuite with Matchers with SwaggerSpecRunner {
@@ -51,7 +51,7 @@ class MultipartTest extends FunSuite with Matchers with SwaggerSpecRunner {
       _,
       Clients(Client(_, className, statements) :: _),
       _
-    )                = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    )                = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
     val List(_, cls) = statements.dropWhile(_.isInstanceOf[Import])
 
     val client = q"""

--- a/src/test/scala/tests/generators/akkaHttp/client/MultipartTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/client/MultipartTest.scala
@@ -1,8 +1,8 @@
 package tests.generators.akkaHttp.client
 
 import com.twilio.guardrail.generators.AkkaHttp
-import com.twilio.guardrail.{Client, Clients, Context}
-import org.scalatest.{FunSuite, Matchers}
+import com.twilio.guardrail.{ Client, Clients, Context }
+import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._
@@ -51,7 +51,7 @@ class MultipartTest extends FunSuite with Matchers with SwaggerSpecRunner {
       _,
       Clients(Client(_, className, statements) :: _),
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    )                = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
     val List(_, cls) = statements.dropWhile(_.isInstanceOf[Import])
 
     val client = q"""

--- a/src/test/scala/tests/generators/akkaHttp/client/ParamConflictsTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/client/ParamConflictsTest.scala
@@ -2,7 +2,7 @@ package tests.generators.akkaHttp.client
 
 import com.twilio.guardrail._
 import com.twilio.guardrail.generators.AkkaHttp
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._
@@ -88,7 +88,7 @@ class ParamConflictsTest extends FunSuite with Matchers with SwaggerSpecRunner {
     val definition = q"""
       case class Foo(conflicting_name: Option[String] = None, ConflictingName: Option[String] = None)
     """
-    val companion = q"""
+    val companion  = q"""
       object Foo {
         implicit val encodeFoo = {
           val readOnlyKeys = Set[String]()

--- a/src/test/scala/tests/generators/akkaHttp/client/ParamConflictsTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/client/ParamConflictsTest.scala
@@ -4,7 +4,7 @@ import com.twilio.guardrail._
 import com.twilio.guardrail.generators.AkkaHttp
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
-
+import com.twilio.guardrail.tests._
 import scala.meta._
 
 class ParamConflictsTest extends FunSuite with Matchers with SwaggerSpecRunner {
@@ -46,7 +46,7 @@ class ParamConflictsTest extends FunSuite with Matchers with SwaggerSpecRunner {
       _,
       Clients(Client(tags, className, statements) :: _),
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     val List(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])
 
@@ -83,7 +83,7 @@ class ParamConflictsTest extends FunSuite with Matchers with SwaggerSpecRunner {
       ProtocolDefinitions(ClassDefinition(_, _, cls, cmp) :: _, _, _, _),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     val definition = q"""
       case class Foo(conflicting_name: Option[String] = None, ConflictingName: Option[String] = None)

--- a/src/test/scala/tests/generators/akkaHttp/client/SchemeTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/client/SchemeTest.scala
@@ -1,8 +1,8 @@
 package tests.generators.akkaHttp.client
 
 import com.twilio.guardrail.generators.AkkaHttp
-import com.twilio.guardrail.{Client, Clients, Context}
-import org.scalatest.{FunSuite, Matchers}
+import com.twilio.guardrail.{ Client, Clients, Context }
+import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._

--- a/src/test/scala/tests/generators/akkaHttp/client/SchemeTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/client/SchemeTest.scala
@@ -4,7 +4,7 @@ import com.twilio.guardrail.generators.AkkaHttp
 import com.twilio.guardrail.{ Client, Clients, Context }
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
-
+import com.twilio.guardrail.tests._
 import scala.meta._
 
 class SchemeTest extends FunSuite with Matchers with SwaggerSpecRunner {
@@ -36,7 +36,7 @@ class SchemeTest extends FunSuite with Matchers with SwaggerSpecRunner {
 
   test("Use first scheme") {
     val (_, Clients(Client(_, _, statements) :: _), _) =
-      runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+      runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     val List(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])
 

--- a/src/test/scala/tests/generators/akkaHttp/client/contentType/TextPlainTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/client/contentType/TextPlainTest.scala
@@ -4,7 +4,7 @@ import com.twilio.guardrail.generators.AkkaHttp
 import com.twilio.guardrail.{ Client, Clients, Context }
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
-
+import com.twilio.guardrail.tests._
 import scala.meta._
 
 class TextPlainTest extends FunSuite with Matchers with SwaggerSpecRunner {
@@ -38,7 +38,7 @@ class TextPlainTest extends FunSuite with Matchers with SwaggerSpecRunner {
       _,
       Clients(Client(tags, className, statements) :: _),
       _
-    )                  = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    )                  = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
     val List(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])
 
     val companion = q"""

--- a/src/test/scala/tests/generators/akkaHttp/client/contentType/TextPlainTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/client/contentType/TextPlainTest.scala
@@ -1,8 +1,8 @@
 package tests.generators.akkaHttp.client.contentType
 
 import com.twilio.guardrail.generators.AkkaHttp
-import com.twilio.guardrail.{Client, Clients, Context}
-import org.scalatest.{FunSuite, Matchers}
+import com.twilio.guardrail.{ Client, Clients, Context }
+import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._
@@ -38,7 +38,7 @@ class TextPlainTest extends FunSuite with Matchers with SwaggerSpecRunner {
       _,
       Clients(Client(tags, className, statements) :: _),
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    )                  = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
     val List(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])
 
     val companion = q"""
@@ -47,7 +47,7 @@ class TextPlainTest extends FunSuite with Matchers with SwaggerSpecRunner {
         def httpClient(httpClient: HttpRequest => Future[HttpResponse], host: String = "http://localhost:1234")(implicit ec: ExecutionContext, mat: Materializer): Client = new Client(host = host)(httpClient = httpClient, ec = ec, mat = mat)
       }
     """
-    val client = q"""
+    val client    = q"""
       class Client(host: String = "http://localhost:1234")(implicit httpClient: HttpRequest => Future[HttpResponse], ec: ExecutionContext, mat: Materializer) {
         val basePath: String = ""
         private[this] def wrap[T: FromEntityUnmarshaller](resp: Future[HttpResponse]): EitherT[Future, Either[Throwable, HttpResponse], T] = {

--- a/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
@@ -36,6 +36,7 @@ class FormFieldsServerTest extends FunSuite with Matchers with SwaggerSpecRunner
     |          in: formData
     |          type: file
     |          required: true
+    |          x-scala-file-hash: SHA-512
     |      responses:
     |        200:
     |          description: Success

--- a/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
@@ -4,6 +4,7 @@ import com.twilio.guardrail.generators.AkkaHttp
 import com.twilio.guardrail.{ Context, Server, Servers }
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
+import com.twilio.guardrail.tests._
 
 class FormFieldsServerTest extends FunSuite with Matchers with SwaggerSpecRunner {
   import scala.meta._
@@ -47,7 +48,7 @@ class FormFieldsServerTest extends FunSuite with Matchers with SwaggerSpecRunner
       _,
       _,
       Servers(Server(pkg, extraImports, genHandler :: genResource :: Nil) :: Nil)
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     val handler  = q"""
       trait Handler {

--- a/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
@@ -96,13 +96,13 @@ class FormFieldsServerTest extends FunSuite with Matchers with SwaggerSpecRunner
               case class bar(value: Long) extends Part
               case class baz(value: (File, Option[String], ContentType, String)) extends Part
             }
-            val Unmarshallfoopart: Unmarshaller[Multipart.FormData.BodyPart, putFooParts.foo] = Unmarshaller.withMaterializer { implicit executionContext =>
+            val UnmarshalfooPart: Unmarshaller[Multipart.FormData.BodyPart, putFooParts.foo] = Unmarshaller.withMaterializer { implicit executionContext =>
               materializer => part => Unmarshaller.firstOf(implicitly[Unmarshaller[Multipart.FormData.BodyPart, String]], MFDBPviaFSU(Unmarshaller.stringUnmarshaller, materializer)).apply(part).map(putFooParts.foo.apply)
             }
-            val Unmarshallbarpart: Unmarshaller[Multipart.FormData.BodyPart, putFooParts.bar] = Unmarshaller.withMaterializer { implicit executionContext =>
+            val UnmarshalbarPart: Unmarshaller[Multipart.FormData.BodyPart, putFooParts.bar] = Unmarshaller.withMaterializer { implicit executionContext =>
               materializer => part => Unmarshaller.firstOf(implicitly[Unmarshaller[Multipart.FormData.BodyPart, Long]], MFDBPviaFSU(Unmarshaller.stringUnmarshaller, materializer)).apply(part).map(putFooParts.bar.apply)
             }
-            val Unmarshallbazpart: Unmarshaller[Multipart.FormData.BodyPart, putFooParts.baz] = handler.putFooUnmarshalToFile[Id]("SHA-512", handler.putFooMapFileField(_, _, _)).map({
+            val UnmarshalbazPart: Unmarshaller[Multipart.FormData.BodyPart, putFooParts.baz] = handler.putFooUnmarshalToFile[Id]("SHA-512", handler.putFooMapFileField(_, _, _)).map({
               case (v1, v2, v3, v4) =>
                 putFooParts.baz((v1, v2, v3, v4))
             })
@@ -119,11 +119,11 @@ class FormFieldsServerTest extends FunSuite with Matchers with SwaggerSpecRunner
                     {
                       part.name match {
                         case "foo" =>
-                          SafeUnmarshaller(Unmarshallfoopart).apply(part)
+                          SafeUnmarshaller(UnmarshalfooPart).apply(part)
                         case "bar" =>
-                          SafeUnmarshaller(Unmarshallbarpart).apply(part)
+                          SafeUnmarshaller(UnmarshalbarPart).apply(part)
                         case "baz" =>
-                          SafeUnmarshaller(AccumulatingUnmarshaller(fileReferences, Unmarshallbazpart)(_.value._1)).apply(part)
+                          SafeUnmarshaller(AccumulatingUnmarshaller(fileReferences, UnmarshalbazPart)(_.value._1)).apply(part)
                         case _ =>
                           SafeUnmarshaller(implicitly[Unmarshaller[Multipart.FormData.BodyPart, Unit]].map(putFooParts.IgnoredPart.apply(_))).apply(part)
                       }

--- a/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
@@ -95,11 +95,11 @@ class FormFieldsServerTest extends FunSuite with Matchers with SwaggerSpecRunner
               case class bar(value: Long) extends Part
               case class baz(value: (File, Option[String], ContentType, String)) extends Part
             }
-            val Unmarshallfoopart: Unmarshaller[Multipart.FormData.BodyPart, putFooParts.foo] = Unmarshaller { implicit executionContext =>
-              part => implicitly[Unmarshaller[Multipart.FormData.BodyPart, String]].apply(part).map(putFooParts.foo.apply)
+            val Unmarshallfoopart: Unmarshaller[Multipart.FormData.BodyPart, putFooParts.foo] = Unmarshaller.withMaterializer { implicit executionContext =>
+              materializer => part => Unmarshaller.firstOf(implicitly[Unmarshaller[Multipart.FormData.BodyPart, String]], MFDBPviaFSU(Unmarshaller.stringUnmarshaller, materializer)).apply(part).map(putFooParts.foo.apply)
             }
-            val Unmarshallbarpart: Unmarshaller[Multipart.FormData.BodyPart, putFooParts.bar] = Unmarshaller { implicit executionContext =>
-              part => implicitly[Unmarshaller[Multipart.FormData.BodyPart, Long]].apply(part).map(putFooParts.bar.apply)
+            val Unmarshallbarpart: Unmarshaller[Multipart.FormData.BodyPart, putFooParts.bar] = Unmarshaller.withMaterializer { implicit executionContext =>
+              materializer => part => Unmarshaller.firstOf(implicitly[Unmarshaller[Multipart.FormData.BodyPart, Long]], MFDBPviaFSU(Unmarshaller.stringUnmarshaller, materializer)).apply(part).map(putFooParts.bar.apply)
             }
             val Unmarshallbazpart: Unmarshaller[Multipart.FormData.BodyPart, putFooParts.baz] = handler.putFooUnmarshalToFile[Id]("SHA-512", handler.putFooMapFileField(_, _, _)).map({
               case (v1, v2, v3, v4) =>

--- a/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
@@ -1,8 +1,8 @@
 package tests.generators.akkaHttp.server
 
 import com.twilio.guardrail.generators.AkkaHttp
-import com.twilio.guardrail.{Context, Server, Servers}
-import org.scalatest.{FunSuite, Matchers}
+import com.twilio.guardrail.{ Context, Server, Servers }
+import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 class FormFieldsServerTest extends FunSuite with Matchers with SwaggerSpecRunner {
@@ -49,7 +49,7 @@ class FormFieldsServerTest extends FunSuite with Matchers with SwaggerSpecRunner
       Servers(Server(pkg, extraImports, genHandler :: genResource :: Nil) :: Nil)
     ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
 
-    val handler = q"""
+    val handler  = q"""
       trait Handler {
         def putFoo(respond: Resource.putFooResponse.type)(foo: String, bar: Long, baz: (File, Option[String], ContentType, String)): scala.concurrent.Future[Resource.putFooResponse]
         def putFooMapFileField(fieldName: String, fileName: Option[String], contentType: ContentType): File

--- a/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
@@ -1,0 +1,185 @@
+package tests.generators.akkaHttp.server
+
+import com.twilio.guardrail.generators.AkkaHttp
+import com.twilio.guardrail.{Context, Server, Servers}
+import org.scalatest.{FunSuite, Matchers}
+import support.SwaggerSpecRunner
+
+class FormFieldsServerTest extends FunSuite with Matchers with SwaggerSpecRunner {
+  import scala.meta._
+
+  val swagger: String = s"""
+    |swagger: "2.0"
+    |info:
+    |  title: Whatever
+    |  version: 1.0.0
+    |host: localhost:1234
+    |schemes:
+    |  - http
+    |paths:
+    |  /foo:
+    |    put:
+    |      operationId: putFoo
+    |      consumes:
+    |        - multipart/form-data
+    |      parameters:
+    |        - name: foo
+    |          in: formData
+    |          type: string
+    |          required: true
+    |        - name: bar
+    |          in: formData
+    |          type: integer
+    |          format: int64
+    |          required: true
+    |        - name: baz
+    |          in: formData
+    |          type: file
+    |          required: true
+    |      responses:
+    |        200:
+    |          description: Success
+    |""".stripMargin
+
+  test("Ensure routes are generated") {
+    val (
+      _,
+      _,
+      Servers(Server(pkg, extraImports, genHandler :: genResource :: Nil) :: Nil)
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+
+    val handler = q"""
+      trait Handler {
+        def putFoo(respond: Resource.putFooResponse.type)(foo: String, bar: Long, baz: (File, Option[String], ContentType, Option[String])): scala.concurrent.Future[Resource.putFooResponse]
+        def putFooMapFileField(fieldName: String, fileName: Option[String], contentType: ContentType): File
+        def putFooUnmarshalToFile(hashType: Option[String], destFn: (String, Option[String], ContentType) => File)(implicit mat: Materializer): Unmarshaller[Multipart.FormData.BodyPart, (File, Option[String], ContentType, Option[String])] = Unmarshaller { implicit executionContext =>
+          part => {
+            val dest = destFn(part.name, part.filename, part.entity.contentType)
+            val messageDigest = hashType.map(MessageDigest.getInstance(_))
+            val fileSink: Sink[ByteString, Future[IOResult]] = FileIO.toPath(dest.toPath).contramap[ByteString] { chunk =>
+              messageDigest.foreach(_.update(chunk.toArray[Byte]))
+              chunk
+            }
+            part.entity.dataBytes.toMat(fileSink)(Keep.right).run().transform({
+              case Failure(t) =>
+                dest.delete()
+                Failure(t)
+              case Success(IOResult(_, Success(_))) =>
+                val hash = messageDigest.map(md => javax.xml.bind.DatatypeConverter.printHexBinary(md.digest()).toLowerCase(java.util.Locale.US))
+                Success((dest, part.filename, part.entity.contentType, hash))
+              case Success(IOResult(_, Failure(t))) =>
+                Failure(t)
+            })
+          }
+        }
+      }
+    """
+    val resource = q"""
+      object Resource {
+        import cats.syntax.either._
+        def discardEntity(implicit mat: akka.stream.Materializer): Directive0 = extractRequest.flatMap { req =>
+          req.discardEntityBytes().future
+          Directive.Empty
+        }
+        implicit def jsonFSU[T: io.circe.Decoder]: Unmarshaller[String, T] = Unmarshaller[String, T] { implicit ev =>
+          string => io.circe.Json.fromString(string).as[T].left.flatMap(err => io.circe.jawn.parse(string).flatMap(_.as[T])).fold(scala.concurrent.Future.failed _, scala.concurrent.Future.successful _)
+        }
+        def routes(handler: Handler)(implicit mat: akka.stream.Materializer): Route = {
+          (put & path("foo") & ({
+            object putFooParts {
+              sealed trait Part
+              case class IgnoredPart(unit: Unit) extends Part
+              case class foo(value: String) extends Part
+              case class bar(value: Long) extends Part
+              case class baz(value: (File, Option[String], ContentType, Option[String])) extends Part
+            }
+            val Unmarshallfoopart: Unmarshaller[Multipart.FormData.BodyPart, putFooParts.foo] = Unmarshaller { implicit executionContext =>
+              part => implicitly[Unmarshaller[Multipart.FormData.BodyPart, String]].apply(part).map(putFooParts.foo.apply)
+            }
+            val Unmarshallbarpart: Unmarshaller[Multipart.FormData.BodyPart, putFooParts.bar] = Unmarshaller { implicit executionContext =>
+              part => implicitly[Unmarshaller[Multipart.FormData.BodyPart, Long]].apply(part).map(putFooParts.bar.apply)
+            }
+            val Unmarshallbazpart: Unmarshaller[Multipart.FormData.BodyPart, putFooParts.baz] = handler.putFooUnmarshalToFile(Option("SHA-512"), handler.putFooMapFileField(_, _, _)).map(putFooParts.baz.apply)
+            val fileReferences = new AtomicReference(List.empty[File])
+            extractExecutionContext.flatMap { implicit executionContext =>
+              extractMaterializer.flatMap { implicit mat =>
+                entity(as[Multipart.FormData]).flatMap { formData =>
+                  val collectedPartsF: Future[Either[Throwable, (Option[String], Option[Long], Option[(File, Option[String], ContentType, Option[String])])]] = for (results <- formData.parts.mapConcat {
+                    part => if (Set[String]("foo", "bar", "baz").contains(part.name)) part :: Nil else {
+                      part.entity.discardBytes()
+                      Nil
+                    }
+                  }.mapAsync(1) { part =>
+                    {
+                      part.name match {
+                        case "foo" =>
+                          SafeUnmarshaller(Unmarshallfoopart).apply(part)
+                        case "bar" =>
+                          SafeUnmarshaller(Unmarshallbarpart).apply(part)
+                        case "baz" =>
+                          SafeUnmarshaller(AccumulatingUnmarshaller(fileReferences, Unmarshallbazpart)(_.value._1)).apply(part)
+                        case _ =>
+                          SafeUnmarshaller(implicitly[Unmarshaller[Multipart.FormData.BodyPart, Unit]].map(putFooParts.IgnoredPart.apply(_))).apply(part)
+                      }
+                    }
+                  }.toMat(Sink.seq[Either[Throwable, putFooParts.Part]])(Keep.right).run()) yield {
+                    results.toList.sequence.map { successes =>
+                      val fooO = successes.collectFirst({
+                        case putFooParts.foo(v1) => v1
+                      })
+                      val barO = successes.collectFirst({
+                        case putFooParts.bar(v1) => v1
+                      })
+                      val bazO = successes.collectFirst({
+                        case putFooParts.baz((v1, v2, v3, v4)) =>
+                          (v1, v2, v3, v4)
+                      })
+                      (fooO, barO, bazO)
+                    }
+                  }
+                  handleExceptions(ExceptionHandler({
+                    case e: Throwable =>
+                      fileReferences.get().foreach(_.delete())
+                      throw e
+                  })) & handleRejections { (rejections: scala.collection.immutable.Seq[Rejection]) =>
+                    fileReferences.get().foreach(_.delete())
+                    None
+                  } & mapResponse { resp =>
+                    fileReferences.get().foreach(_.delete())
+                    resp
+                  } & onSuccess(collectedPartsF)
+                }
+              }
+            }.flatMap(_.fold(t => throw t, {
+              case (fooO, barO, bazO) =>
+                val maybe: Either[Rejection, (String, Long, (File, Option[String], ContentType, Option[String]))] = for (foo <- fooO.toRight(MissingFormFieldRejection("foo")); bar <- barO.toRight(MissingFormFieldRejection("bar")); baz <- bazO.toRight(MissingFormFieldRejection("baz"))) yield {
+                  (foo, bar, baz)
+                }
+                maybe.fold(reject(_), tprovide(_))
+            }))
+          }: Directive[(String, Long, (File, Option[String], ContentType, Option[String]))])) {
+            (foo, bar, baz) => complete(handler.putFoo(putFooResponse)(foo, bar, baz))
+          }
+        }
+        sealed abstract class putFooResponse(val statusCode: StatusCode)
+        case object putFooResponseOK extends putFooResponse(StatusCodes.OK)
+        object putFooResponse {
+          implicit val putFooTRM: ToResponseMarshaller[putFooResponse] = Marshaller { implicit ec =>
+            resp => putFooTR(resp)
+          }
+          implicit def putFooTR(value: putFooResponse)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
+            case r: putFooResponseOK.type =>
+              scala.concurrent.Future.successful(Marshalling.Opaque {
+                () => HttpResponse(r.statusCode)
+              } :: Nil)
+          }
+          def apply[T](value: T)(implicit ev: T => putFooResponse): putFooResponse = ev(value)
+          def OK: putFooResponse = putFooResponseOK
+        }
+      }
+    """
+
+    genHandler.structure shouldEqual handler.structure
+    genResource.structure shouldEqual resource.structure
+  }
+}

--- a/src/test/scala/tests/generators/http4s/BasicTest.scala
+++ b/src/test/scala/tests/generators/http4s/BasicTest.scala
@@ -4,7 +4,7 @@ import com.twilio.guardrail._
 import com.twilio.guardrail.generators.Http4s
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
-
+import com.twilio.guardrail.tests._
 import scala.meta._
 
 class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
@@ -73,7 +73,7 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
       ProtocolDefinitions(RandomType(_, tpe) :: _, _, _, _),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, Http4s)
+    ) = runSwaggerSpec(swagger)(Context.empty, Http4s, defaults.http4sGeneratorSettings)
 
     tpe.structure should equal(t"io.circe.Json".structure)
   }
@@ -83,7 +83,7 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
       ProtocolDefinitions(_ :: ClassDefinition(_, _, cls, cmp) :: _, _, _, _),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, Http4s)
+    ) = runSwaggerSpec(swagger)(Context.empty, Http4s, defaults.http4sGeneratorSettings)
 
     val definition = q"""
       case class Blix(map: io.circe.Json)
@@ -108,7 +108,7 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
       _,
       Clients(Client(tags, className, statements) :: _),
       _
-    )                  = runSwaggerSpec(swagger)(Context.empty, Http4s)
+    )                  = runSwaggerSpec(swagger)(Context.empty, Http4s, defaults.http4sGeneratorSettings)
     val List(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])
 
     val client = q"""

--- a/src/test/scala/tests/generators/http4s/BasicTest.scala
+++ b/src/test/scala/tests/generators/http4s/BasicTest.scala
@@ -2,7 +2,7 @@ package tests.generators.http4s
 
 import com.twilio.guardrail._
 import com.twilio.guardrail.generators.Http4s
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._
@@ -108,7 +108,7 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
       _,
       Clients(Client(tags, className, statements) :: _),
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, Http4s)
+    )                  = runSwaggerSpec(swagger)(Context.empty, Http4s)
     val List(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])
 
     val client = q"""

--- a/src/test/scala/tests/generators/http4s/client/DefaultParametersTest.scala
+++ b/src/test/scala/tests/generators/http4s/client/DefaultParametersTest.scala
@@ -1,8 +1,8 @@
 package tests.generators.http4s.client
 
 import com.twilio.guardrail.generators.Http4s
-import com.twilio.guardrail.{Client, Clients, Context}
-import org.scalatest.{FunSuite, Matchers}
+import com.twilio.guardrail.{ Client, Clients, Context }
+import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 class DefaultParametersTest extends FunSuite with Matchers with SwaggerSpecRunner {

--- a/src/test/scala/tests/generators/http4s/client/DefaultParametersTest.scala
+++ b/src/test/scala/tests/generators/http4s/client/DefaultParametersTest.scala
@@ -4,6 +4,7 @@ import com.twilio.guardrail.generators.Http4s
 import com.twilio.guardrail.{ Client, Clients, Context }
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
+import com.twilio.guardrail.tests._
 
 class DefaultParametersTest extends FunSuite with Matchers with SwaggerSpecRunner {
   import scala.meta._
@@ -124,7 +125,7 @@ class DefaultParametersTest extends FunSuite with Matchers with SwaggerSpecRunne
       _,
       Clients(Client(tags, className, statements) :: _),
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, Http4s)
+    ) = runSwaggerSpec(swagger)(Context.empty, Http4s, defaults.http4sGeneratorSettings)
 
     tags should equal(Seq("store"))
 


### PR DESCRIPTION
- Adding `GeneratorSettings` to provide customizable parameters
- Adding an non-strict path for `Multipart.FormData.BodyPart`-processing, with explicit handling for `File` uploads (#65)
- Fixing a bug where entity is discarded before any `formData` fields are processed