### PR TITLE
Resolving bug where formData with only parameter would cause runtime failures

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,6 +69,7 @@ fullRunTask(
   --client --specPath modules/sample/src/main/resources/formData.yaml --outputPath modules/sample/src/main/scala --packageName form.client.akkaHttp --framework akka-http
   --server --specPath modules/sample/src/main/resources/formData.yaml --outputPath modules/sample/src/main/scala --packageName form.server.http4s --framework http4s
   --server --specPath modules/sample/src/main/resources/formData.yaml --outputPath modules/sample/src/main/scala --packageName form.server.akkaHttp --framework akka-http
+  --server --specPath modules/sample/src/main/resources/issues/issue127.yaml --outputPath modules/sample/src/main/scala --packageName issues.issue127
 """.replaceAllLiterally("\n", " ").split(' ').filter(_.nonEmpty): _*
 )
 

--- a/modules/codegen/src/test/scala/core/issues/Issue127.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue127.scala
@@ -1,0 +1,161 @@
+package tests.core.issues
+
+import _root_.io.swagger.parser.SwaggerParser
+import cats.instances.all._
+import com.twilio.swagger._
+import com.twilio.guardrail.generators.AkkaHttp
+import com.twilio.guardrail.{ Context, Server, Servers }
+import com.twilio.guardrail.tests._
+import org.scalatest.{ FunSuite, Matchers }
+import support.SwaggerSpecRunner
+
+import scala.meta._
+
+class Issue127 extends FunSuite with Matchers with SwaggerSpecRunner {
+  val swagger: String = s"""
+    |swagger: '2.0'
+    |host: localhost:1234
+    |schemes:
+    |- http
+    |paths:
+    |  /file:
+    |    post:
+    |      operationId: uploadFile
+    |      parameters:
+    |      - name: file
+    |        description: File to upload
+    |        in: formData
+    |        type: file
+    |        required: true
+    |      consumes:
+    |      - multipart/form-data
+    |      responses:
+    |        '201':
+    |          description: Success
+    |""".stripMargin
+
+  test("Generate plain array alias definition") {
+    val (
+      _,
+      _,
+      Servers(Server(pkg, extraImports, genHandler :: genResource :: Nil) :: Nil)
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
+
+    val handler = q"""
+      trait Handler {
+        def uploadFile(respond: Resource.uploadFileResponse.type)(file: (File, Option[String], ContentType)): scala.concurrent.Future[Resource.uploadFileResponse]
+        def uploadFileMapFileField(fieldName: String, fileName: Option[String], contentType: ContentType): File
+        def uploadFileUnmarshalToFile[F[_]: Functor](hashType: F[String], destFn: (String, Option[String], ContentType) => File)(implicit mat: Materializer): Unmarshaller[Multipart.FormData.BodyPart, (File, Option[String], ContentType, F[String])] = Unmarshaller { implicit executionContext =>
+          part => {
+            val dest = destFn(part.name, part.filename, part.entity.contentType)
+            val messageDigest = hashType.map(MessageDigest.getInstance(_))
+            val fileSink: Sink[ByteString, Future[IOResult]] = FileIO.toPath(dest.toPath).contramap[ByteString] { chunk =>
+              val _ = messageDigest.map(_.update(chunk.toArray[Byte]))
+              chunk
+            }
+            part.entity.dataBytes.toMat(fileSink)(Keep.right).run().transform({
+              case IOResult(_, Success(_)) =>
+                val hash = messageDigest.map(md => javax.xml.bind.DatatypeConverter.printHexBinary(md.digest()).toLowerCase(java.util.Locale.US))
+                (dest, part.filename, part.entity.contentType, hash)
+              case IOResult(_, Failure(t)) =>
+                throw t
+            }, {
+              case t =>
+                dest.delete()
+                t
+            })
+          }
+        }
+      }
+    """
+
+    val resource = q"""
+      object Resource {
+        def discardEntity(implicit mat: akka.stream.Materializer): Directive0 = extractRequest.flatMap { req =>
+          req.discardEntityBytes().future
+          Directive.Empty
+        }
+        def routes(handler: Handler)(implicit mat: akka.stream.Materializer): Route = {
+          (post & path("file") & ({
+            object uploadFileParts {
+              sealed trait Part
+              case class IgnoredPart(unit: Unit) extends Part
+              case class file(value: (File, Option[String], ContentType)) extends Part
+            }
+            val UnmarshalfilePart: Unmarshaller[Multipart.FormData.BodyPart, uploadFileParts.file] = handler.uploadFileUnmarshalToFile[Option](None, handler.uploadFileMapFileField(_, _, _)).map({
+              case (v1, v2, v3, v4) =>
+                uploadFileParts.file((v1, v2, v3))
+            })
+            extractExecutionContext.flatMap { implicit executionContext =>
+              extractMaterializer.flatMap { implicit mat =>
+                entity(as[Multipart.FormData]).flatMap { formData =>
+                  val fileReferences = new AtomicReference(List.empty[File])
+                  val collectedPartsF: Future[Either[Throwable, Tuple1[Option[(File, Option[String], ContentType)]]]] = for (results <- formData.parts.mapConcat {
+                    part => if (Set[String]("file").contains(part.name)) part :: Nil else {
+                      part.entity.discardBytes()
+                      Nil
+                    }
+                  }.mapAsync(1) { part =>
+                    {
+                      part.name match {
+                        case "file" =>
+                          SafeUnmarshaller(AccumulatingUnmarshaller(fileReferences, UnmarshalfilePart)(_.value._1)).apply(part)
+                        case _ =>
+                          SafeUnmarshaller(implicitly[Unmarshaller[Multipart.FormData.BodyPart, Unit]].map(uploadFileParts.IgnoredPart.apply(_))).apply(part)
+                      }
+                    }
+                  }.toMat(Sink.seq[Either[Throwable, uploadFileParts.Part]])(Keep.right).run()) yield {
+                    results.toList.sequence.map { successes =>
+                      val fileO = successes.collectFirst({
+                        case uploadFileParts.file((v1, v2, v3)) =>
+                          (v1, v2, v3)
+                      })
+                      Tuple1(fileO)
+                    }
+                  }
+                  handleExceptions(ExceptionHandler({
+                    case e: Throwable =>
+                      fileReferences.get().foreach(_.delete())
+                      throw e
+                  })) & handleRejections { (rejections: scala.collection.immutable.Seq[Rejection]) =>
+                    fileReferences.get().foreach(_.delete())
+                    None
+                  } & mapResponse { resp =>
+                    fileReferences.get().foreach(_.delete())
+                    resp
+                  } & onSuccess(collectedPartsF)
+                }
+              }
+            }.flatMap(_.fold(t => throw t, {
+              case Tuple1(fileO) =>
+                val maybe: Either[Rejection, Tuple1[(File, Option[String], ContentType)]] = for (file <- fileO.toRight(MissingFormFieldRejection("file"))) yield {
+                  Tuple1(file)
+                }
+                maybe.fold(reject(_), tprovide(_))
+            }))
+          }: Directive[Tuple1[(File, Option[String], ContentType)]])) {
+            file => complete(handler.uploadFile(uploadFileResponse)(file))
+          }
+        }
+        sealed abstract class uploadFileResponse(val statusCode: StatusCode)
+        case object uploadFileResponseCreated extends uploadFileResponse(StatusCodes.Created)
+        object uploadFileResponse {
+          implicit val uploadFileTRM: ToResponseMarshaller[uploadFileResponse] = Marshaller { implicit ec =>
+            resp => uploadFileTR(resp)
+          }
+          implicit def uploadFileTR(value: uploadFileResponse)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
+            case r: uploadFileResponseCreated.type =>
+              scala.concurrent.Future.successful(Marshalling.Opaque {
+                () => HttpResponse(r.statusCode)
+              } :: Nil)
+          }
+          def apply[T](value: T)(implicit ev: T => uploadFileResponse): uploadFileResponse = ev(value)
+          def Created: uploadFileResponse = uploadFileResponseCreated
+        }
+      }
+    """
+
+    genHandler.structure shouldBe handler.structure
+    genResource.structure shouldBe resource.structure
+  }
+}

--- a/modules/sample/src/main/resources/issues/issue127.yaml
+++ b/modules/sample/src/main/resources/issues/issue127.yaml
@@ -1,0 +1,19 @@
+swagger: '2.0'
+host: localhost:1234
+schemes:
+- http
+paths:
+  /file:
+    post:
+      operationId: uploadFile
+      parameters:
+      - name: file
+        description: File to upload
+        in: formData
+        type: file
+        required: true
+      consumes:
+      - multipart/form-data
+      responses:
+        '201':
+          description: Success


### PR DESCRIPTION
scala.meta seems to not automatically lift `q"(..${List(q"foo")})"` into `q"Tuple1(foo)"`. This makes sense, though ends up requiring special casing. This PR implements the special casing required.