### PR TITLE
Deep hierarchy

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/CLI.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/CLI.scala
@@ -14,8 +14,7 @@ import com.twilio.swagger.core.{ LogLevel, LogLevels }
 import com.twilio.guardrail.generators.GeneratorSettings
 import scala.io.AnsiColor
 
-object CLI {
-  def main(args: Array[String]): Unit = run(args)(CoreTermInterp)
+object CLICommon {
 
   def run(args: Array[String])(interpreter: CoreTerm ~> CoreTarget): Unit = {
     // Hacky loglevel parsing, only supports levels that come before absolutely
@@ -68,6 +67,8 @@ object CLI {
 
     val (coreLogger, deferred) = result.run
 
+    print(coreLogger.show)
+
     val (logger, paths) = deferred
       .traverse {
         case (generatorSettings, rs) =>
@@ -83,6 +84,8 @@ object CLI {
       }
       .map(_.flatten)
       .run
+
+    print(logger.show)
   }
 
   def unsafePrintHelp(): Unit = {
@@ -120,4 +123,15 @@ object CLI {
 
     System.err.println(text)
   }
+}
+
+trait CLICommon {
+  val interpreter: CoreTerm ~> CoreTarget
+
+  def main(args: Array[String]): Unit =
+    CLICommon.run(args)(interpreter)
+}
+
+object CLI extends CLICommon {
+  val interpreter = CoreTermInterp
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -95,7 +95,10 @@ object Common {
             )
 
           case ADT(name, tpe, trt, obj) =>
-            val polyImports: Import = q"""import io.circe.generic.extras._"""
+            val polyImports: List[Import] = List(
+              q"""import io.circe.generic.extras._""",
+              q"""import cats.syntax.either._"""
+            )
 
             (
               List(
@@ -105,7 +108,7 @@ object Common {
                     package ${buildPkgTerm(dtoComponents)}
 
                     ..$imports
-                    $polyImports
+                    ..$polyImports
                     $trt
                     $obj
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -94,7 +94,7 @@ object Common {
               List.empty[Stat]
             )
 
-          case ADT(name, tpe, trt, children, obj) =>
+          case ADT(name, tpe, trt, obj) =>
             val polyImports: Import = q"""import io.circe.generic.extras._"""
 
             (
@@ -107,8 +107,6 @@ object Common {
                     ..$imports
                     $polyImports
                     $trt
-                    ..$children
-
                     $obj
 
                   """

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolElems.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolElems.scala
@@ -13,7 +13,7 @@ case class DeferredMap(name: String)   extends LazyProtocolElems
 sealed trait StrictProtocolElems extends ProtocolElems
 
 case class RandomType(name: String, tpe: Type) extends StrictProtocolElems
-case class ClassDefinition(name: String, tpe: Type.Name, cls: Defn.Class, companion: Defn.Object, parents: List[SupperClass] = Nil)
+case class ClassDefinition(name: String, tpe: Type.Name, cls: Defn.Class, companion: Defn.Object, parents: List[SuperClass] = Nil)
     extends StrictProtocolElems
 
 case class ADT(name: String, tpe: Type.Name, trt: Defn.Trait, companion: Defn.Object) extends StrictProtocolElems

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolElems.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolElems.scala
@@ -13,11 +13,10 @@ case class DeferredMap(name: String)   extends LazyProtocolElems
 sealed trait StrictProtocolElems extends ProtocolElems
 
 case class RandomType(name: String, tpe: Type) extends StrictProtocolElems
-case class ClassDefinition(name: String, tpe: Type.Name, cls: Defn.Class, companion: Defn.Object, parent: Option[String] = None)
+case class ClassDefinition(name: String, tpe: Type.Name, cls: Defn.Class, companion: Defn.Object, parents: List[SupperClass] = Nil)
     extends StrictProtocolElems
 
-case class ADT(name: String, tpe: Type.Name, trt: Defn.Trait, children: List[Defn.Class], companion: Defn.Object)
-    extends StrictProtocolElems
+case class ADT(name: String, tpe: Type.Name, trt: Defn.Trait, companion: Defn.Object) extends StrictProtocolElems
 
 case class EnumDefinition(
     name: String,

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolElems.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolElems.scala
@@ -39,9 +39,10 @@ object ProtocolElems {
               strictElems
                 .find(_.name == name)
                 .map {
-                  case RandomType(`name`, tpe)                              => RandomType(name, tpe)
-                  case ClassDefinition(`name`, tpe, cls, companion, parent) => RandomType(name, tpe)
-                  case EnumDefinition(`name`, tpe, `elems`, cls, companion) => RandomType(name, tpe)
+                  case RandomType(name, tpe)                              => RandomType(name, tpe)
+                  case ClassDefinition(name, tpe, cls, companion, parent) => RandomType(name, tpe)
+                  case EnumDefinition(name, tpe, elems, cls, companion)   => RandomType(name, tpe)
+                  case ADT(name, tpe, _, _)                               => RandomType(name, tpe)
                 }
                 .getOrElse(d)
 
@@ -49,9 +50,10 @@ object ProtocolElems {
               strictElems
                 .find(_.name == name)
                 .map {
-                  case RandomType(`name`, tpe)                              => RandomType(name, t"IndexedSeq[$tpe]")
-                  case ClassDefinition(`name`, tpe, cls, companion, _)      => RandomType(name, t"IndexedSeq[$tpe]")
-                  case EnumDefinition(`name`, tpe, `elems`, cls, companion) => RandomType(name, t"IndexedSeq[$tpe]")
+                  case RandomType(name, tpe)                            => RandomType(name, t"IndexedSeq[$tpe]")
+                  case ClassDefinition(name, tpe, cls, companion, _)    => RandomType(name, t"IndexedSeq[$tpe]")
+                  case EnumDefinition(name, tpe, elems, cls, companion) => RandomType(name, t"IndexedSeq[$tpe]")
+                  case ADT(name, tpe, _, _)                             => RandomType(name, t"IndexedSeq[$tpe]")
                 }
                 .getOrElse(d)
 
@@ -59,9 +61,10 @@ object ProtocolElems {
               strictElems
                 .find(_.name == name)
                 .map {
-                  case RandomType(`name`, tpe)                              => RandomType(name, t"Map[String, $tpe]")
-                  case ClassDefinition(`name`, tpe, cls, companion, _)      => RandomType(name, t"Map[String, $tpe]")
-                  case EnumDefinition(`name`, tpe, `elems`, cls, companion) => RandomType(name, t"Map[String, $tpe]")
+                  case RandomType(name, tpe)                            => RandomType(name, t"Map[String, $tpe]")
+                  case ClassDefinition(name, tpe, cls, companion, _)    => RandomType(name, t"Map[String, $tpe]")
+                  case EnumDefinition(name, tpe, elems, cls, companion) => RandomType(name, t"Map[String, $tpe]")
+                  case ADT(name, tpe, _, _)                             => RandomType(name, t"Map[String, $tpe]")
                 }
                 .getOrElse(d)
           }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
@@ -34,6 +34,13 @@ case class ProtocolParameter(
     emptyToNullKey: Option[String]
 )
 
+case class SupperClass(
+    clsName: String,
+    tpl: Type,
+    params: List[ProtocolParameter],
+    discriminator: Option[String]
+)
+
 object ProtocolGenerator {
 
   val toPascalRegexes = List(
@@ -88,57 +95,89 @@ object ProtocolGenerator {
     */
   private[this] def fromPoly[F[_]](
       hierarchy: ClassHierarchy,
-      concreteTypes: List[PropMeta]
+      concreteTypes: List[PropMeta],
+      definitions: List[(String, Model)]
   )(implicit F: FrameworkTerms[F], P: PolyProtocolTerms[F], M: ModelProtocolTerms[F]): Free[F, ProtocolElems] = {
+
     import P._
     import M._
 
-    def compositeSeq(hierarchy: ClassHierarchy): Free[F, List[Either[String, Defn.Class]]] =
-      hierarchy.children.traverse { case (childCls, compModel) => composite(hierarchy.parentModel, compModel, childCls) }
+    //fixme: get parameters!!
+    //fixme: render companion (probably needed only once per hierarchy -> for the parent)
+    //fixme: get Pet's parameters
 
-    def composite(parent: ModelImpl, model: ComposedModel, className: String): Free[F, Either[String, Defn.Class]] = {
-      def validProg(clsName: String)(props: List[(String, Property)]): Free[F, Defn.Class] = {
-        val needCamelSnakeConversion = props.forall { case (k, _) => couldBeSnakeCase(k) }
-        for {
-          params <- props.traverse(transformProperty(clsName, needCamelSnakeConversion, concreteTypes) _ tupled)
-          terms = params.map(_.term)
-          definition <- renderDTOClass(clsName, terms, Some(hierarchy.parentName))
-        } yield {
-          Escape.escapeTree(definition)
-        }
-      }
-
-      for {
-        props <- extractChildProperties(parent, model, parent.getDiscriminator)
-        res   <- props.traverse(validProg(className))
-      } yield res
-    }
+    val discriminator: String = hierarchy.discriminator
 
     for {
-      childDefs <- compositeSeq(hierarchy)
-      props     <- extractProperties(hierarchy.parentModel).map(_.right.get) //fixme unsafe
-      needCamelSnakeConversion = props.forall { case (k, _) => couldBeSnakeCase(k) }
+      parents <- extractParents(hierarchy.parentModel, definitions, concreteTypes)
+      props   <- extractProperties(hierarchy.parentModel).map(_.right.get) //fixme unsafe
+      needCamelSnakeConversion = props.forall {
+        case (k, v) => couldBeSnakeCase(k)
+      }
       params <- props.traverse(transformProperty(hierarchy.parentName, needCamelSnakeConversion, concreteTypes) _ tupled)
-      terms         = params.map(_.term)
-      discriminator = hierarchy.parentModel.getDiscriminator
-      definition        <- renderSealedTrait(hierarchy.parentName, terms, discriminator)
-      discriminatorStat <- renderDiscriminator(discriminator)
-      encoder           <- encodeADT(hierarchy.parentName, needCamelSnakeConversion)
-      decoder           <- decodeADT(hierarchy.parentName, needCamelSnakeConversion)
-      cmp               <- renderADTCompanion(hierarchy.parentName, discriminatorStat, encoder, decoder)
+      terms = params.map(_.term)
+      definition <- renderSealedTrait(hierarchy.parentName, terms, discriminator, parents)
+      encoder    <- encodeADT(hierarchy.parentName, needCamelSnakeConversion)
+      decoder    <- decodeADT(hierarchy.parentName, needCamelSnakeConversion)
+      cmp        <- renderDTOCompanion(hierarchy.parentName, List.empty, encoder, decoder)
 
     } yield {
-      ADT(
-        name = hierarchy.parentName,
-        tpe = Type.Name(hierarchy.parentName),
-        trt = definition,
-        children = childDefs.map(_.right.get), //fixme unsafe
-        companion = cmp
-      )
+      ADT(hierarchy.parentName, Type.Name(hierarchy.parentName), definition, cmp)
     }
   }
 
-  private[this] def fromModel[F[_]](clsName: String, model: ModelImpl, concreteTypes: List[PropMeta])(
+  def extractParents[F[_]](elem: Model, definitions: List[(String, Model)], concreteTypes: List[PropMeta])(
+      implicit M: ModelProtocolTerms[F],
+      F: FrameworkTerms[F]
+  ): Free[F, List[SupperClass]] = {
+    import scala.collection.JavaConverters._
+    import M._
+
+    def allParents(model: Model): List[(String, Model)] =
+      (model match {
+        case elem: ComposedModel =>
+          definitions.collectFirst {
+            case (clsName, e) if elem.getInterfaces.asScala.headOption.exists(_.getSimpleRef == clsName) => (clsName, e)
+          }
+        case _ => None
+      }) match {
+        case Some(x @ (_, el)) => x :: allParents(el)
+        case _                 => Nil
+      }
+
+    def validProg(clsName: String)(props: List[(String, Property)]): Free[F, List[ProtocolParameter]] = {
+      val needCamelSnakeConversion = props.forall({
+        case (k, v) => couldBeSnakeCase(k)
+      })
+      for {
+        params <- props.traverse(transformProperty(clsName, needCamelSnakeConversion, concreteTypes) _ tupled)
+      } yield params
+    }
+
+    for {
+      a <- Free.pure(allParents(elem))
+      supper <- a.traverse { parents =>
+        val (clsName, parent) = parents
+        for {
+          props <- extractProperties(parent)
+          proto <- props.traverse(validProg(clsName))
+        } yield
+          proto.map { a =>
+            SupperClass(clsName, Type.Name(clsName), a, parent match {
+              case m: ModelImpl => Option(m.getDiscriminator)
+              case _            => None
+            })
+          }
+      }
+
+    } yield
+      supper.collect {
+        case Right(x) => x
+      }
+
+  }
+
+  private[this] def fromModel[F[_]](clsName: String, model: Model, parents: List[SupperClass], concreteTypes: List[PropMeta])(
       implicit M: ModelProtocolTerms[F],
       F: FrameworkTerms[F]
   ): Free[F, Either[String, ProtocolElems]] = {
@@ -171,12 +210,12 @@ object ProtocolGenerator {
       for {
         params <- props.traverse(transformProperty(clsName, needCamelSnakeConversion, concreteTypes) _ tupled)
         terms = params.map(_.term)
-        defn <- renderDTOClass(clsName, terms, None)
+        defn <- renderDTOClass(clsName, terms, parents)
         deps = params.flatMap(_.dep)
-        encoder <- encodeModel(clsName, needCamelSnakeConversion, params)
-        decoder <- decodeModel(clsName, needCamelSnakeConversion, params)
+        encoder <- encodeModel(clsName, needCamelSnakeConversion, params, parents)
+        decoder <- decodeModel(clsName, needCamelSnakeConversion, params, parents)
         cmp     <- renderDTOCompanion(clsName, List.empty, encoder, decoder)
-      } yield ClassDefinition(clsName, Type.Name(clsName), Escape.escapeTree(defn), Escape.escapeTree(cmp))
+      } yield ClassDefinition(clsName, Type.Name(clsName), Escape.escapeTree(defn), Escape.escapeTree(cmp), parents)
     }
 
     for {
@@ -185,14 +224,24 @@ object ProtocolGenerator {
     } yield res
   }
 
-  def modelTypeAlias[F[_]](clsName: String, model: ModelImpl)(
+  def modelTypeAlias[F[_]](clsName: String, abstractModel: Model)(
       implicit A: AliasProtocolTerms[F],
       F: FrameworkTerms[F]
   ): Free[F, ProtocolElems] = {
     import F._
+    val model = abstractModel match {
+      case m: ModelImpl => Some(m)
+      case m: ComposedModel =>
+        m.getAllOf.asScala.toList.get(1).flatMap {
+          case m: ModelImpl => Some(m)
+          case _            => None
+        }
+      case _ => None
+    }
     getGeneratorSettings().flatMap { implicit generatorSettings =>
-      val tpe = Option(model.getType)
-        .fold[Type](generatorSettings.jsonType)(raw => SwaggerUtil.typeName(raw, Option(model.getFormat), ScalaType(model)))
+      val tpe = model
+        .map(_.getType)
+        .fold[Type](generatorSettings.jsonType)(raw => SwaggerUtil.typeName(raw, model.map(_.getFormat), model.flatMap(ScalaType(_))))
       typeAlias(clsName, tpe)
     }
   }
@@ -220,41 +269,37 @@ object ProtocolGenerator {
     } yield ret
   }
 
-  case class ClassHierarchy(parentName: String, parentModel: ModelImpl, children: List[(String, ComposedModel)])
+  case class ClassHierarchy(parentName: String, parentModel: Model, discriminator: String)
 
   /**
     * returns objects grouped into hierarchies
     */
   def groupHierarchies(definitions: List[(String, Model)]): List[ClassHierarchy] = {
 
-    // parent -> child
-    val children: Map[String, List[(String, ComposedModel)]] = definitions
-      .map {
-        case (clsName, comp: ComposedModel) if comp.getInterfaces.asScala.headOption.map(_.getSimpleRef).isDefined =>
-          val parentName = comp.getInterfaces.asScala.headOption.map(_.getSimpleRef).get
-          Some((parentName, (clsName, comp)))
+    def firstInHierarchy(model: Model): Option[ModelImpl] =
+      (model match {
+        case elem: ComposedModel =>
+          definitions.collectFirst {
+            case (clsName, element) if elem.getInterfaces.asScala.headOption.exists(_.getSimpleRef == clsName) => element
+          }
         case _ => None
+      }) match {
+        case Some(x: ComposedModel) => firstInHierarchy(x)
+        case Some(x: ModelImpl)     => Some(x)
+        case _                      => None
       }
-      .collect { case Some(x) => x }
-      .groupBy(_._1)
-      .mapValues(_.map(_._2))
 
-    val parents: Map[String, ModelImpl] = definitions
-      .map { // Fixme here should be List
-        case (clsName, impl: ModelImpl) if Option(impl.getDiscriminator).isDefined =>
-          Some((clsName, impl))
-        case _ => None
+    definitions
+      .collect {
+        case (clsName, comp: ComposedModel) if definitions.exists {
+              case (_, m: ComposedModel) => m.getInterfaces.asScala.headOption.exists(_.getSimpleRef == clsName)
+              case _                     => false
+            } =>
+          ClassHierarchy(clsName, comp, firstInHierarchy(comp).get.getDiscriminator) //todo unsafe
+        case (clsName, model: ModelImpl) if Option(model.getDiscriminator).isDefined =>
+          ClassHierarchy(clsName, model, model.getDiscriminator)
       }
-      .collect { case Some(x) => x }
-      .toMap
 
-    parents
-      .map {
-        case (parentName, model) =>
-          children.get(parentName).map(children => ClassHierarchy(parentName, model, children))
-      }
-      .collect { case Some(x) => x }
-      .toList
   }
 
   def fromSwagger[F[_]](swagger: Swagger)(
@@ -275,24 +320,37 @@ object ProtocolGenerator {
 
     val hierarchies = groupHierarchies(definitions)
 
+    // todo without trait
     val definitionsWithoutPoly: List[(String, Model)] = definitions.filter { // filter out polymorphic definitions
-      case (_, _: ComposedModel)                                     => false
+      case (clsName, _: ComposedModel) if definitions.exists {
+            case (_, m: ComposedModel) => m.getInterfaces.asScala.headOption.exists(_.getSimpleRef == clsName)
+            case _                     => false
+          } =>
+        false
       case (_, m: ModelImpl) if Option(m.getDiscriminator).isDefined => false
       case _                                                         => true
     }
 
     for {
       concreteTypes <- extractConcreteTypes(definitions)
-      polyADTs      <- hierarchies.traverse(fromPoly(_, concreteTypes))
+      polyADTs      <- hierarchies.traverse(fromPoly(_, concreteTypes, definitions))
       elems <- definitionsWithoutPoly.traverse {
         case (clsName, model) =>
           model match {
             case m: ModelImpl =>
               for {
-                enum  <- fromEnum(clsName, m)
-                model <- fromModel(clsName, m, concreteTypes)
-                alias <- modelTypeAlias(clsName, m)
+                enum    <- fromEnum(clsName, m)
+                parents <- extractParents(m, definitions, concreteTypes)
+                model   <- fromModel(clsName, m, parents, concreteTypes)
+                alias   <- modelTypeAlias(clsName, m)
               } yield enum.orElse(model).getOrElse(alias)
+
+            case comp: ComposedModel =>
+              for {
+                parents <- extractParents(comp, definitions, concreteTypes)
+                model   <- fromModel(clsName, comp, parents, concreteTypes)
+                alias   <- modelTypeAlias(clsName, comp)
+              } yield model.getOrElse(alias)
 
             case arr: ArrayModel =>
               fromArray(clsName, arr, concreteTypes)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
@@ -121,7 +121,7 @@ object ProtocolGenerator {
       definition <- renderSealedTrait(hierarchy.parentName, terms, discriminator, parents)
       encoder    <- encodeADT(hierarchy.parentName, children)
       decoder    <- decodeADT(hierarchy.parentName, children)
-      cmp        <- renderADTCompanion(hierarchy.parentName, needCamelSnakeConversion, discriminator, encoder, decoder)
+      cmp        <- renderADTCompanion(hierarchy.parentName, discriminator, encoder, decoder)
 
     } yield {
       ADT(
@@ -194,7 +194,6 @@ object ProtocolGenerator {
       * so essentially we have to return false if:
       *   - there are any uppercase characters
       */
-
     for {
       props <- extractProperties(model)
       needCamelSnakeConversion = props.forall { case (k, _) => couldBeSnakeCase(k) }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
@@ -224,7 +224,7 @@ object ProtocolGenerator {
     }
     getGeneratorSettings().flatMap { implicit generatorSettings =>
       val tpe = model
-        .map(_.getType)
+        .flatMap(model => Option(model.getType))
         .fold[Type](generatorSettings.jsonType)(
           raw => SwaggerUtil.typeName(raw, model.flatMap(f => Option(f.getFormat)), model.flatMap(ScalaType(_)))
         )

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
@@ -241,7 +241,9 @@ object ProtocolGenerator {
     getGeneratorSettings().flatMap { implicit generatorSettings =>
       val tpe = model
         .map(_.getType)
-        .fold[Type](generatorSettings.jsonType)(raw => SwaggerUtil.typeName(raw, model.map(_.getFormat), model.flatMap(ScalaType(_))))
+        .fold[Type](generatorSettings.jsonType)(
+          raw => SwaggerUtil.typeName(raw, model.flatMap(f => Option(f.getFormat)), model.flatMap(ScalaType(_)))
+        )
       typeAlias(clsName, tpe)
     }
   }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/circe/protocol/CirceProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/circe/protocol/CirceProtocolGenerator.scala
@@ -167,7 +167,7 @@ object CirceProtocolGenerator {
         }
 
       case RenderDTOClass(clsName, selfTerms, parents) =>
-        val discriminator = parents.collectFirst { case SuperClass(_, _, _, Some(discriminator)) => discriminator }
+        val discriminator = parents.find(_.discriminator.isDefined).flatMap(_.discriminator) //collectFirst { case SuperClass(_, _, _, Some(discriminator)) => discriminator }
         val parentNameOpt = parents.headOption.map(_.clsName)
         val terms = (parents.flatMap(_.params.map(_.term)) ++ selfTerms).filterNot(
           param => discriminator.contains(param.name.value)
@@ -181,7 +181,7 @@ object CirceProtocolGenerator {
         Target.pure(code)
 
       case EncodeModel(clsName, needCamelSnakeConversion, selfParams, parents) =>
-        val discriminator = parents.collectFirst { case SuperClass(_, _, _, Some(discriminator)) => discriminator }
+        val discriminator = parents.find(_.discriminator.isDefined).flatMap(_.discriminator)
         val params = (parents.flatMap(_.params) ++ selfParams).filterNot(
           param => discriminator.contains(param.name)
         )
@@ -232,7 +232,7 @@ object CirceProtocolGenerator {
         """)
 
       case DecodeModel(clsName, needCamelSnakeConversion, selfParams, parents) =>
-        val discriminator = parents.collectFirst { case SuperClass(_, _, _, Some(discriminator)) => discriminator }
+        val discriminator = parents.find(_.discriminator.isDefined).flatMap(_.discriminator)
         val params = (parents.flatMap(_.params) ++ selfParams).filterNot(
           param => discriminator.contains(param.name)
         )

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/circe/protocol/CirceProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/circe/protocol/CirceProtocolGenerator.scala
@@ -366,7 +366,7 @@ object CirceProtocolGenerator {
           }
 
         Target.pure(
-          parentNameOpt.fold(q"""sealed trait ${Type.Name(className)} {..${testTerms}}""")(
+          parentNameOpt.fold(q"""trait ${Type.Name(className)} {..${testTerms}}""")(
             parentName =>
               q"""trait ${Type.Name(className)} extends ${template"${init"${Type.Name(parentName)}(...$Nil)"}{..${testTerms}}"} """
           )

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/circe/protocol/CirceProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/circe/protocol/CirceProtocolGenerator.scala
@@ -368,7 +368,7 @@ object CirceProtocolGenerator {
         Target.pure(
           parentNameOpt.fold(q"""sealed trait ${Type.Name(className)} {..${testTerms}}""")(
             parentName =>
-              q"""sealed trait ${Type.Name(className)} extends ${template"${init"${Type.Name(parentName)}(...$Nil)"}{..${testTerms}}"} """
+              q"""trait ${Type.Name(className)} extends ${template"${init"${Type.Name(parentName)}(...$Nil)"}{..${testTerms}}"} """
           )
         )
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/circe/protocol/CirceProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/circe/protocol/CirceProtocolGenerator.scala
@@ -323,12 +323,9 @@ object CirceProtocolGenerator {
 
   object PolyProtocolTermInterp extends (PolyProtocolTerm ~> Target) {
     override def apply[A](fa: PolyProtocolTerm[A]): Target[A] = fa match {
-      case RenderADTCompanion(clsName, needCamelSnakeConversion, discriminator, encoder, decoder) =>
-        val normalizedDiscriminator =
-          if (needCamelSnakeConversion) q"io.circe.derivation.renaming.snakeCase(${Lit.String(discriminator)})"
-          else Lit.String(discriminator)
+      case RenderADTCompanion(clsName, discriminator, encoder, decoder) =>
         val code = q"""object ${Term.Name(clsName)} {
-             val discriminator:String = ${normalizedDiscriminator}
+             val discriminator:String = ${Lit.String(discriminator)}
             ..${List(encoder, decoder)}
           }
           """

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/circe/protocol/CirceProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/circe/protocol/CirceProtocolGenerator.scala
@@ -358,7 +358,16 @@ object CirceProtocolGenerator {
         val testTerms = terms
           .filter(_.name.value != discriminator)
           .map { t =>
-            q"""def ${Term.Name(t.name.value)} : ${t.decltpe.getOrElse(Type.Name("Any"))}"""
+            val tpe: Type = t.decltpe
+              .flatMap({
+                case tpe: Type => Some(tpe)
+                case x =>
+                  println(s"Unsure how to map ${x.structure}, please report this bug!")
+                  None
+              })
+              .get
+
+            q"""def ${Term.Name(t.name.value)} : ${tpe}"""
           }
 
         Target.pure(

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/circe/protocol/CirceProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/circe/protocol/CirceProtocolGenerator.scala
@@ -96,14 +96,11 @@ object CirceProtocolGenerator {
     def apply[T](term: ModelProtocolTerm[T]): Target[T] = term match {
       case ExtractProperties(swagger) =>
         Target.pure(
-          Either.fromOption(
-            (swagger match {
-              case m: ModelImpl        => Option(m.getProperties)
-              case comp: ComposedModel => comp.getAllOf().asScala.toList.get(1).flatMap(prop => Option(prop.getProperties))
-              case _                   => None
-            }).map(_.asScala.toList),
-            "Model has no properties"
-          )
+          (swagger match {
+            case m: ModelImpl        => Option(m.getProperties)
+            case comp: ComposedModel => comp.getAllOf().asScala.toList.get(1).flatMap(prop => Option(prop.getProperties))
+            case _                   => None
+          }).map(_.asScala.toList).toList.flatten
         )
 
       case TransformProperty(clsName, name, property, needCamelSnakeConversion, concreteTypes) =>

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/circe/protocol/CirceProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/circe/protocol/CirceProtocolGenerator.scala
@@ -2,7 +2,7 @@ package com.twilio.guardrail.generators.circe.protocol
 
 import java.util.Locale
 
-import _root_.io.swagger.models.ModelImpl
+import _root_.io.swagger.models.{ ComposedModel, ModelImpl }
 import _root_.io.swagger.models.properties._
 import cats.data.EitherT
 import cats.implicits._
@@ -12,7 +12,7 @@ import com.twilio.guardrail.extract.{ Default, ScalaEmptyIsNull, ScalaType }
 import com.twilio.guardrail.generators.GeneratorSettings
 import com.twilio.guardrail.protocol.terms.protocol._
 import com.twilio.guardrail.swagger.SwaggerUtil
-import com.twilio.guardrail.{ ProtocolParameter, Target }
+import com.twilio.guardrail.{ ProtocolParameter, SupperClass, Target }
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable
@@ -94,17 +94,17 @@ object CirceProtocolGenerator {
 
   object ModelProtocolTermInterp extends (ModelProtocolTerm ~> Target) {
     def apply[T](term: ModelProtocolTerm[T]): Target[T] = term match {
-      case ExtractChildProperties(parent, child, discriminator) =>
-        val allProps = Semigroup[Option[List[(String, Property)]]].combine(
-          Option(parent.getProperties).map(_.asScala.toList),
-          Option(child.getChild.getProperties).map(_.asScala.toList)
-        )
-        val omitDiscriminator = allProps.map(_.filter { case (p, _) => p != discriminator })
-
-        Target.pure(Either.fromOption(omitDiscriminator, "Model has no properties"))
-
       case ExtractProperties(swagger) =>
-        Target.pure(Either.fromOption(Option(swagger.getProperties()).map(_.asScala.toList), "Model has no properties"))
+        Target.pure(
+          Either.fromOption(
+            (swagger match {
+              case m: ModelImpl        => Option(m.getProperties)
+              case comp: ComposedModel => comp.getAllOf().asScala.toList.get(1).flatMap(prop => Option(prop.getProperties))
+              case _                   => None
+            }).map(_.asScala.toList),
+            "Model has no properties"
+          )
+        )
 
       case TransformProperty(clsName, name, property, needCamelSnakeConversion, concreteTypes) =>
         Target.getGeneratorSettings.flatMap { implicit gs =>
@@ -169,15 +169,25 @@ object CirceProtocolGenerator {
           } yield ProtocolParameter(term, name, dep, readOnlyKey, emptyToNullKey)
         }
 
-      case RenderDTOClass(clsName, terms, parentNameOpt) =>
+      case RenderDTOClass(clsName, selfTerms, parents) =>
+        val discriminator = parents.collectFirst { case SupperClass(_, _, _, Some(discriminator)) => discriminator }
+        val parentNameOpt = parents.headOption.map(_.clsName)
+        val terms = (parents.flatMap(_.params.map(_.term)) ++ selfTerms).filterNot(
+          param => discriminator.contains(param.name.value)
+        )
         val code = parentNameOpt
           .fold(q"""case class ${Type.Name(clsName)}(..${terms})""")(
-            parentName => q"""case class ${Type.Name(clsName)}(..${terms}) extends AbstractPet"""
+            parentName =>
+              q"""case class ${Type.Name(clsName)}(..${terms}) extends ${template"${init"${Type.Name(parentName)}(...$Nil)"}"}"""
           )
 
         Target.pure(code)
 
-      case EncodeModel(clsName, needCamelSnakeConversion, params) =>
+      case EncodeModel(clsName, needCamelSnakeConversion, selfParams, parents) =>
+        val discriminator = parents.collectFirst { case SupperClass(_, _, _, Some(discriminator)) => discriminator }
+        val params = (parents.flatMap(_.params) ++ selfParams).filterNot(
+          param => discriminator.contains(param.name)
+        )
         val readOnlyKeys: List[String] = params.flatMap(_.readOnlyKey).toList
         val paramCount                 = params.length
         val typeName                   = Type.Name(clsName)
@@ -224,7 +234,11 @@ object CirceProtocolGenerator {
           }
         """)
 
-      case DecodeModel(clsName, needCamelSnakeConversion, params) =>
+      case DecodeModel(clsName, needCamelSnakeConversion, selfParams, parents) =>
+        val discriminator = parents.collectFirst { case SupperClass(_, _, _, Some(discriminator)) => discriminator }
+        val params = (parents.flatMap(_.params) ++ selfParams).filterNot(
+          param => discriminator.contains(param.name)
+        )
         val emptyToNullKeys: List[String] = params.flatMap(_.emptyToNullKey).toList
         val paramCount                    = params.length
         val decVal = if (paramCount <= 22 && emptyToNullKeys.isEmpty) {
@@ -342,16 +356,22 @@ object CirceProtocolGenerator {
 
         Target.pure(code)
 
-      case RenderSealedTrait(className, terms, discriminator: String) =>
+      case RenderSealedTrait(className, terms, discriminator, parents) =>
+        val parentNameOpt = parents.headOption.map(_.clsName)
+        //fixme: Discriminator shouldn't be rendered
         val testTerms = terms
           .filter(_.name.value != discriminator)
           .map { t =>
             q"""def ${Term.Name(t.name.value)} : ${t.decltpe.getOrElse(Type.Name("Any"))}"""
           }
 
-        Target.pure {
-          q"""sealed trait ${Type.Name(className)} {..$testTerms}"""
-        }
+        Target.pure(
+          parentNameOpt.fold(q"""sealed trait ${Type.Name(className)} {..${testTerms}}""")(
+            parentName =>
+              q"""sealed trait ${Type.Name(className)} extends ${template"${init"${Type.Name(parentName)}(...$Nil)"}{..${testTerms}}"} """
+          )
+        )
+
     }
   }
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/circe/protocol/CirceProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/circe/protocol/CirceProtocolGenerator.scala
@@ -12,7 +12,7 @@ import com.twilio.guardrail.extract.{ Default, ScalaEmptyIsNull, ScalaType }
 import com.twilio.guardrail.generators.GeneratorSettings
 import com.twilio.guardrail.protocol.terms.protocol._
 import com.twilio.guardrail.swagger.SwaggerUtil
-import com.twilio.guardrail.{ ProtocolParameter, SupperClass, Target }
+import com.twilio.guardrail.{ ProtocolParameter, SuperClass, Target }
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable
@@ -167,7 +167,7 @@ object CirceProtocolGenerator {
         }
 
       case RenderDTOClass(clsName, selfTerms, parents) =>
-        val discriminator = parents.collectFirst { case SupperClass(_, _, _, Some(discriminator)) => discriminator }
+        val discriminator = parents.collectFirst { case SuperClass(_, _, _, Some(discriminator)) => discriminator }
         val parentNameOpt = parents.headOption.map(_.clsName)
         val terms = (parents.flatMap(_.params.map(_.term)) ++ selfTerms).filterNot(
           param => discriminator.contains(param.name.value)
@@ -181,7 +181,7 @@ object CirceProtocolGenerator {
         Target.pure(code)
 
       case EncodeModel(clsName, needCamelSnakeConversion, selfParams, parents) =>
-        val discriminator = parents.collectFirst { case SupperClass(_, _, _, Some(discriminator)) => discriminator }
+        val discriminator = parents.collectFirst { case SuperClass(_, _, _, Some(discriminator)) => discriminator }
         val params = (parents.flatMap(_.params) ++ selfParams).filterNot(
           param => discriminator.contains(param.name)
         )
@@ -232,7 +232,7 @@ object CirceProtocolGenerator {
         """)
 
       case DecodeModel(clsName, needCamelSnakeConversion, selfParams, parents) =>
-        val discriminator = parents.collectFirst { case SupperClass(_, _, _, Some(discriminator)) => discriminator }
+        val discriminator = parents.collectFirst { case SuperClass(_, _, _, Some(discriminator)) => discriminator }
         val params = (parents.flatMap(_.params) ++ selfParams).filterNot(
           param => discriminator.contains(param.name)
         )

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerm.scala
@@ -2,7 +2,7 @@ package com.twilio.guardrail.protocol.terms.protocol
 
 import _root_.io.swagger.models.{ ComposedModel, Model, ModelImpl }
 import _root_.io.swagger.models.properties.Property
-import com.twilio.guardrail.{ ProtocolParameter, SupperClass }
+import com.twilio.guardrail.{ ProtocolParameter, SuperClass }
 import com.twilio.guardrail.generators.GeneratorSettings
 
 import scala.meta._
@@ -18,17 +18,17 @@ case class TransformProperty(
     concreteTypes: List[PropMeta]
 ) extends ModelProtocolTerm[ProtocolParameter]
 
-case class RenderDTOClass(clsName: String, terms: List[Term.Param], parents: List[SupperClass] = Nil) extends ModelProtocolTerm[Defn.Class]
+case class RenderDTOClass(clsName: String, terms: List[Term.Param], parents: List[SuperClass] = Nil) extends ModelProtocolTerm[Defn.Class]
 case class EncodeModel(
     clsName: String,
     needCamelSnakeConversion: Boolean,
     params: List[ProtocolParameter],
-    parents: List[SupperClass] = Nil
+    parents: List[SuperClass] = Nil
 ) extends ModelProtocolTerm[Stat]
 case class DecodeModel(
     clsName: String,
     needCamelSnakeConversion: Boolean,
     params: List[ProtocolParameter],
-    parents: List[SupperClass] = Nil
+    parents: List[SuperClass] = Nil
 ) extends ModelProtocolTerm[Stat]
 case class RenderDTOCompanion(clsName: String, deps: List[Term.Name], encoder: Stat, decoder: Stat) extends ModelProtocolTerm[Defn.Object]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerm.scala
@@ -8,7 +8,7 @@ import com.twilio.guardrail.generators.GeneratorSettings
 import scala.meta._
 
 sealed trait ModelProtocolTerm[T]
-case class ExtractProperties(swagger: Model) extends ModelProtocolTerm[Either[String, List[(String, Property)]]]
+case class ExtractProperties(swagger: Model) extends ModelProtocolTerm[List[(String, Property)]]
 
 case class TransformProperty(
     clsName: String,

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerm.scala
@@ -1,16 +1,14 @@
 package com.twilio.guardrail.protocol.terms.protocol
 
-import _root_.io.swagger.models.{ ComposedModel, ModelImpl }
+import _root_.io.swagger.models.{ ComposedModel, Model, ModelImpl }
 import _root_.io.swagger.models.properties.Property
-import com.twilio.guardrail.ProtocolParameter
+import com.twilio.guardrail.{ ProtocolParameter, SupperClass }
 import com.twilio.guardrail.generators.GeneratorSettings
 
 import scala.meta._
 
 sealed trait ModelProtocolTerm[T]
-case class ExtractProperties(swagger: ModelImpl) extends ModelProtocolTerm[Either[String, List[(String, Property)]]]
-case class ExtractChildProperties(parent: ModelImpl, child: ComposedModel, discriminator: String)
-    extends ModelProtocolTerm[Either[String, List[(String, Property)]]]
+case class ExtractProperties(swagger: Model) extends ModelProtocolTerm[Either[String, List[(String, Property)]]]
 
 case class TransformProperty(
     clsName: String,
@@ -20,7 +18,17 @@ case class TransformProperty(
     concreteTypes: List[PropMeta]
 ) extends ModelProtocolTerm[ProtocolParameter]
 
-case class RenderDTOClass(clsName: String, terms: List[Term.Param], parentName: Option[String])             extends ModelProtocolTerm[Defn.Class]
-case class EncodeModel(clsName: String, needCamelSnakeConversion: Boolean, params: List[ProtocolParameter]) extends ModelProtocolTerm[Stat]
-case class DecodeModel(clsName: String, needCamelSnakeConversion: Boolean, params: List[ProtocolParameter]) extends ModelProtocolTerm[Stat]
-case class RenderDTOCompanion(clsName: String, deps: List[Term.Name], encoder: Stat, decoder: Stat)         extends ModelProtocolTerm[Defn.Object]
+case class RenderDTOClass(clsName: String, terms: List[Term.Param], parents: List[SupperClass] = Nil) extends ModelProtocolTerm[Defn.Class]
+case class EncodeModel(
+    clsName: String,
+    needCamelSnakeConversion: Boolean,
+    params: List[ProtocolParameter],
+    parents: List[SupperClass] = Nil
+) extends ModelProtocolTerm[Stat]
+case class DecodeModel(
+    clsName: String,
+    needCamelSnakeConversion: Boolean,
+    params: List[ProtocolParameter],
+    parents: List[SupperClass] = Nil
+) extends ModelProtocolTerm[Stat]
+case class RenderDTOCompanion(clsName: String, deps: List[Term.Name], encoder: Stat, decoder: Stat) extends ModelProtocolTerm[Defn.Object]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerms.scala
@@ -10,7 +10,7 @@ import scala.meta._
 
 class ModelProtocolTerms[F[_]](implicit I: InjectK[ModelProtocolTerm, F]) {
 
-  def extractProperties(swagger: Model): Free[F, Either[String, List[(String, Property)]]] =
+  def extractProperties(swagger: Model): Free[F, List[(String, Property)]] =
     Free.inject[ModelProtocolTerm, F](ExtractProperties(swagger))
 
   def transformProperty(clsName: String, needCamelSnakeConversion: Boolean, concreteTypes: List[PropMeta])(

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerms.scala
@@ -1,25 +1,17 @@
 package com.twilio.guardrail.protocol.terms.protocol
 
-import _root_.io.swagger.models.{ ComposedModel, ModelImpl }
+import _root_.io.swagger.models.{ ComposedModel, Model, ModelImpl }
 import _root_.io.swagger.models.properties.Property
 import cats.InjectK
 import cats.free.Free
-import com.twilio.guardrail.ProtocolParameter
+import com.twilio.guardrail.{ ProtocolParameter, SupperClass }
 
 import scala.meta._
 
 class ModelProtocolTerms[F[_]](implicit I: InjectK[ModelProtocolTerm, F]) {
 
-  def extractProperties(swagger: ModelImpl): Free[F, Either[String, List[(String, Property)]]] =
+  def extractProperties(swagger: Model): Free[F, Either[String, List[(String, Property)]]] =
     Free.inject[ModelProtocolTerm, F](ExtractProperties(swagger))
-
-  // For ADTs
-  def extractChildProperties(
-      parent: ModelImpl,
-      child: ComposedModel,
-      discriminator: String
-  ): Free[F, Either[String, List[(String, Property)]]] =
-    Free.inject[ModelProtocolTerm, F](ExtractChildProperties(parent, child, discriminator))
 
   def transformProperty(clsName: String, needCamelSnakeConversion: Boolean, concreteTypes: List[PropMeta])(
       name: String,
@@ -27,14 +19,24 @@ class ModelProtocolTerms[F[_]](implicit I: InjectK[ModelProtocolTerm, F]) {
   ): Free[F, ProtocolParameter] =
     Free.inject[ModelProtocolTerm, F](TransformProperty(clsName, name, prop, needCamelSnakeConversion, concreteTypes))
 
-  def renderDTOClass(clsName: String, terms: List[Term.Param], parentName: Option[String]): Free[F, Defn.Class] =
-    Free.inject[ModelProtocolTerm, F](RenderDTOClass(clsName, terms, parentName))
+  def renderDTOClass(clsName: String, terms: List[Term.Param], parents: List[SupperClass] = Nil): Free[F, Defn.Class] =
+    Free.inject[ModelProtocolTerm, F](RenderDTOClass(clsName, terms, parents))
 
-  def encodeModel(clsName: String, needCamelSnakeConversion: Boolean, params: List[ProtocolParameter]): Free[F, Stat] =
-    Free.inject[ModelProtocolTerm, F](EncodeModel(clsName, needCamelSnakeConversion, params))
+  def encodeModel(
+      clsName: String,
+      needCamelSnakeConversion: Boolean,
+      params: List[ProtocolParameter],
+      parents: List[SupperClass] = Nil
+  ): Free[F, Stat] =
+    Free.inject[ModelProtocolTerm, F](EncodeModel(clsName, needCamelSnakeConversion, params, parents))
 
-  def decodeModel(clsName: String, needCamelSnakeConversion: Boolean, params: List[ProtocolParameter]): Free[F, Stat] =
-    Free.inject[ModelProtocolTerm, F](DecodeModel(clsName, needCamelSnakeConversion, params))
+  def decodeModel(
+      clsName: String,
+      needCamelSnakeConversion: Boolean,
+      params: List[ProtocolParameter],
+      parents: List[SupperClass] = Nil
+  ): Free[F, Stat] =
+    Free.inject[ModelProtocolTerm, F](DecodeModel(clsName, needCamelSnakeConversion, params, parents))
 
   def renderDTOCompanion(clsName: String, deps: List[Term.Name], encoder: Stat, decoder: Stat): Free[F, Defn.Object] =
     Free.inject[ModelProtocolTerm, F](RenderDTOCompanion(clsName, deps, encoder, decoder))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerms.scala
@@ -4,7 +4,7 @@ import _root_.io.swagger.models.{ ComposedModel, Model, ModelImpl }
 import _root_.io.swagger.models.properties.Property
 import cats.InjectK
 import cats.free.Free
-import com.twilio.guardrail.{ ProtocolParameter, SupperClass }
+import com.twilio.guardrail.{ ProtocolParameter, SuperClass }
 
 import scala.meta._
 
@@ -19,14 +19,14 @@ class ModelProtocolTerms[F[_]](implicit I: InjectK[ModelProtocolTerm, F]) {
   ): Free[F, ProtocolParameter] =
     Free.inject[ModelProtocolTerm, F](TransformProperty(clsName, name, prop, needCamelSnakeConversion, concreteTypes))
 
-  def renderDTOClass(clsName: String, terms: List[Term.Param], parents: List[SupperClass] = Nil): Free[F, Defn.Class] =
+  def renderDTOClass(clsName: String, terms: List[Term.Param], parents: List[SuperClass] = Nil): Free[F, Defn.Class] =
     Free.inject[ModelProtocolTerm, F](RenderDTOClass(clsName, terms, parents))
 
   def encodeModel(
       clsName: String,
       needCamelSnakeConversion: Boolean,
       params: List[ProtocolParameter],
-      parents: List[SupperClass] = Nil
+      parents: List[SuperClass] = Nil
   ): Free[F, Stat] =
     Free.inject[ModelProtocolTerm, F](EncodeModel(clsName, needCamelSnakeConversion, params, parents))
 
@@ -34,7 +34,7 @@ class ModelProtocolTerms[F[_]](implicit I: InjectK[ModelProtocolTerm, F]) {
       clsName: String,
       needCamelSnakeConversion: Boolean,
       params: List[ProtocolParameter],
-      parents: List[SupperClass] = Nil
+      parents: List[SuperClass] = Nil
   ): Free[F, Stat] =
     Free.inject[ModelProtocolTerm, F](DecodeModel(clsName, needCamelSnakeConversion, params, parents))
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/PolyProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/PolyProtocolTerm.scala
@@ -1,7 +1,7 @@
 package com.twilio.guardrail.protocol.terms.protocol
 import cats.InjectK
 import cats.free.Free
-import com.twilio.guardrail.{ ProtocolParameter, SupperClass }
+import com.twilio.guardrail.{ ProtocolParameter, SuperClass }
 
 import scala.meta.{ Defn, Stat, Term }
 
@@ -10,7 +10,7 @@ import scala.meta.{ Defn, Stat, Term }
   */
 sealed trait PolyProtocolTerm[T]
 
-case class RenderSealedTrait(className: String, terms: List[Term.Param], discriminator: String, parents: List[SupperClass] = Nil)
+case class RenderSealedTrait(className: String, terms: List[Term.Param], discriminator: String, parents: List[SuperClass] = Nil)
     extends PolyProtocolTerm[Defn.Trait]
 
 case class EncodeADT(clsName: String, children: List[String] = Nil) extends PolyProtocolTerm[Stat]
@@ -24,7 +24,7 @@ class PolyProtocolTerms[F[_]](implicit I: InjectK[PolyProtocolTerm, F]) {
       className: String,
       terms: List[Term.Param],
       discriminator: String,
-      parents: List[SupperClass] = Nil
+      parents: List[SuperClass] = Nil
   ): Free[F, Defn.Trait] =
     Free.inject[PolyProtocolTerm, F](RenderSealedTrait(className, terms, discriminator, parents))
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/PolyProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/PolyProtocolTerm.scala
@@ -13,13 +13,12 @@ sealed trait PolyProtocolTerm[T]
 case class RenderSealedTrait(className: String, terms: List[Term.Param], discriminator: String, parents: List[SupperClass] = Nil)
     extends PolyProtocolTerm[Defn.Trait]
 
-case class EncodeADT(clsName: String, needCamelSnakeConversion: Boolean) extends PolyProtocolTerm[Stat]
+case class EncodeADT(clsName: String, children: List[String] = Nil) extends PolyProtocolTerm[Stat]
 
-case class DecodeADT(clsName: String, needCamelSnakeConversion: Boolean) extends PolyProtocolTerm[Stat]
+case class DecodeADT(clsName: String, children: List[String] = Nil) extends PolyProtocolTerm[Stat]
 
-case class RenderDiscriminator(discriminator: String) extends PolyProtocolTerm[Stat]
-
-case class RenderADTCompanion(clsName: String, discriminator: Stat, encoder: Stat, decoder: Stat) extends PolyProtocolTerm[Defn.Object]
+case class RenderADTCompanion(clsName: String, needCamelSnakeConversion: Boolean, discriminator: String, encoder: Stat, decoder: Stat)
+    extends PolyProtocolTerm[Defn.Object]
 
 class PolyProtocolTerms[F[_]](implicit I: InjectK[PolyProtocolTerm, F]) {
   def renderSealedTrait(
@@ -30,17 +29,20 @@ class PolyProtocolTerms[F[_]](implicit I: InjectK[PolyProtocolTerm, F]) {
   ): Free[F, Defn.Trait] =
     Free.inject[PolyProtocolTerm, F](RenderSealedTrait(className, terms, discriminator, parents))
 
-  def encodeADT(clsName: String, needCamelSnakeConversion: Boolean): Free[F, Stat] =
-    Free.inject[PolyProtocolTerm, F](EncodeADT(clsName, needCamelSnakeConversion))
+  def encodeADT(clsName: String, children: List[String] = Nil): Free[F, Stat] =
+    Free.inject[PolyProtocolTerm, F](EncodeADT(clsName, children))
 
-  def decodeADT(clsName: String, needCamelSnakeConversion: Boolean): Free[F, Stat] =
-    Free.inject[PolyProtocolTerm, F](DecodeADT(clsName, needCamelSnakeConversion))
+  def decodeADT(clsName: String, children: List[String] = Nil): Free[F, Stat] =
+    Free.inject[PolyProtocolTerm, F](DecodeADT(clsName, children))
 
-  def renderDiscriminator(discriminator: String): Free[F, Stat] =
-    Free.inject[PolyProtocolTerm, F](RenderDiscriminator(discriminator))
-
-  def renderADTCompanion(clsName: String, discriminator: Stat, encoder: Stat, decoder: Stat): Free[F, Defn.Object] =
-    Free.inject[PolyProtocolTerm, F](RenderADTCompanion(clsName, discriminator, encoder, decoder))
+  def renderADTCompanion(
+      clsName: String,
+      needCamelSnakeConversion: Boolean,
+      discriminator: String,
+      encoder: Stat,
+      decoder: Stat
+  ): Free[F, Defn.Object] =
+    Free.inject[PolyProtocolTerm, F](RenderADTCompanion(clsName, needCamelSnakeConversion, discriminator, encoder, decoder))
 
 }
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/PolyProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/PolyProtocolTerm.scala
@@ -17,8 +17,7 @@ case class EncodeADT(clsName: String, children: List[String] = Nil) extends Poly
 
 case class DecodeADT(clsName: String, children: List[String] = Nil) extends PolyProtocolTerm[Stat]
 
-case class RenderADTCompanion(clsName: String, needCamelSnakeConversion: Boolean, discriminator: String, encoder: Stat, decoder: Stat)
-    extends PolyProtocolTerm[Defn.Object]
+case class RenderADTCompanion(clsName: String, discriminator: String, encoder: Stat, decoder: Stat) extends PolyProtocolTerm[Defn.Object]
 
 class PolyProtocolTerms[F[_]](implicit I: InjectK[PolyProtocolTerm, F]) {
   def renderSealedTrait(
@@ -37,12 +36,11 @@ class PolyProtocolTerms[F[_]](implicit I: InjectK[PolyProtocolTerm, F]) {
 
   def renderADTCompanion(
       clsName: String,
-      needCamelSnakeConversion: Boolean,
       discriminator: String,
       encoder: Stat,
       decoder: Stat
   ): Free[F, Defn.Object] =
-    Free.inject[PolyProtocolTerm, F](RenderADTCompanion(clsName, needCamelSnakeConversion, discriminator, encoder, decoder))
+    Free.inject[PolyProtocolTerm, F](RenderADTCompanion(clsName, discriminator, encoder, decoder))
 
 }
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/PolyProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/PolyProtocolTerm.scala
@@ -1,6 +1,8 @@
 package com.twilio.guardrail.protocol.terms.protocol
 import cats.InjectK
 import cats.free.Free
+import com.twilio.guardrail.{ ProtocolParameter, SupperClass }
+
 import scala.meta.{ Defn, Stat, Term }
 
 /**
@@ -8,7 +10,8 @@ import scala.meta.{ Defn, Stat, Term }
   */
 sealed trait PolyProtocolTerm[T]
 
-case class RenderSealedTrait(className: String, terms: List[Term.Param], discriminator: String) extends PolyProtocolTerm[Defn.Trait]
+case class RenderSealedTrait(className: String, terms: List[Term.Param], discriminator: String, parents: List[SupperClass] = Nil)
+    extends PolyProtocolTerm[Defn.Trait]
 
 case class EncodeADT(clsName: String, needCamelSnakeConversion: Boolean) extends PolyProtocolTerm[Stat]
 
@@ -19,8 +22,13 @@ case class RenderDiscriminator(discriminator: String) extends PolyProtocolTerm[S
 case class RenderADTCompanion(clsName: String, discriminator: Stat, encoder: Stat, decoder: Stat) extends PolyProtocolTerm[Defn.Object]
 
 class PolyProtocolTerms[F[_]](implicit I: InjectK[PolyProtocolTerm, F]) {
-  def renderSealedTrait(className: String, terms: List[Term.Param], discriminator: String): Free[F, Defn.Trait] =
-    Free.inject[PolyProtocolTerm, F](RenderSealedTrait(className, terms, discriminator))
+  def renderSealedTrait(
+      className: String,
+      terms: List[Term.Param],
+      discriminator: String,
+      parents: List[SupperClass] = Nil
+  ): Free[F, Defn.Trait] =
+    Free.inject[PolyProtocolTerm, F](RenderSealedTrait(className, terms, discriminator, parents))
 
   def encodeADT(clsName: String, needCamelSnakeConversion: Boolean): Free[F, Stat] =
     Free.inject[PolyProtocolTerm, F](EncodeADT(clsName, needCamelSnakeConversion))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/swagger/SwaggerUtil.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/swagger/SwaggerUtil.scala
@@ -114,6 +114,8 @@ object SwaggerUtil {
                 Resolved(t"IndexedSeq[$tpe]", None, None)
               case EnumDefinition(name, tpe, elems, cls, companion) =>
                 Resolved(t"IndexedSeq[$tpe]", None, None)
+              case ADT(_, tpe, _, _) =>
+                Resolved(t"IndexedSeq[$tpe]", None, None)
             }
         case DeferredMap(name) =>
           Target
@@ -124,6 +126,8 @@ object SwaggerUtil {
               case ClassDefinition(_, tpe, _, _, _) =>
                 Resolved(t"Map[String, $tpe]", None, None)
               case EnumDefinition(_, tpe, _, _, _) =>
+                Resolved(t"Map[String, $tpe]", None, None)
+              case ADT(_, tpe, _, _) =>
                 Resolved(t"Map[String, $tpe]", None, None)
             }
       }

--- a/modules/sample/src/main/resources/polymorphism.yaml
+++ b/modules/sample/src/main/resources/polymorphism.yaml
@@ -3,18 +3,25 @@ info:
   title: Parsing Error Sample
   version: 1.0.0
 paths:
-  /pet:
+  /pet/{name}:
     get:
-      operationId: getPets
+      operationId: getPet
+      parameters:
+        - $ref: '#/parameters/PetNamePathParam'
       responses:
         200:
           description: Return the details about the pet
           schema:
-            $ref: '#/definitions/AbstractPet'
+            $ref: '#/definitions/Pet'
 parameters:
-
+  PetNamePathParam:
+    name: name
+    description: Unique name of the pet
+    in: path
+    type: string
+    required: true
 definitions:
-  AbstractPet:
+  Pet:
     type: object
     discriminator: petType
     properties:
@@ -25,11 +32,10 @@ definitions:
     required:
     - name
     - petType
-
   Cat:
     description: A representation of a cat
     allOf:
-    - $ref: '#/definitions/AbstractPet'
+    - $ref: '#/definitions/Pet'
     - type: object
       properties:
         huntingSkill:
@@ -43,11 +49,10 @@ definitions:
           - aggressive
       required:
       - huntingSkill
-
   Dog:
     description: A representation of a dog
     allOf:
-    - $ref: '#/definitions/AbstractPet'
+    - $ref: '#/definitions/Pet'
     - type: object
       properties:
         packSize:

--- a/src/test/scala/core/issues/Issue43.scala
+++ b/src/test/scala/core/issues/Issue43.scala
@@ -362,7 +362,7 @@ class Issue43 extends FunSpec with Matchers with SwaggerSpecRunner {
       ProtocolDefinitions(ClassDefinition(cls, _, defCls, _, _) :: ADT(_, _, _, _) :: Nil, _, _, _),
       _,
       _
-      ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     cls shouldBe "Cat"
     defCls.structure shouldBe q"""case class Cat(name: String) extends Pet""".structure

--- a/src/test/scala/core/issues/Issue43.scala
+++ b/src/test/scala/core/issues/Issue43.scala
@@ -130,7 +130,7 @@ class Issue43 extends FunSpec with Matchers with SwaggerSpecRunner {
     }
 
     it("should generate parent as trait") {
-      trtPet.structure shouldBe q"sealed trait Pet { def name: String }".structure
+      trtPet.structure shouldBe q"trait Pet { def name: String }".structure
     }
 
     it("should be right parent companion object") {
@@ -289,9 +289,9 @@ class Issue43 extends FunSpec with Matchers with SwaggerSpecRunner {
     }
 
     it("should generate parent as trait") {
-      trtPet.structure shouldBe q"sealed trait Pet { def name: String }".structure
+      trtPet.structure shouldBe q"trait Pet { def name: String }".structure
       println(trtCat.toString())
-      trtCat.structure shouldBe q"sealed trait Cat extends Pet { def huntingSkill: String }".structure
+      trtCat.structure shouldBe q"trait Cat extends Pet { def huntingSkill: String }".structure
     }
 
     it("should be right parent companion object") {

--- a/src/test/scala/core/issues/Issue43.scala
+++ b/src/test/scala/core/issues/Issue43.scala
@@ -1,0 +1,310 @@
+package tests.core.issues
+
+import com.twilio.guardrail.generators.AkkaHttp
+import com.twilio.guardrail.tests._
+import com.twilio.guardrail._
+import org.scalatest.{ FunSpec, FunSuite, Matchers }
+import support.SwaggerSpecRunner
+
+import scala.meta._
+
+class Issue43 extends FunSpec with Matchers with SwaggerSpecRunner {
+
+  describe("Generate hierarchical classes") {
+
+    val swagger: String = """
+      | swagger: '2.0'
+      | info:
+      |   title: Parsing Error Sample
+      |   version: 1.0.0
+      | paths:
+      |   /pet/{name}:
+      |     get:
+      |       operationId: getPet
+      |       parameters:
+      |         - $ref: '#/parameters/PetNamePathParam'
+      |       responses:
+      |         200:
+      |           description: Return the details about the pet
+      |           schema:
+      |             $ref: '#/definitions/Pet'
+      | parameters:
+      |   PetNamePathParam:
+      |     name: name
+      |     description: Unique name of the pet
+      |     in: path
+      |     type: string
+      |     required: true
+      | definitions:
+      |   Pet:
+      |     type: object
+      |     discriminator: petType
+      |     properties:
+      |       name:
+      |         type: string
+      |       petType:
+      |         type: string
+      |     required:
+      |     - name
+      |     - petType
+      |   Cat:
+      |     description: A representation of a cat
+      |     allOf:
+      |     - $ref: '#/definitions/Pet'
+      |     - type: object
+      |       properties:
+      |         huntingSkill:
+      |           type: string
+      |           description: The measured skill for hunting
+      |           default: lazy
+      |           enum:
+      |           - clueless
+      |           - lazy
+      |           - adventurous
+      |           - aggressive
+      |       required:
+      |       - huntingSkill
+      |   Dog:
+      |     description: A representation of a dog
+      |     allOf:
+      |     - $ref: '#/definitions/Pet'
+      |     - type: object
+      |       properties:
+      |         packSize:
+      |           type: integer
+      |           format: int32
+      |           description: the size of the pack the dog is from
+      |           default: 0
+      |           minimum: 0
+      |       required:
+      |       - packSize""".stripMargin
+
+    val (
+      ProtocolDefinitions(
+        ClassDefinition(nameCat, tpeCat, clsCat, companionCat, catParents) :: ClassDefinition(nameDog, tpeDog, _, _, _) :: ADT(
+          namePet,
+          tpePet,
+          trtPet,
+          companion
+        ) :: Nil,
+        _,
+        _,
+        _
+      ),
+      _,
+      _
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
+
+    it("should generate right name of pets") {
+      nameCat shouldBe "Cat"
+      nameDog shouldBe "Dog"
+      namePet shouldBe "Pet"
+    }
+
+    it("should be right type of pets") {
+      tpeCat.structure shouldBe t"Cat".structure
+      tpeDog.structure shouldBe t"Dog".structure
+      tpePet.structure shouldBe t"Pet".structure
+    }
+
+    it("should be parent-child relationship") {
+      catParents.length shouldBe 1
+      catParents.headOption.map(_.clsName) shouldBe Some("Pet")
+    }
+
+    it("should generate right case class") {
+      clsCat.structure shouldBe q"""case class Cat(name: String, huntingSkill: String = "lazy") extends Pet""".structure
+    }
+
+    it("should generate right companion object") {
+      companionCat.toString.replaceAll("\n", "") shouldBe
+        """object Cat {
+          |  implicit val encodeCat = {
+          |    val readOnlyKeys = Set[String]()
+          |    Encoder.forProduct2("name", "huntingSkill") { (o: Cat) => (o.name, o.huntingSkill) }.mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
+          |  }
+          |  implicit val decodeCat = Decoder.forProduct2("name", "huntingSkill")(Cat.apply _)
+          |}
+          |
+          |""".stripMargin.replaceAll("\n", "")
+    }
+
+    it("should generate parent as trait") {
+      trtPet.structure shouldBe q"sealed trait Pet { def name: String }".structure
+    }
+
+    it("should be right parent companion object") {
+      companion.structure shouldBe q"""object Pet {
+      implicit val encoder: Encoder[Pet] = deriveEncoder[Pet]
+      implicit val decoder: Decoder[Pet] = deriveDecoder[Pet]
+    }""".structure
+    }
+
+  }
+
+  describe("Generate deep hierarchical classes") {
+
+    val swagger: String = """
+     | swagger: '2.0'
+     | info:
+     |   title: Parsing Error Sample
+     |   version: 1.0.0
+     | paths:
+     |   /pet/{name}:
+     |     get:
+     |       operationId: getPet
+     |       parameters:
+     |         - $ref: '#/parameters/PetNamePathParam'
+     |       responses:
+     |         200:
+     |           description: Return the details about the pet
+     |           schema:
+     |             $ref: '#/definitions/Pet'
+     | parameters:
+     |   PetNamePathParam:
+     |     name: name
+     |     description: Unique name of the pet
+     |     in: path
+     |     type: string
+     |     required: true
+     | definitions:
+     |   Pet:
+     |     type: object
+     |     discriminator: petType
+     |     properties:
+     |       name:
+     |         type: string
+     |       petType:
+     |         type: string
+     |     required:
+     |     - name
+     |     - petType
+     |   Cat:
+     |     description: A representation of a cat
+     |     allOf:
+     |     - $ref: '#/definitions/Pet'
+     |     - type: object
+     |       properties:
+     |         huntingSkill:
+     |           type: string
+     |           description: The measured skill for hunting
+     |           default: lazy
+     |           enum:
+     |           - clueless
+     |           - lazy
+     |           - adventurous
+     |           - aggressive
+     |       required:
+     |       - huntingSkill
+     |   PersianCat:
+     |     description: A representation of a cat
+     |     allOf:
+     |     - $ref: '#/definitions/Cat'
+     |     - type: object
+     |       properties:
+     |         wool:
+     |           type: integer
+     |           format: int32
+     |           description: The length of wool
+     |           default: 10
+     |   Dog:
+     |     description: A representation of a dog
+     |     allOf:
+     |     - $ref: '#/definitions/Pet'
+     |     - type: object
+     |       properties:
+     |         packSize:
+     |           type: integer
+     |           format: int32
+     |           description: the size of the pack the dog is from
+     |           default: 0
+     |           minimum: 0
+     |       required:
+     |       - packSize""".stripMargin
+
+    val (
+      ProtocolDefinitions(
+        ClassDefinition(namePersianCat, tpePersianCat, clsPersianCat, companionPersianCat, persianCatParents)
+          :: ClassDefinition(nameDog, tpeDog, clsDog, companionDog, dogParents)
+          :: ADT(namePet, tpePet, trtPet, companionPet) :: ADT(nameCat, tpeCat, trtCat, companionCat) :: Nil,
+        _,
+        _,
+        _
+      ),
+      _,
+      _
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
+
+    it("should generate right name of pets") {
+      namePet shouldBe "Pet"
+      nameDog shouldBe "Dog"
+      nameCat shouldBe "Cat"
+      namePersianCat shouldBe "PersianCat"
+    }
+
+    it("should be right type of pets") {
+      tpeCat.structure shouldBe t"Cat".structure
+      tpeDog.structure shouldBe t"Dog".structure
+      tpePersianCat.structure shouldBe t"PersianCat".structure
+      tpePet.structure shouldBe t"Pet".structure
+    }
+
+    it("should be parent-child relationship") {
+
+      dogParents.length shouldBe 1
+      dogParents.headOption.map(_.clsName) shouldBe Some("Pet")
+
+      persianCatParents.length shouldBe 2
+      persianCatParents.map(_.clsName) shouldBe List("Cat", "Pet")
+
+    }
+
+    it("should generate right case class") {
+      clsDog.structure shouldBe q"""case class Dog(name: String, packSize: Int = 0) extends Pet""".structure
+      println(persianCatParents)
+      clsPersianCat.structure shouldBe q"""case class PersianCat(huntingSkill: String = "lazy", name: String, wool: Option[Int] = Option(10)) extends Cat""".structure
+    }
+
+    it("should generate right companion object") {
+      companionDog.toString.replaceAll("\n", "") shouldBe
+        """object Dog {
+          |  implicit val encodeDog = {
+          |    val readOnlyKeys = Set[String]()
+          |    Encoder.forProduct2("name", "packSize") { (o: Dog) => (o.name, o.packSize) }.mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
+          |  }
+          |  implicit val decodeDog = Decoder.forProduct2("name", "packSize")(Dog.apply _)
+          |}
+          |
+          |""".stripMargin.replaceAll("\n", "")
+      companionPersianCat.toString.replaceAll("\n", "") shouldBe
+        """object PersianCat {
+          |  implicit val encodePersianCat = {
+          |    val readOnlyKeys = Set[String]()
+          |    Encoder.forProduct3("huntingSkill", "name", "wool") { (o: PersianCat) => (o.huntingSkill, o.name, o.wool) }.mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
+          |  }
+          |  implicit val decodePersianCat = Decoder.forProduct3("huntingSkill", "name", "wool")(PersianCat.apply _)
+          |}
+          |
+          |""".stripMargin.replaceAll("\n", "")
+    }
+
+    it("should generate parent as trait") {
+      trtPet.structure shouldBe q"sealed trait Pet { def name: String }".structure
+      println(trtCat.toString())
+      trtCat.structure shouldBe q"sealed trait Cat extends Pet { def huntingSkill: String }".structure
+    }
+
+    it("should be right parent companion object") {
+      companionPet.structure shouldBe q"""object Pet {
+      implicit val encoder: Encoder[Pet] = deriveEncoder[Pet]
+      implicit val decoder: Decoder[Pet] = deriveDecoder[Pet]
+    }""".structure
+      companionCat.structure shouldBe q"""object Cat {
+      implicit val encoder: Encoder[Cat] = deriveEncoder[Cat]
+      implicit val decoder: Decoder[Cat] = deriveDecoder[Cat]
+    }""".structure
+    }
+
+  }
+
+}


### PR DESCRIPTION
The current implementation mistakenly believes that inheritance can only be a one-level.
It's look like wrong decision. A class can inherit from another class while the parent class can also be inherited from some class.

for instance:
`A -> B -> C`

It is more correct to save the hierarchy of inheritance not in the parent but in the child.

In this implementation was made couple common changes
first:
`case class ADT(name: String, tpe: Type.Name, trt: Defn.Trait, companion: Defn.Object) extends StrictProtocolElems` - field child was removed
second:
`case class ClassDefinition(name: String, tpe: Type.Name, cls: Defn.Class, companion: Defn.Object, parents: List[SupperClass] = Nil)
    extends StrictProtocolElems` - field parents was added

This solves the problem deep-inheritance.

I hope. It'll help you.
