### PR TITLE
Error reporting and logging

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ReadSwagger.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ReadSwagger.scala
@@ -6,16 +6,24 @@ import cats._
 import java.nio.file.Path
 import scala.io.AnsiColor
 import scala.util.Try
+import cats.syntax.either._
 
 case class ReadSwagger[T](path: Path, next: Swagger => T)
 object ReadSwagger {
+  @deprecated("0.37.1", "Hiding the error result prevents build tools from failing on file read")
   def unsafeReadSwagger[T: Monoid](rs: ReadSwagger[T]): T =
-    (for {
-      absolutePath <- Try(rs.path.toAbsolutePath.toString).toOption
-      swagger      <- Option(new SwaggerParser().read(absolutePath))
-    } yield rs.next(swagger))
-      .getOrElse {
-        println(s"${AnsiColor.RED}Spec file ${rs.path} is either incorrectly formatted or missing.${AnsiColor.RESET}")
+    readSwagger(rs)
+      .fold({ err =>
+        println(s"${AnsiColor.RED}${err}${AnsiColor.RESET}")
         Monoid.empty[T]
-      }
+      }, identity)
+
+  def readSwagger[T](rs: ReadSwagger[T]): Either[String, T] =
+    Either.fromOption(
+      (for {
+        absolutePath <- Try(rs.path.toAbsolutePath.toString).toOption
+        swagger      <- Option(new SwaggerParser().read(absolutePath))
+      } yield rs.next(swagger)),
+      s"Spec file ${rs.path} is either incorrectly formatted or missing."
+    )
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/WriteTree.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/WriteTree.scala
@@ -1,5 +1,7 @@
 package com.twilio.guardrail
 
+import cats.data.{ Writer, WriterT }
+import cats.implicits._
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.{ Files, Path, StandardOpenOption }
 import scala.io.AnsiColor
@@ -7,39 +9,47 @@ import scala.meta._
 
 case class WriteTree(path: Path, contents: Tree)
 object WriteTree {
-  val unsafeWriteTree: WriteTree => Path = {
+  val unsafeWriteTreeLogged: WriteTree => Writer[List[String], Path] = {
     case WriteTree(path, tree) =>
       val UTF8 = java.nio.charset.Charset.availableCharsets.get("UTF-8")
       val data = tree.syntax.getBytes(UTF8)
       Files.createDirectories(path.getParent)
-      if (Files.exists(path)) {
-        val exists: Array[Byte] = Files.readAllBytes(path)
-        val diffIdx: Option[Int] =
-          exists
-            .zip(data)
-            .zipWithIndex
-            .find({ case ((a, b), _) => a != b })
-            .map(_._2)
-            .orElse(Some(Math.max(exists.length, data.length)))
-            .filterNot(Function.const(data.length == exists.length))
+      for {
+        _ <- if (Files.exists(path)) {
+          val exists: Array[Byte] = Files.readAllBytes(path)
+          val diffIdx: Option[Int] =
+            exists
+              .zip(data)
+              .zipWithIndex
+              .find({ case ((a, b), _) => a != b })
+              .map(_._2)
+              .orElse(Some(Math.max(exists.length, data.length)))
+              .filterNot(Function.const(data.length == exists.length))
 
-        diffIdx.foreach { diffIdx =>
-          val existSample = new String(exists, UTF_8)
-            .slice(Math.max(diffIdx - 10, diffIdx), Math.max(diffIdx - 10, diffIdx) + 50)
-            .replace("\n", "\\n")
-          val newSample = new String(data, UTF_8)
-            .slice(Math.max(diffIdx - 10, diffIdx), Math.max(diffIdx - 10, diffIdx) + 50)
-            .replace("\n", "\\n")
+          diffIdx.traverse { diffIdx =>
+            val existSample = new String(exists, UTF_8)
+              .slice(Math.max(diffIdx - 10, diffIdx), Math.max(diffIdx - 10, diffIdx) + 50)
+              .replace("\n", "\\n")
+            val newSample = new String(data, UTF_8)
+              .slice(Math.max(diffIdx - 10, diffIdx), Math.max(diffIdx - 10, diffIdx) + 50)
+              .replace("\n", "\\n")
 
-          System.err.println(s"""|
-          |${AnsiColor.RED}Warning:${AnsiColor.RESET}
-          |  The file $path contained different content than was expected.
-          |
-          |  Existing file: $existSample
-          |  New file     : $newSample
-          |""".stripMargin)
-        }
-      }
-      Files.write(path, data, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)
+            Writer.tell(List(s"""|
+            |${AnsiColor.RED}Warning:${AnsiColor.RESET}
+            |  The file $path contained different content than was expected.
+            |
+            |  Existing file: $existSample
+            |  New file     : $newSample
+            |""".stripMargin))
+          }
+        } else Writer(List.empty[String], Option.empty[Unit])
+      } yield Files.write(path, data, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)
   }
+
+  val unsafeWriteTree: WriteTree => Path =
+    unsafeWriteTreeLogged.map {
+      case WriterT((lines, path)) =>
+        lines.foreach(System.err.println(_))
+        path
+    }
 }


### PR DESCRIPTION
This provides non-`println` versions of `unsafeReadSwagger` and `unsafeWriteTree` for use in build tools
Primary motivator is to make the sbt plugin fail if it can't read specification files