### PR TITLE
Custom multipart decoder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ target/
 modules/sample/target/
 modules/sample/src/main/scala/*
 !modules/sample/src/main/scala/App.scala
+!modules/sample/src/main/scala/support
 
 .idea

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ fullRunTask(
   Test,
   "com.twilio.guardrail.CLI",
   """
-  --defaults --import akka.NotUsed
+  --defaults --import akka.NotUsed --import support.PositiveLong
   --client --specPath modules/sample/src/main/resources/petstore.json --outputPath modules/sample/src/main/scala --packageName clients.http4s --framework http4s
   --client --specPath modules/sample/src/main/resources/petstore.json --outputPath modules/sample/src/main/scala --packageName clients.akkaHttp --framework akka-http
   --server --specPath modules/sample/src/main/resources/petstore.json --outputPath modules/sample/src/main/scala --packageName servers

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpClientGenerator.scala
@@ -189,6 +189,7 @@ object AkkaHttpClientGenerator {
             .orElse(textPlainBody)
             .orElse(safeBody.map(_._1))
             .getOrElse(q"HttpEntity.Empty")
+
           val methodBody: Term = if (tracing) {
             val tracingLabel = q"""s"$${clientName}:$${methodName}""""
             q"""
@@ -224,8 +225,7 @@ object AkkaHttpClientGenerator {
           ).flatten
 
           q"""
-          def ${Term
-            .Name(methodName)}(...${arglists}): EitherT[Future, Either[Throwable, HttpResponse], $responseTypeRef] = $methodBody
+          def ${Term.Name(methodName)}(...${arglists}): EitherT[Future, Either[Throwable, HttpResponse], $responseTypeRef] = $methodBody
           """
         }
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpGenerator.scala
@@ -1,7 +1,7 @@
 package com.twilio.guardrail
 package generators
 
-import _root_.io.swagger.models._
+import io.swagger.models._
 import cats.arrow.FunctionK
 import cats.data.NonEmptyList
 import cats.instances.all._

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpGenerator.scala
@@ -101,7 +101,7 @@ object AkkaHttpGenerator {
               case "" =>
                 throw Unmarshaller.NoContentException
               case data =>
-                jawn.parse(data).valueOr(throw _)
+                jawn.parse(data).getOrElse(Json.fromString(data))
             }
 
             def jsonDecoderUnmarshaller[A](implicit J: ${jsonDecoderTypeclass}[A]): FromStringUnmarshaller[A] = {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpGenerator.scala
@@ -100,11 +100,11 @@ object AkkaHttpGenerator {
             implicit val ignoredUnmarshaller: FromEntityUnmarshaller[IgnoredEntity] =
               Unmarshaller.strict(_ => IgnoredEntity.empty)
 
-            implicit def MFDBPviaFSU[T](implicit ev: Unmarshaller[BodyPartEntity, T], mat: Materializer): Unmarshaller[Multipart.FormData.BodyPart, T] = Unmarshaller { implicit executionContext => entity =>
+            implicit def MFDBPviaFSU[T](implicit ev: Unmarshaller[BodyPartEntity, T]): Unmarshaller[Multipart.FormData.BodyPart, T] = Unmarshaller.withMaterializer { implicit executionContext => implicit mat => entity =>
               ev.apply(entity.entity)
             }
 
-            implicit def BPEviaFSU[T](implicit ev: Unmarshaller[String, T], mat: Materializer): Unmarshaller[BodyPartEntity, T] = Unmarshaller { implicit executionContext => entity =>
+            implicit def BPEviaFSU[T](implicit ev: Unmarshaller[String, T]): Unmarshaller[BodyPartEntity, T] = Unmarshaller.withMaterializer { implicit executionContext => implicit mat => entity =>
               entity.dataBytes
                 .runWith(Sink.fold(ByteString.empty)((accum, bs) => accum.concat(bs)))
                 .map(_.decodeString(java.nio.charset.StandardCharsets.UTF_8))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpGenerator.scala
@@ -89,11 +89,11 @@ object AkkaHttpGenerator {
                 .forContentTypes(MediaTypes.${Term.Name("`application/json`")})
                 .map {
                   case ByteString.empty => throw Unmarshaller.NoContentException
-                  case data             => jawn.parseByteBuffer(data.asByteBuffer).fold(throw _, identity)
+                  case data             => jawn.parseByteBuffer(data.asByteBuffer).valueOr(throw _)
                 }
 
             implicit def jsonEntityUnmarshaller[A](implicit J: ${jsonDecoderTypeclass}[A]): FromEntityUnmarshaller[A] = {
-              def decode(json: ${gs.jsonType}) = J.decodeJson(json).fold(throw _, identity)
+              def decode(json: ${gs.jsonType}) = J.decodeJson(json).valueOr(throw _)
               jsonUnmarshaller.map(decode)
             }
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
@@ -572,10 +572,10 @@ object AkkaHttpServerGenerator {
                   (
                     q"""
                         val ${unmarshallerName.toVar}: Unmarshaller[Multipart.FormData.BodyPart, ${Type
-                      .Select(partsTerm, containerName.toType)}] = Unmarshaller.withMaterializer { implicit executionContext => materializer => part =>
+                      .Select(partsTerm, containerName.toType)}] = Unmarshaller { implicit executionContext => part =>
                           Unmarshaller.firstOf(
                             implicitly[Unmarshaller[Multipart.FormData.BodyPart, ${realType}]],
-                            MFDBPviaFSU(Unmarshaller.stringUnmarshaller, materializer)
+                            MFDBPviaFSU(Unmarshaller.stringUnmarshaller)
                           ).apply(part).map(${Term
                       .Select(partsTerm, containerName.toTerm)}.apply)
                         }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
@@ -393,7 +393,6 @@ object AkkaHttpServerGenerator {
           routesParams = List(param"handler: ${Type.Name(handlerName)}") ++ extraRouteParams
         } yield q"""
           object ${Term.Name(resourceName)} {
-            import cats.syntax.either._
             def discardEntity(implicit mat: akka.stream.Materializer): Directive0 = extractRequest.flatMap({ req => req.discardEntityBytes().future; Directive.Empty })
             implicit def jsonFSU[T: io.circe.Decoder]: Unmarshaller[String, T] = Unmarshaller[String, T]({
               implicit ev => string =>

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
@@ -572,11 +572,9 @@ object AkkaHttpServerGenerator {
                     q"""
                         val ${unmarshallerName.toVar}: Unmarshaller[Multipart.FormData.BodyPart, ${Type
                       .Select(partsTerm, containerName.toType)}] = Unmarshaller { implicit executionContext => part =>
-                          Unmarshaller.firstOf(
-                            implicitly[Unmarshaller[Multipart.FormData.BodyPart, ${realType}]],
-                            MFDBPviaFSU(Unmarshaller.stringUnmarshaller)
-                          ).apply(part).map(${Term
-                      .Select(partsTerm, containerName.toTerm)}.apply)
+                          val json: Unmarshaller[Multipart.FormData.BodyPart, ${realType}] = MFDBPviaFSU(jsonEntityUnmarshaller[${realType}])
+                          val string: Unmarshaller[Multipart.FormData.BodyPart, ${realType}] = MFDBPviaFSU(BPEviaFSU(jsonDecoderUnmarshaller))
+                          Unmarshaller.firstOf(json, string).apply(part).map(${Term.Select(partsTerm, containerName.toTerm)}.apply)
                         }
                       """,
                     Case(argName.toLit, None, q"""

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/CirceProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/CirceProtocolGenerator.scala
@@ -321,8 +321,7 @@ object CirceProtocolGenerator {
           List(
             q"import io.circe._",
             q"import io.circe.syntax._",
-            q"import io.circe.generic.semiauto._",
-            q"import cats.syntax.either._"
+            q"import io.circe.generic.semiauto._"
           )
         )
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sClientGenerator.scala
@@ -89,7 +89,7 @@ object Http4sClientGenerator {
               q"$tParamName.map(v => Part.formData[F](${tName.toLit}, Formatter.show(v)))"
 
             def liftTerm(tParamName: Term.Name, tName: RawParameterName) =
-              q"Some(Multipart(${tName.toLit}, Formatter.show($tParamName)))"
+              q"Some(Part.formData[F](${tName.toLit}, Formatter.show($tParamName)))"
 
             val args: List[Term] = parameters.foldLeft(List.empty[Term]) {
               case (a, ScalaParameter(_, param, paramName, argName, _)) =>

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
@@ -60,6 +60,8 @@ object ScalaGenerator {
                 implicit val showString = build[String](identity)
                 implicit val showInt = build[Int](_.toString)
                 implicit val showLong = build[Long](_.toString)
+                implicit val showFloat = build[Float](_.toString)
+                implicit val showDouble = build[Double](_.toString)
                 implicit val showBigInt = build[BigInt](_.toString)
                 implicit val showBigDecimal = build[BigDecimal](_.toString)
                 implicit val showBoolean = build[Boolean](_.toString)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
@@ -64,7 +64,6 @@ object ScalaGenerator {
                 implicit val showBigDecimal = build[BigDecimal](_.toString)
                 implicit val showBoolean = build[Boolean](_.toString)
                 implicit val showOffsetDateTime = build[java.time.OffsetDateTime](_.format(java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME))
-                implicit val showAnyVal = build[AnyVal](_.toString)
               }
 
               object Formatter {

--- a/modules/sample/src/main/resources/petstore.json
+++ b/modules/sample/src/main/resources/petstore.json
@@ -464,7 +464,8 @@
             "description": "ID of pet to update",
             "required": true,
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-scala-type": "PositiveLong"
           },
           {
             "name": "additionalMetadata",
@@ -494,6 +495,14 @@
             "required": true,
             "type": "file",
             "x-scala-file-hash": "SHA-256"
+          },
+          {
+            "name": "custom-value",
+            "in": "formData",
+            "required": true,
+            "type": "number",
+            "format": "int64",
+            "x-scala-type": "PositiveLong"
           }
         ],
         "responses": {

--- a/modules/sample/src/main/resources/petstore.json
+++ b/modules/sample/src/main/resources/petstore.json
@@ -497,9 +497,23 @@
             "x-scala-file-hash": "SHA-256"
           },
           {
+            "name": "long-value",
+            "in": "formData",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
             "name": "custom-value",
             "in": "formData",
             "required": true,
+            "type": "integer",
+            "format": "int64",
+            "x-scala-type": "PositiveLong"
+          },
+          {
+            "name": "custom-optional-value",
+            "in": "formData",
             "type": "number",
             "format": "int64",
             "x-scala-type": "PositiveLong"

--- a/modules/sample/src/main/scala/support/PositiveLong.scala
+++ b/modules/sample/src/main/scala/support/PositiveLong.scala
@@ -1,0 +1,13 @@
+package support
+
+import clients.akkaHttp.{ Implicits => AkkaImplicits }
+import clients.http4s.{ Implicits => Http4sImplicits }
+import io.circe.Decoder
+
+class PositiveLong private (val value: Long) extends AnyVal
+object PositiveLong {
+  def apply(value: Long): Option[PositiveLong] = if (value >= 0) Some(new PositiveLong(value)) else None
+  implicit val akkaShowable = AkkaImplicits.Show.build[PositiveLong](_.value.toString())
+  implicit val http4sShowable = Http4sImplicits.Show.build[PositiveLong](_.value.toString())
+  implicit val decodePositiveLong = Decoder.decodeLong.emap(num => PositiveLong.apply(num).toRight(s"${num} is not positive"))
+}

--- a/modules/sample/src/test/scala/core/RoundTrip.scala
+++ b/modules/sample/src/test/scala/core/RoundTrip.scala
@@ -65,7 +65,7 @@ class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaF
                                                                    file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType)],
                                                                    file2: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType),
                                                                    file3: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, String),
-                                                                   customValue: support.PositiveLong) = ???
+                                                                   longValue: Long, customValue: support.PositiveLong, customOptionalValue: Option[support.PositiveLong]) = ???
     }))
 
     val petClient = PetClient.httpClient(httpClient)
@@ -124,7 +124,7 @@ class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaF
                                                                    file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType)],
                                                                    file2: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType),
                                                                    file3: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, String),
-                                                                   customValue: support.PositiveLong) = ???
+                                                                   longValue: Long, customValue: support.PositiveLong, customOptionalValue: Option[support.PositiveLong]) = ???
     }))
 
     val petClient = PetClient.httpClient(httpClient)
@@ -167,7 +167,7 @@ class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaF
                                                                    file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType)],
                                                                    file2: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType),
                                                                    file3: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, String),
-                                                                   customValue: support.PositiveLong) = ???
+                                                                   longValue: Long, customValue: support.PositiveLong, customOptionalValue: Option[support.PositiveLong]) = ???
     }))
 
     val petClient = PetClient.httpClient(httpClient)
@@ -202,7 +202,7 @@ class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaF
                                                                    file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType)],
                                                                    file2: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType),
                                                                    file3: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, String),
-                                                                   customValue: support.PositiveLong) = ???
+                                                                   longValue: Long, customValue: support.PositiveLong, customOptionalValue: Option[support.PositiveLong]) = ???
     }))
 
     val petClient = PetClient.httpClient(httpClient)
@@ -236,7 +236,7 @@ class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaF
                                                                    file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType)],
                                                                    file2: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType),
                                                                    file3: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, String),
-                                                                   customValue: support.PositiveLong) = {
+                                                                   longValue: Long, customValue: support.PositiveLong, customOptionalValue: Option[support.PositiveLong]) = {
         val f1Length = file.flatMap({ case (f, _, _) => if (f.exists) { Some(f.length) } else None })
         val f2Length = if (file2._1.exists) { Some(file2._1.length) } else None
         val f3Length = if (file3._1.exists) { Some(file3._1.length) } else None
@@ -258,7 +258,9 @@ class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaF
         None,
         HttpEntity(ContentTypes.`application/json`, ""),
         HttpEntity(ContentTypes.`application/json`, ""),
-        PositiveLong(10L).get
+        5L,
+        PositiveLong(10L).get,
+        PositiveLong(20L)
       )
       .value
       .futureValue

--- a/modules/sample/src/test/scala/core/RoundTrip.scala
+++ b/modules/sample/src/test/scala/core/RoundTrip.scala
@@ -14,6 +14,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.SpanSugar._
 import org.scalatest.{ EitherValues, FunSuite, Matchers }
 import scala.concurrent.Future
+import support.PositiveLong
 
 class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaFutures with ScalatestRouteTest {
   override implicit val patienceConfig = PatienceConfig(1000 millis, 1000 millis)
@@ -59,11 +60,12 @@ class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaF
       def updatePetWithForm(respond: PetResource.updatePetWithFormResponse.type)(petId: Long, name: Option[String] = None, status: Option[String] = None) = ???
       def uploadFileMapFileField(fieldName: String, fileName: Option[String], contentType: ContentType) =
         java.io.File.createTempFile("download_", ".dat", new java.io.File("/tmp"))
-      def uploadFile(respond: PetResource.uploadFileResponse.type)(petId: Long,
+      def uploadFile(respond: PetResource.uploadFileResponse.type)(petId: support.PositiveLong,
                                                                    additionalMetadata: Option[String],
                                                                    file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType)],
                                                                    file2: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType),
-                                                                   file3: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, String)) = ???
+                                                                   file3: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, String),
+                                                                   customValue: support.PositiveLong) = ???
     }))
 
     val petClient = PetClient.httpClient(httpClient)
@@ -117,11 +119,12 @@ class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaF
       def updatePetWithForm(respond: PetResource.updatePetWithFormResponse.type)(petId: Long, name: Option[String] = None, status: Option[String] = None) = ???
       def uploadFileMapFileField(fieldName: String, fileName: Option[String], contentType: ContentType) =
         java.io.File.createTempFile("download_", ".dat", new java.io.File("/tmp"))
-      def uploadFile(respond: PetResource.uploadFileResponse.type)(petId: Long,
+      def uploadFile(respond: PetResource.uploadFileResponse.type)(petId: support.PositiveLong,
                                                                    additionalMetadata: Option[String],
                                                                    file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType)],
                                                                    file2: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType),
-                                                                   file3: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, String)) = ???
+                                                                   file3: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, String),
+                                                                   customValue: support.PositiveLong) = ???
     }))
 
     val petClient = PetClient.httpClient(httpClient)
@@ -159,11 +162,12 @@ class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaF
       def updatePetWithForm(respond: PetResource.updatePetWithFormResponse.type)(petId: Long, name: Option[String] = None, status: Option[String] = None) = ???
       def uploadFileMapFileField(fieldName: String, fileName: Option[String], contentType: ContentType) =
         java.io.File.createTempFile("download_", ".dat", new java.io.File("/tmp"))
-      def uploadFile(respond: PetResource.uploadFileResponse.type)(petId: Long,
+      def uploadFile(respond: PetResource.uploadFileResponse.type)(petId: support.PositiveLong,
                                                                    additionalMetadata: Option[String],
                                                                    file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType)],
                                                                    file2: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType),
-                                                                   file3: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, String)) = ???
+                                                                   file3: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, String),
+                                                                   customValue: support.PositiveLong) = ???
     }))
 
     val petClient = PetClient.httpClient(httpClient)
@@ -193,11 +197,12 @@ class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaF
       def updatePetWithForm(respond: PetResource.updatePetWithFormResponse.type)(petId: Long, name: Option[String] = None, status: Option[String] = None) = ???
       def uploadFileMapFileField(fieldName: String, fileName: Option[String], contentType: ContentType) =
         java.io.File.createTempFile("download_", ".dat", new java.io.File("/tmp"))
-      def uploadFile(respond: PetResource.uploadFileResponse.type)(petId: Long,
+      def uploadFile(respond: PetResource.uploadFileResponse.type)(petId: support.PositiveLong,
                                                                    additionalMetadata: Option[String],
                                                                    file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType)],
                                                                    file2: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType),
-                                                                   file3: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, String)) = ???
+                                                                   file3: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, String),
+                                                                   customValue: support.PositiveLong) = ???
     }))
 
     val petClient = PetClient.httpClient(httpClient)
@@ -226,11 +231,12 @@ class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaF
       def updatePetWithForm(respond: PetResource.updatePetWithFormResponse.type)(petId: Long, name: Option[String] = None, status: Option[String] = None) = ???
       def uploadFileMapFileField(fieldName: String, fileName: Option[String], contentType: ContentType) =
         java.io.File.createTempFile("download_", ".dat", new java.io.File("/tmp"))
-      def uploadFile(respond: PetResource.uploadFileResponse.type)(petId: Long,
+      def uploadFile(respond: PetResource.uploadFileResponse.type)(petId: support.PositiveLong,
                                                                    additionalMetadata: Option[String],
                                                                    file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType)],
                                                                    file2: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType),
-                                                                   file3: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, String)) = {
+                                                                   file3: (java.io.File, Option[String], akka.http.scaladsl.model.ContentType, String),
+                                                                   customValue: support.PositiveLong) = {
         val f1Length = file.flatMap({ case (f, _, _) => if (f.exists) { Some(f.length) } else None })
         val f2Length = if (file2._1.exists) { Some(file2._1.length) } else None
         val f3Length = if (file3._1.exists) { Some(file3._1.length) } else None
@@ -247,11 +253,12 @@ class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaF
 
     val result = petClient
       .uploadFile(
-        petId,
+        PositiveLong(petId).get,
         Some("Additional metadata"),
         None,
         HttpEntity(ContentTypes.`application/json`, ""),
-        HttpEntity(ContentTypes.`application/json`, "")
+        HttpEntity(ContentTypes.`application/json`, ""),
+        PositiveLong(10L).get
       )
       .value
       .futureValue

--- a/modules/sample/src/test/scala/core/RoundTrip.scala
+++ b/modules/sample/src/test/scala/core/RoundTrip.scala
@@ -17,7 +17,7 @@ import scala.concurrent.Future
 import support.PositiveLong
 
 class RoundTripTest extends FunSuite with Matchers with EitherValues with ScalaFutures with ScalatestRouteTest {
-  override implicit val patienceConfig = PatienceConfig(1000 millis, 1000 millis)
+  override implicit val patienceConfig = PatienceConfig(10 seconds, 1 second)
 
   // Placeholder until property testing
   val id: Option[Long]              = None

--- a/src/test/scala/tests/generators/akkaHttp/AkkaHttpServerTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/AkkaHttpServerTest.scala
@@ -142,7 +142,6 @@ class AkkaHttpServerTest extends FunSuite with Matchers with SwaggerSpecRunner {
     """
     val resource = q"""
       object StoreResource {
-        import cats.syntax.either._
         def discardEntity(implicit mat: akka.stream.Materializer): Directive0 = extractRequest.flatMap { req =>
           req.discardEntityBytes().future
           Directive.Empty

--- a/src/test/scala/tests/generators/akkaHttp/StaticParametersTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/StaticParametersTest.scala
@@ -44,7 +44,6 @@ class StaticParametersTest extends FunSuite with Matchers with SwaggerSpecRunner
 
     val resource = q"""
       object Resource {
-        import cats.syntax.either._
         def discardEntity(implicit mat: akka.stream.Materializer): Directive0 = extractRequest.flatMap { req =>
           req.discardEntityBytes().future
           Directive.Empty

--- a/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
+++ b/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
@@ -79,7 +79,6 @@ class FormFieldsServerTest extends FunSuite with Matchers with SwaggerSpecRunner
     """
     val resource = q"""
       object Resource {
-        import cats.syntax.either._
         def discardEntity(implicit mat: akka.stream.Materializer): Directive0 = extractRequest.flatMap { req =>
           req.discardEntityBytes().future
           Directive.Empty


### PR DESCRIPTION
Resolves: #70 #71 #72

Explicitly calling out how JSON parsing fallback is handled for fields:

Submitting via:

    curl ... -F foo=bar

is treated the same way as:

    curl ... -F 'foo="bar"'

This is somewhat undesirable, but avoids us accidentally including
unescaped doublequotes into string values. This sets a general precident
of:

    curl ... -F 'foo=\"bar\"'

being the blessed way to ensure JSON tokens are not accidentally
processed when they were intended to be included in the value.
