### PR TITLE
Sort routes to ensure deterministic output

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
@@ -40,15 +40,17 @@ object ServerGenerator {
     val basePath: Option[String] = Option(swagger.getBasePath)
 
     for {
-      routes           <- extractOperations(paths)
-      classNamedRoutes <- routes.traverse(route => getClassName(route.operation).map(_ -> route))
+      routes <- extractOperations(paths)
+      classNamedRoutes <- routes
+        .traverse(route => getClassName(route.operation).map(_ -> route))
       groupedRoutes = classNamedRoutes
         .groupBy(_._1)
         .mapValues(_.map(_._2))
         .toList
       extraImports <- getExtraImports(context.tracing)
       servers <- groupedRoutes.traverse {
-        case (className, routes) =>
+        case (className, unsortedRoutes) =>
+          val routes       = unsortedRoutes.sortBy(r => (r.path, r.method))
           val resourceName = formatClassName(className.lastOption.getOrElse(""))
           val handlerName =
             formatHandlerName(className.lastOption.getOrElse(""))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
@@ -201,11 +201,16 @@ object AkkaHttpServerGenerator {
             .groupBy(_._1)
             .flatMap({
               case (tpe, (_, name) :: Nil) =>
-                Some(q"implicit def ${Term
-                  .Name(s"${name.value}Ev")}(value: ${tpe}): ${responseSuperType} = ${name}(value)")
-              case _ => None
+                Some(tpe -> name)
+              case _ =>
+                None
             })
             .toList
+            .sortBy(_._2.value)
+            .map {
+              case (tpe, name) =>
+                q"implicit def ${Term.Name(s"${name.value}Ev")}(value: ${tpe}): ${responseSuperType} = ${name}(value)"
+            }
 
           companion = q"""
             object ${responseSuperTerm} {


### PR DESCRIPTION
I've been getting increasingly frustrated with my play project continually recompiling my guardrail routes and finally dug in to find out what was happening. In short, there are a couple of places in the route generation pipeline for akka http server that use groupBy and never sort the results, producing non-determinstic ordering in the Routes.scala files, causing the Scala compiler to have to compile and slow everything down.

I've hacked in sorting on the places I've found, and it resolves my issue. The failing tests are due to hardcoded output in a different order. I'm not sure how you're getting ahold of the generated .scala files to put in the tests so I thought I'd throw this up for comment.

Fixes https://github.com/twilio/sbt-guardrail/issues/8