### PR TITLE
Language abstraction

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -102,6 +102,10 @@ addCommandAlias(
   "; set publishTo in codegen := (sonatypePublishTo in codegen).value; codegen/publishSigned"
 )
 
+resolvers += Resolver.sonatypeRepo("releases")
+addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.8")
+addCompilerPlugin("org.spire-math" % "kind-projector"  % "0.9.8" cross CrossVersion.binary)
+
 publishMavenStyle := true
 
 val testDependencies = Seq(
@@ -109,6 +113,8 @@ val testDependencies = Seq(
 )
 
 val codegenSettings = Seq(
+  addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.8"),
+  addCompilerPlugin("org.spire-math" % "kind-projector"  % "0.9.8" cross CrossVersion.binary),
   libraryDependencies ++= testDependencies ++ Seq(
     "org.scalameta" %% "scalameta"     % "4.0.0",
     "io.swagger"    % "swagger-parser" % "1.0.39",

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ licenses in ThisBuild += ("MIT", url("http://opensource.org/licenses/MIT"))
 enablePlugins(GitVersioning)
 git.useGitDescribe := true
 
-crossScalaVersions := Seq("2.11.12", "2.12.7")
+crossScalaVersions := Seq("2.11.12", "2.12.3")
 scalaVersion in ThisBuild := crossScalaVersions.value.last
 
 scalafmtOnCompile in ThisBuild := true

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ClientGenerator.scala
@@ -7,7 +7,7 @@ import cats.syntax.all._
 import com.twilio.guardrail.protocol.terms.client.{ ClientTerm, ClientTerms }
 
 import scala.collection.JavaConverters._
-import scala.meta.{ Lit, Term, Type, _ }
+import scala.meta.{ Defn, Import, Lit, Stat, Term, Type }
 import com.twilio.guardrail.terms.RouteMeta
 
 case class Clients(clients: List[Client])

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ClientGenerator.scala
@@ -4,7 +4,8 @@ import _root_.io.swagger.models._
 import cats.free.Free
 import cats.instances.all._
 import cats.syntax.all._
-import com.twilio.guardrail.protocol.terms.client.{ ClientTerm, ClientTerms }
+import com.twilio.guardrail.protocol.terms.client.ClientTerms
+import com.twilio.guardrail.languages.ScalaLanguage
 
 import scala.collection.JavaConverters._
 import scala.meta.{ Defn, Import, Lit, Stat, Term, Type }
@@ -23,7 +24,7 @@ object ClientGenerator {
       host: Option[String],
       basePath: Option[String],
       groupedRoutes: List[(List[String], List[RouteMeta])]
-  )(protocolElems: List[StrictProtocolElems])(implicit C: ClientTerms[F]): Free[F, Clients] = {
+  )(protocolElems: List[StrictProtocolElems])(implicit C: ClientTerms[ScalaLanguage, F]): Free[F, Clients] = {
     import C._
     for {
       clientImports      <- getImports(context.tracing)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ClientGenerator.scala
@@ -29,7 +29,7 @@ object ClientGenerator {
       host: Option[String],
       basePath: Option[String],
       groupedRoutes: List[(List[String], List[RouteMeta])]
-  )(protocolElems: List[StrictProtocolElems])(implicit C: ClientTerms[L, F]): Free[F, Clients[L]] = {
+  )(protocolElems: List[StrictProtocolElems[L]])(implicit C: ClientTerms[L, F]): Free[F, Clients[L]] = {
     import C._
     for {
       clientImports      <- getImports(context.tracing)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ClientGenerator.scala
@@ -18,8 +18,6 @@ case class RenderedClientOperation(
 )
 
 object ClientGenerator {
-  type ClientGenerator[A] = ClientTerm[A]
-
   def fromSwagger[F[_]](context: Context, frameworkImports: List[Import])(
       schemes: List[String],
       host: Option[String],

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -171,7 +171,7 @@ object Common {
         case CodegenTarget.Server =>
           for {
             serverMeta <- ServerGenerator
-              .fromSwagger[CodegenApplication](context, swagger, frameworkImports)(protocolElems)
+              .fromSwagger[ScalaLanguage, CodegenApplication](context, swagger, frameworkImports)(protocolElems)
             Servers(servers) = serverMeta
           } yield CodegenDefinitions[ScalaLanguage](List.empty, servers)
       }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -8,15 +8,16 @@ import cats.syntax.either._
 import cats.syntax.semigroup._
 import cats.syntax.traverse._
 import cats.~>
-import com.twilio.guardrail.terms.{ CoreTerm, CoreTerms, ScalaTerms, SwaggerTerms }
-import com.twilio.guardrail.terms.framework.FrameworkTerms
 import com.twilio.guardrail.generators.GeneratorSettings
-import java.nio.file.{ Path, Paths }
+import com.twilio.guardrail.languages.ScalaLanguage
 import com.twilio.guardrail.protocol.terms.protocol.PolyProtocolTerms
-
+import com.twilio.guardrail.terms.framework.FrameworkTerms
+import com.twilio.guardrail.terms.{ CoreTerm, CoreTerms, ScalaTerms, SwaggerTerms }
+import java.nio.file.{ Path, Paths }
 import scala.collection.JavaConverters._
 import scala.io.AnsiColor
 import scala.meta._
+import com.twilio.guardrail.languages.ScalaLanguage
 
 object Common {
   def writePackage(kind: CodegenTarget,
@@ -25,10 +26,10 @@ object Common {
                    outputPath: Path,
                    pkgName: List[String],
                    dtoPackage: List[String],
-                   customImports: List[Import])(implicit F: FrameworkTerms[CodegenApplication],
-                                                Sc: ScalaTerms[CodegenApplication],
-                                                Pol: PolyProtocolTerms[CodegenApplication],
-                                                Sw: SwaggerTerms[CodegenApplication]): Free[CodegenApplication, List[WriteTree]] = {
+                   customImports: List[Import])(implicit F: FrameworkTerms[ScalaLanguage, CodegenApplication],
+                                                Sc: ScalaTerms[ScalaLanguage, CodegenApplication],
+                                                Pol: PolyProtocolTerms[ScalaLanguage, CodegenApplication],
+                                                Sw: SwaggerTerms[ScalaLanguage, CodegenApplication]): Free[CodegenApplication, List[WriteTree]] = {
     import F._
     import Sc._
     import Sw._

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -128,19 +128,14 @@ object Common {
           stat.copy(rhs = q"${companion}.${mirror}")
         })
 
-      packageObject = WriteTree(
-        dtoPackagePath.resolve("package.scala"),
-        source"""package ${dtoPkg}
-            ..${customImports ++ packageObjectImports ++ protocolImports}
-
-            object ${companion} {
-              ..${implicits.map(_.copy(mods = List.empty))}
-            }
-
-            package object ${Term.Name(dtoComponents.last)} {
-              ..${(mirroredImplicits ++ statements ++ extraTypes).to[List]}
-            }
-          """
+      packageObject <- writePackageObject(
+        dtoPackagePath,
+        dtoComponents,
+        customImports,
+        packageObjectImports,
+        protocolImports,
+        packageObjectContents,
+        extraTypes
       )
 
       schemes = Option(swagger.getSchemes)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolElems.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolElems.scala
@@ -2,47 +2,50 @@ package com.twilio.guardrail
 
 import cats.MonadError
 import scala.meta._
+import com.twilio.guardrail.languages.LA
+import com.twilio.guardrail.languages.ScalaLanguage
 
-sealed trait ProtocolElems
+sealed trait ProtocolElems[L <: LA]
 
-sealed trait LazyProtocolElems         extends ProtocolElems { def name: String }
-case class Deferred(name: String)      extends LazyProtocolElems
-case class DeferredArray(name: String) extends LazyProtocolElems
-case class DeferredMap(name: String)   extends LazyProtocolElems
+sealed trait LazyProtocolElems[L <: LA]         extends ProtocolElems[L] { def name: String }
+case class Deferred[L <: LA](name: String)      extends LazyProtocolElems[L]
+case class DeferredArray[L <: LA](name: String) extends LazyProtocolElems[L]
+case class DeferredMap[L <: LA](name: String)   extends LazyProtocolElems[L]
 
-sealed trait StrictProtocolElems                                                                                                   extends ProtocolElems { def name: String }
-case class RandomType(name: String, tpe: Type)                                                                                     extends StrictProtocolElems
-case class ClassDefinition(name: String, tpe: Type.Name, cls: Defn.Class, companion: Defn.Object, parents: List[SuperClass] = Nil) extends StrictProtocolElems
+sealed trait StrictProtocolElems[L <: LA]                 extends ProtocolElems[L] { def name: String }
+case class RandomType[L <: LA](name: String, tpe: L#Type) extends StrictProtocolElems[L]
+case class ClassDefinition[L <: LA](name: String, tpe: L#TypeName, cls: L#ClassDefinition, companion: L#ObjectDefinition, parents: List[SuperClass[L]] = Nil)
+    extends StrictProtocolElems[L]
 
-case class ADT(name: String, tpe: Type.Name, trt: Defn.Trait, companion: Defn.Object) extends StrictProtocolElems
+case class ADT[L <: LA](name: String, tpe: L#TypeName, trt: L#Trait, companion: L#ObjectDefinition) extends StrictProtocolElems[L]
 
-case class EnumDefinition(
+case class EnumDefinition[L <: LA](
     name: String,
-    tpe: Type.Name,
-    elems: List[(String, Term.Name, Term.Select)],
+    tpe: L#TypeName,
+    elems: List[(String, L#TermName, Term.Select)],
     cls: Defn.Class,
     companion: Defn.Object
-) extends StrictProtocolElems
+) extends StrictProtocolElems[L]
 
 object ProtocolElems {
-  def resolve[F[_]](elems: List[ProtocolElems], limit: Int = 10)(implicit M: MonadError[F, String]): F[List[StrictProtocolElems]] =
-    M.tailRecM[(Int, List[ProtocolElems]), List[StrictProtocolElems]]((limit, elems))({
+  def resolve[F[_]](elems: List[ProtocolElems[ScalaLanguage]], limit: Int = 10)(implicit M: MonadError[F, String]): F[List[StrictProtocolElems[ScalaLanguage]]] =
+    M.tailRecM[(Int, List[ProtocolElems[ScalaLanguage]]), List[StrictProtocolElems[ScalaLanguage]]]((limit, elems))({
       case (iters, xs) if iters > 0 =>
-        val lazyElems   = xs.collect { case x: LazyProtocolElems   => x }
-        val strictElems = xs.collect { case x: StrictProtocolElems => x }
+        val lazyElems: List[LazyProtocolElems[ScalaLanguage]]     = xs.collect { case x: LazyProtocolElems[_]   => x }
+        val strictElems: List[StrictProtocolElems[ScalaLanguage]] = xs.collect { case x: StrictProtocolElems[_] => x }
         if (lazyElems.nonEmpty) {
-          val newElems = strictElems ++ lazyElems.map {
+          val newElems: List[ProtocolElems[ScalaLanguage]] = strictElems ++ lazyElems.map {
             case d @ Deferred(name) =>
               strictElems
                 .find(_.name == name)
                 .map({
-                  case RandomType(name, tpe) => RandomType(name, tpe)
+                  case RandomType(name, tpe) => RandomType[ScalaLanguage](name, tpe)
                   case ClassDefinition(name, tpe, cls, companion, _) =>
-                    RandomType(name, tpe)
+                    RandomType[ScalaLanguage](name, tpe)
                   case EnumDefinition(name, tpe, elems, cls, companion) =>
-                    RandomType(name, tpe)
+                    RandomType[ScalaLanguage](name, tpe)
                   case ADT(name, tpe, _, _) =>
-                    RandomType(name, tpe)
+                    RandomType[ScalaLanguage](name, tpe)
                 })
                 .getOrElse(d)
             case d @ DeferredArray(name) =>
@@ -50,13 +53,13 @@ object ProtocolElems {
                 .find(_.name == name)
                 .map({
                   case RandomType(name, tpe) =>
-                    RandomType(name, t"IndexedSeq[${tpe}]")
+                    RandomType[ScalaLanguage](name, t"IndexedSeq[${tpe}]")
                   case ClassDefinition(name, tpe, cls, companion, _) =>
-                    RandomType(name, t"IndexedSeq[${tpe}]")
+                    RandomType[ScalaLanguage](name, t"IndexedSeq[${tpe}]")
                   case EnumDefinition(name, tpe, elems, cls, companion) =>
-                    RandomType(name, t"IndexedSeq[${tpe}]")
+                    RandomType[ScalaLanguage](name, t"IndexedSeq[${tpe}]")
                   case ADT(name, tpe, _, _) =>
-                    RandomType(name, t"IndexedSeq[$tpe]")
+                    RandomType[ScalaLanguage](name, t"IndexedSeq[${tpe}]")
                 })
                 .getOrElse(d)
             case d @ DeferredMap(name) =>
@@ -64,13 +67,13 @@ object ProtocolElems {
                 .find(_.name == name)
                 .map({
                   case RandomType(name, tpe) =>
-                    RandomType(name, t"Map[String, ${tpe}]")
+                    RandomType[ScalaLanguage](name, t"Map[String, ${tpe}]")
                   case ClassDefinition(name, tpe, cls, companion, _) =>
-                    RandomType(name, t"Map[String, ${tpe}]")
+                    RandomType[ScalaLanguage](name, t"Map[String, ${tpe}]")
                   case EnumDefinition(name, tpe, elems, cls, companion) =>
-                    RandomType(name, t"Map[String, ${tpe}]")
+                    RandomType[ScalaLanguage](name, t"Map[String, ${tpe}]")
                   case ADT(name, tpe, _, _) =>
-                    RandomType(name, t"Map[String, $tpe]")
+                    RandomType[ScalaLanguage](name, t"Map[String, ${tpe}]")
                 })
                 .getOrElse(d)
           }
@@ -78,7 +81,7 @@ object ProtocolElems {
           M.pure(Left(next))
         } else M.pure(Right(strictElems))
       case (_, xs) =>
-        val lazyElems = xs.collect { case x: LazyProtocolElems => x }
+        val lazyElems = xs.collect { case x: LazyProtocolElems[_] => x }
         M.raiseError(s"Unable to resolve: ${lazyElems.map(_.name)}")
     })
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
@@ -9,6 +9,7 @@ import com.twilio.guardrail.extract.ScalaType
 import java.util.Locale
 
 import com.twilio.guardrail.generators.GeneratorSettings
+import com.twilio.guardrail.languages.LA
 import com.twilio.guardrail.protocol.terms.protocol._
 import com.twilio.guardrail.terms.framework.FrameworkTerms
 import com.twilio.guardrail.languages.ScalaLanguage
@@ -19,24 +20,28 @@ import scala.language.postfixOps
 import scala.language.reflectiveCalls
 import scala.meta._
 
-case class ProtocolDefinitions(elems: List[StrictProtocolElems],
-                               protocolImports: List[Import],
-                               packageObjectImports: List[Import],
-                               packageObjectContents: List[Defn.Val])
+case class ProtocolDefinitions[L <: LA](elems: List[StrictProtocolElems[L]],
+                                        protocolImports: List[L#Import],
+                                        packageObjectImports: List[L#Import],
+                                        packageObjectContents: List[L#ValueDefinition])
 
-case class ProtocolParameter(term: Term.Param, name: String, dep: Option[Term.Name], readOnlyKey: Option[String], emptyToNullKey: Option[String])
+case class ProtocolParameter[L <: LA](term: L#MethodParameter,
+                                      name: String,
+                                      dep: Option[L#TermName],
+                                      readOnlyKey: Option[String],
+                                      emptyToNullKey: Option[String])
 
-case class SuperClass(
+case class SuperClass[L <: LA](
     clsName: String,
-    tpl: Type,
+    tpl: L#Type,
     interfaces: List[String],
-    params: List[ProtocolParameter],
+    params: List[ProtocolParameter[L]],
     discriminators: List[String]
 )
 
 object ProtocolGenerator {
   private[this] def fromEnum[F[_]](clsName: String, swagger: ModelImpl)(implicit E: EnumProtocolTerms[ScalaLanguage, F],
-                                                                        F: FrameworkTerms[ScalaLanguage, F]): Free[F, Either[String, ProtocolElems]] = {
+                                                                        F: FrameworkTerms[ScalaLanguage, F]): Free[F, Either[String, ProtocolElems[ScalaLanguage]]] = {
     import E._
     import F._
 
@@ -51,7 +56,7 @@ object ProtocolGenerator {
         (accum, regex) => regex.replaceAllIn(accum, m => m.group(1).toUpperCase(Locale.US))
       )
 
-    def validProg(enum: List[String], tpe: Type): Free[F, EnumDefinition] = {
+    def validProg(enum: List[String], tpe: Type): Free[F, EnumDefinition[ScalaLanguage]] = {
       val elems = enum.map { elem =>
         val valueTerm = Term.Name(toPascalCase(elem))
         (elem, valueTerm, q"${Term.Name(clsName)}.$valueTerm")
@@ -64,13 +69,13 @@ object ProtocolGenerator {
             q"val ${Pat.Var(pascalValue)}: ${Type.Name(clsName)} = members.${pascalValue}"
           })
           .to[List]
-        values: Defn.Val = q"val values = Vector(..$pascalValues)"
+        values = q"val values = Vector(..$pascalValues)"
         encoder <- encodeEnum(clsName)
         decoder <- decodeEnum(clsName)
 
         defn      <- renderClass(clsName, tpe)
         companion <- renderCompanion(clsName, members, accessors, values, encoder, decoder)
-      } yield EnumDefinition(clsName, Type.Name(clsName), elems, defn, companion)
+      } yield EnumDefinition[ScalaLanguage](clsName, Type.Name(clsName), elems, defn, companion)
     }
 
     for {
@@ -106,7 +111,7 @@ object ProtocolGenerator {
       hierarchy: ClassParent,
       concreteTypes: List[PropMeta],
       definitions: List[(String, Model)]
-  )(implicit F: FrameworkTerms[ScalaLanguage, F], P: PolyProtocolTerms[ScalaLanguage, F], M: ModelProtocolTerms[ScalaLanguage, F]): Free[F, ProtocolElems] = {
+  )(implicit F: FrameworkTerms[ScalaLanguage, F], P: PolyProtocolTerms[ScalaLanguage, F], M: ModelProtocolTerms[ScalaLanguage, F]): Free[F, ProtocolElems[ScalaLanguage]] = {
     import P._
     import M._
 
@@ -131,7 +136,7 @@ object ProtocolGenerator {
       cmp        <- renderADTCompanion(hierarchy.name, discriminator, encoder, decoder)
 
     } yield {
-      ADT(
+      ADT[ScalaLanguage](
         name = hierarchy.name,
         tpe = Type.Name(hierarchy.name),
         trt = definition,
@@ -144,7 +149,7 @@ object ProtocolGenerator {
       implicit M: ModelProtocolTerms[ScalaLanguage, F],
       F: FrameworkTerms[ScalaLanguage, F],
       P: PolyProtocolTerms[ScalaLanguage, F]
-  ): Free[F, List[SuperClass]] = {
+  ): Free[F, List[SuperClass[ScalaLanguage]]] = {
     import M._
     import P._
 
@@ -168,7 +173,7 @@ object ProtocolGenerator {
           params <- props.traverse(transformProperty(clsName, needCamelSnakeConversion, concreteTypes) _ tupled)
           interfacesCls = interfaces.map(_.getSimpleRef)
         } yield
-          SuperClass(
+          SuperClass[ScalaLanguage](
             clsName,
             Type.Name(clsName),
             interfacesCls,
@@ -182,10 +187,10 @@ object ProtocolGenerator {
     } yield supper
   }
 
-  private[this] def fromModel[F[_]](clsName: String, model: Model, parents: List[SuperClass], concreteTypes: List[PropMeta])(
+  private[this] def fromModel[F[_]](clsName: String, model: Model, parents: List[SuperClass[ScalaLanguage]], concreteTypes: List[PropMeta])(
       implicit M: ModelProtocolTerms[ScalaLanguage, F],
       F: FrameworkTerms[ScalaLanguage, F]
-  ): Free[F, Either[String, ProtocolElems]] = {
+  ): Free[F, Either[String, ProtocolElems[ScalaLanguage]]] = {
     import M._
     import F._
 
@@ -201,13 +206,13 @@ object ProtocolGenerator {
       cmp     <- renderDTOCompanion(clsName, List.empty, encoder, decoder)
     } yield
       if (parents.isEmpty && props.isEmpty) Left("Entity isn't model")
-      else Right(ClassDefinition(clsName, Type.Name(clsName), defn, cmp, parents))
+      else Right(ClassDefinition[ScalaLanguage](clsName, Type.Name(clsName), defn, cmp, parents))
   }
 
   def modelTypeAlias[F[_]](clsName: String, abstractModel: Model)(
       implicit A: AliasProtocolTerms[ScalaLanguage, F],
       F: FrameworkTerms[ScalaLanguage, F]
-  ): Free[F, ProtocolElems] = {
+  ): Free[F, ProtocolElems[ScalaLanguage]] = {
     import F._
     val model = abstractModel match {
       case m: ModelImpl => Some(m)
@@ -228,20 +233,20 @@ object ProtocolGenerator {
     }
   }
 
-  def plainTypeAlias[F[_]](clsName: String)(implicit A: AliasProtocolTerms[ScalaLanguage, F], F: FrameworkTerms[ScalaLanguage, F]): Free[F, ProtocolElems] = {
+  def plainTypeAlias[F[_]](clsName: String)(implicit A: AliasProtocolTerms[ScalaLanguage, F], F: FrameworkTerms[ScalaLanguage, F]): Free[F, ProtocolElems[ScalaLanguage]] = {
     import F._
     getGeneratorSettings().flatMap { implicit generatorSettings =>
       typeAlias(clsName, generatorSettings.jsonType)
     }
   }
 
-  def typeAlias[F[_]](clsName: String, tpe: Type)(implicit A: AliasProtocolTerms[ScalaLanguage, F]): Free[F, ProtocolElems] = {
+  def typeAlias[F[_]](clsName: String, tpe: Type)(implicit A: AliasProtocolTerms[ScalaLanguage, F]): Free[F, ProtocolElems[ScalaLanguage]] = {
     import A._
-    Free.pure(RandomType(clsName, tpe))
+    Free.pure(RandomType[ScalaLanguage](clsName, tpe))
   }
 
   def fromArray[F[_]](clsName: String, arr: ArrayModel, concreteTypes: List[PropMeta])(implicit R: ArrayProtocolTerms[ScalaLanguage, F],
-                                                                                       A: AliasProtocolTerms[ScalaLanguage, F]): Free[F, ProtocolElems] = {
+                                                                                                A: AliasProtocolTerms[ScalaLanguage, F]): Free[F, ProtocolElems[ScalaLanguage]] = {
     import R._
     for {
       tpe <- extractArrayType(arr, concreteTypes)
@@ -308,7 +313,7 @@ object ProtocolGenerator {
       S: ProtocolSupportTerms[ScalaLanguage, F],
       F: FrameworkTerms[ScalaLanguage, F],
       P: PolyProtocolTerms[ScalaLanguage, F]
-  ): Free[F, ProtocolDefinitions] = {
+  ): Free[F, ProtocolDefinitions[ScalaLanguage]] = {
     import S._
     import F._
     import P._
@@ -360,6 +365,6 @@ object ProtocolGenerator {
 
       polyADTElems <- resolveProtocolElems(polyADTs)
       strictElems  <- resolveProtocolElems(elems)
-    } yield ProtocolDefinitions(strictElems ++ polyADTElems, protoImports, pkgImports, pkgObjectContents)
+    } yield ProtocolDefinitions[ScalaLanguage](strictElems ++ polyADTElems, protoImports, pkgImports, pkgObjectContents)
   }
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
@@ -11,6 +11,7 @@ import java.util.Locale
 import com.twilio.guardrail.generators.GeneratorSettings
 import com.twilio.guardrail.protocol.terms.protocol._
 import com.twilio.guardrail.terms.framework.FrameworkTerms
+import com.twilio.guardrail.languages.ScalaLanguage
 
 import scala.collection.JavaConverters._
 import scala.language.higherKinds
@@ -34,8 +35,8 @@ case class SuperClass(
 )
 
 object ProtocolGenerator {
-  private[this] def fromEnum[F[_]](clsName: String, swagger: ModelImpl)(implicit E: EnumProtocolTerms[F],
-                                                                        F: FrameworkTerms[F]): Free[F, Either[String, ProtocolElems]] = {
+  private[this] def fromEnum[F[_]](clsName: String, swagger: ModelImpl)(implicit E: EnumProtocolTerms[ScalaLanguage, F],
+                                                                        F: FrameworkTerms[ScalaLanguage, F]): Free[F, Either[String, ProtocolElems]] = {
     import E._
     import F._
 
@@ -105,7 +106,7 @@ object ProtocolGenerator {
       hierarchy: ClassParent,
       concreteTypes: List[PropMeta],
       definitions: List[(String, Model)]
-  )(implicit F: FrameworkTerms[F], P: PolyProtocolTerms[F], M: ModelProtocolTerms[F]): Free[F, ProtocolElems] = {
+  )(implicit F: FrameworkTerms[ScalaLanguage, F], P: PolyProtocolTerms[ScalaLanguage, F], M: ModelProtocolTerms[ScalaLanguage, F]): Free[F, ProtocolElems] = {
     import P._
     import M._
 
@@ -140,9 +141,9 @@ object ProtocolGenerator {
   }
 
   def extractParents[F[_]](elem: Model, definitions: List[(String, Model)], concreteTypes: List[PropMeta])(
-      implicit M: ModelProtocolTerms[F],
-      F: FrameworkTerms[F],
-      P: PolyProtocolTerms[F]
+      implicit M: ModelProtocolTerms[ScalaLanguage, F],
+      F: FrameworkTerms[ScalaLanguage, F],
+      P: PolyProtocolTerms[ScalaLanguage, F]
   ): Free[F, List[SuperClass]] = {
     import M._
     import P._
@@ -182,8 +183,8 @@ object ProtocolGenerator {
   }
 
   private[this] def fromModel[F[_]](clsName: String, model: Model, parents: List[SuperClass], concreteTypes: List[PropMeta])(
-      implicit M: ModelProtocolTerms[F],
-      F: FrameworkTerms[F]
+      implicit M: ModelProtocolTerms[ScalaLanguage, F],
+      F: FrameworkTerms[ScalaLanguage, F]
   ): Free[F, Either[String, ProtocolElems]] = {
     import M._
     import F._
@@ -204,8 +205,8 @@ object ProtocolGenerator {
   }
 
   def modelTypeAlias[F[_]](clsName: String, abstractModel: Model)(
-      implicit A: AliasProtocolTerms[F],
-      F: FrameworkTerms[F]
+      implicit A: AliasProtocolTerms[ScalaLanguage, F],
+      F: FrameworkTerms[ScalaLanguage, F]
   ): Free[F, ProtocolElems] = {
     import F._
     val model = abstractModel match {
@@ -227,20 +228,20 @@ object ProtocolGenerator {
     }
   }
 
-  def plainTypeAlias[F[_]](clsName: String)(implicit A: AliasProtocolTerms[F], F: FrameworkTerms[F]): Free[F, ProtocolElems] = {
+  def plainTypeAlias[F[_]](clsName: String)(implicit A: AliasProtocolTerms[ScalaLanguage, F], F: FrameworkTerms[ScalaLanguage, F]): Free[F, ProtocolElems] = {
     import F._
     getGeneratorSettings().flatMap { implicit generatorSettings =>
       typeAlias(clsName, generatorSettings.jsonType)
     }
   }
 
-  def typeAlias[F[_]](clsName: String, tpe: Type)(implicit A: AliasProtocolTerms[F]): Free[F, ProtocolElems] = {
+  def typeAlias[F[_]](clsName: String, tpe: Type)(implicit A: AliasProtocolTerms[ScalaLanguage, F]): Free[F, ProtocolElems] = {
     import A._
     Free.pure(RandomType(clsName, tpe))
   }
 
-  def fromArray[F[_]](clsName: String, arr: ArrayModel, concreteTypes: List[PropMeta])(implicit R: ArrayProtocolTerms[F],
-                                                                                       A: AliasProtocolTerms[F]): Free[F, ProtocolElems] = {
+  def fromArray[F[_]](clsName: String, arr: ArrayModel, concreteTypes: List[PropMeta])(implicit R: ArrayProtocolTerms[ScalaLanguage, F],
+                                                                                       A: AliasProtocolTerms[ScalaLanguage, F]): Free[F, ProtocolElems] = {
     import R._
     for {
       tpe <- extractArrayType(arr, concreteTypes)
@@ -300,13 +301,13 @@ object ProtocolGenerator {
   }
 
   def fromSwagger[F[_]](swagger: Swagger)(
-      implicit E: EnumProtocolTerms[F],
-      M: ModelProtocolTerms[F],
-      A: AliasProtocolTerms[F],
-      R: ArrayProtocolTerms[F],
-      S: ProtocolSupportTerms[F],
-      F: FrameworkTerms[F],
-      P: PolyProtocolTerms[F]
+      implicit E: EnumProtocolTerms[ScalaLanguage, F],
+      M: ModelProtocolTerms[ScalaLanguage, F],
+      A: AliasProtocolTerms[ScalaLanguage, F],
+      R: ArrayProtocolTerms[ScalaLanguage, F],
+      S: ProtocolSupportTerms[ScalaLanguage, F],
+      F: FrameworkTerms[ScalaLanguage, F],
+      P: PolyProtocolTerms[ScalaLanguage, F]
   ): Free[F, ProtocolDefinitions] = {
     import S._
     import F._

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
@@ -7,8 +7,8 @@ import cats.free.Free
 import cats.instances.all._
 import cats.syntax.all._
 import com.twilio.guardrail.generators.ScalaParameter
+import com.twilio.guardrail.languages.ScalaLanguage
 import com.twilio.guardrail.protocol.terms.server.{ ServerTerm, ServerTerms }
-
 import scala.collection.JavaConverters._
 import scala.meta._
 
@@ -31,7 +31,7 @@ object ServerGenerator {
 
   def fromSwagger[F[_]](context: Context, swagger: Swagger, frameworkImports: List[Import])(
       protocolElems: List[StrictProtocolElems]
-  )(implicit S: ServerTerms[F]): Free[F, Servers] = {
+  )(implicit S: ServerTerms[ScalaLanguage, F]): Free[F, Servers] = {
     import S._
 
     val paths: List[(String, Path)] =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
@@ -7,20 +7,19 @@ import cats.free.Free
 import cats.instances.all._
 import cats.syntax.all._
 import com.twilio.guardrail.generators.ScalaParameter
-import com.twilio.guardrail.languages.ScalaLanguage
+import com.twilio.guardrail.languages.{ LA, ScalaLanguage }
 import com.twilio.guardrail.protocol.terms.server.{ ServerTerm, ServerTerms }
 import scala.collection.JavaConverters._
-import scala.meta._
 
-case class Servers(servers: List[Server])
-case class Server(pkg: List[String], extraImports: List[Import], src: List[Stat])
-case class TracingField(param: ScalaParameter, term: Term)
+case class Servers[L <: LA](servers: List[Server[L]])
+case class Server[L <: LA](pkg: List[String], extraImports: List[L#Import], src: List[L#Statement])
+case class TracingField[L <: LA](param: ScalaParameter, term: L#Term)
 case class ServerRoute(path: String, method: HttpMethod, operation: Operation)
-case class RenderedRoutes(
-    routes: Term,
-    methodSigs: List[Decl.Def],
-    supportDefinitions: List[Defn],
-    handlerDefinitions: List[Stat]
+case class RenderedRoutes[L <: LA](
+    routes: L#Term,
+    methodSigs: List[L#MethodDeclaration],
+    supportDefinitions: List[L#Definition],
+    handlerDefinitions: List[L#Statement]
 )
 
 object ServerGenerator {
@@ -29,9 +28,9 @@ object ServerGenerator {
   def formatClassName(str: String): String   = s"${str.capitalize}Resource"
   def formatHandlerName(str: String): String = s"${str.capitalize}Handler"
 
-  def fromSwagger[F[_]](context: Context, swagger: Swagger, frameworkImports: List[Import])(
+  def fromSwagger[L <: LA, F[_]](context: Context, swagger: Swagger, frameworkImports: List[L#Import])(
       protocolElems: List[StrictProtocolElems]
-  )(implicit S: ServerTerms[ScalaLanguage, F]): Free[F, Servers] = {
+  )(implicit S: ServerTerms[L, F]): Free[F, Servers[L]] = {
     import S._
 
     val paths: List[(String, Path)] =
@@ -69,6 +68,6 @@ object ServerGenerator {
             Server(className, frameworkImports ++ extraImports, handlerSrc +: classSrc)
           }
       }
-    } yield Servers(servers)
+    } yield Servers[L](servers)
   }
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
@@ -26,8 +26,6 @@ case class RenderedRoutes(
 object ServerGenerator {
   import NelShim._
 
-  type ServerGenerator[A] = ServerTerm[A]
-
   def formatClassName(str: String): String   = s"${str.capitalize}Resource"
   def formatHandlerName(str: String): String = s"${str.capitalize}Handler"
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
@@ -29,7 +29,7 @@ object ServerGenerator {
   def formatHandlerName(str: String): String = s"${str.capitalize}Handler"
 
   def fromSwagger[L <: LA, F[_]](context: Context, swagger: Swagger, frameworkImports: List[L#Import])(
-      protocolElems: List[StrictProtocolElems]
+      protocolElems: List[StrictProtocolElems[L]]
   )(implicit S: ServerTerms[L, F]): Free[F, Servers[L]] = {
     import S._
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
@@ -11,6 +11,7 @@ import com.twilio.guardrail.generators.{ GeneratorSettings, ScalaParameter }
 import java.util.{ Map => JMap }
 import scala.language.reflectiveCalls
 import scala.meta._
+import com.twilio.guardrail.languages.ScalaLanguage
 
 object SwaggerUtil {
   sealed trait ResolvedType
@@ -71,7 +72,7 @@ object SwaggerUtil {
         }
     }
 
-    def resolve(value: ResolvedType, protocolElems: List[StrictProtocolElems]): Target[Resolved] =
+    def resolve(value: ResolvedType, protocolElems: List[StrictProtocolElems[ScalaLanguage]]): Target[Resolved] =
       value match {
         case x @ Resolved(tpe, _, default) => Target.pure(x)
         case Deferred(name) =>

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttp.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttp.scala
@@ -12,15 +12,23 @@ import SwaggerGenerator._
 import AkkaHttpGenerator._
 
 object AkkaHttp extends FunctionK[CodegenApplication, Target] {
-  val interpSP: CodegenApplicationSP ~> Target                   = ProtocolSupportTermInterp or ServerTermInterp
-  val interpMSP: CodegenApplicationMSP ~> Target                 = ModelProtocolTermInterp or interpSP
-  val interpEMSP: CodegenApplicationEMSP ~> Target               = EnumProtocolTermInterp or interpMSP
-  val interpCEMSP: CodegenApplicationCEMSP ~> Target             = ClientTermInterp or interpEMSP
-  val interpACEMSP: CodegenApplicationACEMSP ~> Target           = AliasProtocolTermInterp or interpCEMSP
-  val interpACEMSSP: CodegenApplicationACEMSSP ~> Target         = ScalaInterp or interpACEMSP
-  val interpACEMSSPR: CodegenApplicationACEMSSPR ~> Target       = ArrayProtocolTermInterp or interpACEMSSP
-  val interpACEMSSPRS: CodegenApplicationACEMSSPRS ~> Target     = SwaggerInterp or interpACEMSSPR
-  val interpACEMSSPRSF: CodegenApplicationACEMSSPRSF ~> Target   = FrameworkInterp or interpACEMSSPRS
-  val interpACEMSSPRSFP: CodegenApplicationACEMSSPRSFP ~> Target = PolyProtocolTermInterp or interpACEMSSPRSF
-  def apply[T](x: CodegenApplication[T]): Target[T]              = interpACEMSSPRSFP.apply(x)
+  val interpDefinitionPM: DefinitionPM ~> Target         = ProtocolSupportTermInterp or ModelProtocolTermInterp
+  val interpDefinitionPME: DefinitionPME ~> Target       = EnumProtocolTermInterp or interpDefinitionPM
+  val interpDefinitionPMEA: DefinitionPMEA ~> Target     = AliasProtocolTermInterp or interpDefinitionPME
+  val interpDefinitionPMEAA: DefinitionPMEAA ~> Target   = ArrayProtocolTermInterp or interpDefinitionPMEA
+  val interpDefinitionPMEAAP: DefinitionPMEAAP ~> Target = PolyProtocolTermInterp or interpDefinitionPMEAA
+
+  val interpModel: ModelInterpreters ~> Target = interpDefinitionPMEAAP
+
+  val interpFrameworkC: FrameworkC ~> Target     = ClientTermInterp or interpModel
+  val interpFrameworkCS: FrameworkCS ~> Target   = ServerTermInterp or interpFrameworkC
+  val interpFrameworkCSF: FrameworkCSF ~> Target = FrameworkInterp or interpFrameworkCS
+
+  val interpFramework: ClientServerTerms ~> Target = interpFrameworkCSF
+
+  val parser: Parser ~> Target = SwaggerInterp or interpFramework
+
+  val codegenApplication: CodegenApplication ~> Target = ScalaInterp or parser
+
+  def apply[T](x: CodegenApplication[T]): Target[T] = codegenApplication.apply(x)
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpClientGenerator.scala
@@ -310,7 +310,7 @@ object AkkaHttpClientGenerator {
               headerArgs,
               extraImplicits
             )
-          } yield RenderedClientOperation(defn, List.empty)
+          } yield RenderedClientOperation[ScalaLanguage](defn, List.empty)
         }
 
       case GetImports(tracing) => Target.pure(List.empty)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpClientGenerator.scala
@@ -9,13 +9,14 @@ import cats.data.NonEmptyList
 import cats.syntax.flatMap._
 import com.twilio.guardrail.protocol.terms.client._
 import com.twilio.guardrail.terms.RouteMeta
+import com.twilio.guardrail.languages.ScalaLanguage
 
 import scala.collection.JavaConverters._
 import scala.meta._
 
 object AkkaHttpClientGenerator {
 
-  object ClientTermInterp extends FunctionK[ClientTerm, Target] {
+  object ClientTermInterp extends FunctionK[ClientTerm[ScalaLanguage, ?], Target] {
     def splitOperationParts(operationId: String): (List[String], String) = {
       val parts = operationId.split('.')
       (parts.drop(1).toList, parts.last)
@@ -43,7 +44,7 @@ object AkkaHttpClientGenerator {
         }
         .fold(param"host: String")(v => param"host: String = ${Lit.String(v)}")
 
-    def apply[T](term: ClientTerm[T]): Target[T] = term match {
+    def apply[T](term: ClientTerm[ScalaLanguage, T]): Target[T] = term match {
       case GenerateClientOperation(className, RouteMeta(pathStr, httpMethod, operation), tracing, protocolElems) =>
         def generateUrlWithParams(path: String, pathArgs: List[ScalaParameter], qsArgs: List[ScalaParameter]): Target[Term] =
           for {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpGenerator.scala
@@ -14,10 +14,11 @@ import com.twilio.guardrail.terms.framework._
 import java.util.Locale
 import scala.collection.JavaConverters._
 import scala.meta._
+import com.twilio.guardrail.languages.ScalaLanguage
 
 object AkkaHttpGenerator {
-  object FrameworkInterp extends FunctionK[FrameworkTerm, Target] {
-    def apply[T](term: FrameworkTerm[T]): Target[T] = term match {
+  object FrameworkInterp extends FunctionK[FrameworkTerm[ScalaLanguage, ?], Target] {
+    def apply[T](term: FrameworkTerm[ScalaLanguage, T]): Target[T] = term match {
       case GetFrameworkImports(tracing) =>
         Target.pure(
           List(

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
@@ -11,8 +11,8 @@ import cats.syntax.functor._
 import cats.syntax.traverse._
 import com.twilio.guardrail.SwaggerUtil
 import com.twilio.guardrail.extract.{ ScalaPackage, ScalaTracingLabel, ServerRawResponse }
+import com.twilio.guardrail.languages.ScalaLanguage
 import com.twilio.guardrail.protocol.terms.server._
-
 import scala.collection.JavaConverters._
 import scala.meta._
 
@@ -104,12 +104,12 @@ object AkkaHttpServerGenerator {
       }
   }
 
-  object ServerTermInterp extends FunctionK[ServerTerm, Target] {
+  object ServerTermInterp extends FunctionK[ServerTerm[ScalaLanguage, ?], Target] {
     def splitOperationParts(operationId: String): (List[String], String) = {
       val parts = operationId.split('.')
       (parts.drop(1).toList, parts.last)
     }
-    def apply[T](term: ServerTerm[T]): Target[T] = term match {
+    def apply[T](term: ServerTerm[ScalaLanguage, T]): Target[T] = term match {
       case ExtractOperations(paths) =>
         for {
           _ <- Target.log.debug("AkkaHttpServerGenerator", "server")(s"extractOperations(${paths})")

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
@@ -252,7 +252,7 @@ object AkkaHttpServerGenerator {
                     .orElse(resourceName.lastOption.map(clientName => Lit.String(s"${clientName}:${operationId}"))),
                   "Missing client name"
                 )
-              } yield Some(TracingField(ScalaParameter.fromParam(param"traceBuilder: TraceBuilder"), q"""trace(${label})"""))
+              } yield Some(TracingField[ScalaLanguage](ScalaParameter.fromParam(param"traceBuilder: TraceBuilder"), q"""trace(${label})"""))
             } else Target.pure(None)
           } yield res
         }
@@ -269,7 +269,7 @@ object AkkaHttpServerGenerator {
           combinedRouteTerms <- combineRouteTerms(routeTerms)
           methodSigs = renderedRoutes.map(_.methodSig)
         } yield {
-          RenderedRoutes(
+          RenderedRoutes[ScalaLanguage](
             combinedRouteTerms,
             methodSigs,
             renderedRoutes.flatMap(_.supportDefinitions),
@@ -659,7 +659,7 @@ object AkkaHttpServerGenerator {
     def generateRoute(resourceName: String,
                       basePath: Option[String],
                       route: ServerRoute,
-                      tracingFields: Option[TracingField],
+                      tracingFields: Option[TracingField[ScalaLanguage]],
                       protocolElems: List[StrictProtocolElems]): Target[RenderedRoute] =
       // Generate the pair of the Handler method and the actual call to `complete(...)`
       for {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
@@ -660,7 +660,7 @@ object AkkaHttpServerGenerator {
                       basePath: Option[String],
                       route: ServerRoute,
                       tracingFields: Option[TracingField[ScalaLanguage]],
-                      protocolElems: List[StrictProtocolElems]): Target[RenderedRoute] =
+                      protocolElems: List[StrictProtocolElems[ScalaLanguage]]): Target[RenderedRoute] =
       // Generate the pair of the Handler method and the actual call to `complete(...)`
       for {
         _ <- Target.log.debug("AkkaHttpServerGenerator", "server")(s"generateRoute(${resourceName}, ${basePath}, ${route}, ${tracingFields})")

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/CirceProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/CirceProtocolGenerator.scala
@@ -8,6 +8,7 @@ import cats.~>
 import com.twilio.guardrail.extract.{ Default, ScalaEmptyIsNull, ScalaType }
 import com.twilio.guardrail.terms
 import java.util.Locale
+import com.twilio.guardrail.languages.ScalaLanguage
 
 import com.twilio.guardrail.protocol.terms.protocol._
 
@@ -25,8 +26,8 @@ object CirceProtocolGenerator {
       .map(_.tpe)
       .map(f)
 
-  object EnumProtocolTermInterp extends (EnumProtocolTerm ~> Target) {
-    def apply[T](term: EnumProtocolTerm[T]): Target[T] = term match {
+  object EnumProtocolTermInterp extends (EnumProtocolTerm[ScalaLanguage, ?] ~> Target) {
+    def apply[T](term: EnumProtocolTerm[ScalaLanguage, T]): Target[T] = term match {
       case ExtractEnum(swagger) =>
         Target.pure(Either.fromOption(Option(swagger.getEnum()).map(_.asScala.to[List]), "Model has no enumerations"))
 
@@ -87,8 +88,8 @@ object CirceProtocolGenerator {
     }
   }
 
-  object ModelProtocolTermInterp extends (ModelProtocolTerm ~> Target) {
-    def apply[T](term: ModelProtocolTerm[T]): Target[T] = term match {
+  object ModelProtocolTermInterp extends (ModelProtocolTerm[ScalaLanguage, ?] ~> Target) {
+    def apply[T](term: ModelProtocolTerm[ScalaLanguage, T]): Target[T] = term match {
       case ExtractProperties(swagger) =>
         Target.pure(
           (swagger match {
@@ -300,14 +301,14 @@ object CirceProtocolGenerator {
     }
   }
 
-  object AliasProtocolTermInterp extends (AliasProtocolTerm ~> Target) {
-    def apply[T](term: AliasProtocolTerm[T]): Target[T] = term match {
+  object AliasProtocolTermInterp extends (AliasProtocolTerm[ScalaLanguage, ?] ~> Target) {
+    def apply[T](term: AliasProtocolTerm[ScalaLanguage, T]): Target[T] = term match {
       case _ => ???
     }
   }
 
-  object ArrayProtocolTermInterp extends (ArrayProtocolTerm ~> Target) {
-    def apply[T](term: ArrayProtocolTerm[T]): Target[T] = term match {
+  object ArrayProtocolTermInterp extends (ArrayProtocolTerm[ScalaLanguage, ?] ~> Target) {
+    def apply[T](term: ArrayProtocolTerm[ScalaLanguage, T]): Target[T] = term match {
       case ExtractArrayType(arr, concreteTypes) =>
         SwaggerUtil.modelMetaType(arr).flatMap {
           case SwaggerUtil.Resolved(tpe, dep, default) => Target.pure(tpe)
@@ -321,8 +322,8 @@ object CirceProtocolGenerator {
     }
   }
 
-  object ProtocolSupportTermInterp extends (ProtocolSupportTerm ~> Target) {
-    def apply[T](term: ProtocolSupportTerm[T]): Target[T] = term match {
+  object ProtocolSupportTermInterp extends (ProtocolSupportTerm[ScalaLanguage, ?] ~> Target) {
+    def apply[T](term: ProtocolSupportTerm[ScalaLanguage, T]): Target[T] = term match {
       case ExtractConcreteTypes(definitions) =>
         Target.getGeneratorSettings.flatMap { implicit gs =>
           for {
@@ -387,8 +388,8 @@ object CirceProtocolGenerator {
     }
   }
 
-  object PolyProtocolTermInterp extends (PolyProtocolTerm ~> Target) {
-    override def apply[A](fa: PolyProtocolTerm[A]): Target[A] = fa match {
+  object PolyProtocolTermInterp extends (PolyProtocolTerm[ScalaLanguage, ?] ~> Target) {
+    override def apply[A](fa: PolyProtocolTerm[ScalaLanguage, A]): Target[A] = fa match {
       case ExtractSuperClass(swagger, definitions) =>
         def allParents(model: Model): List[(String, Model, List[RefModel])] =
           (model match {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/CirceProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/CirceProtocolGenerator.scala
@@ -164,7 +164,7 @@ object CirceProtocolGenerator {
               )(Function.const((tpe, defaultValue)) _)
             term = param"${Term.Name(argName)}: ${finalDeclType}".copy(default = finalDefaultValue)
             dep  = rawDep.filterNot(_.value == clsName) // Filter out our own class name
-          } yield ProtocolParameter(term, name, dep, readOnlyKey, emptyToNullKey)
+          } yield ProtocolParameter[ScalaLanguage](term, name, dep, readOnlyKey, emptyToNullKey)
         }
 
       case RenderDTOClass(clsName, selfTerms, parents) =>

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4s.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4s.scala
@@ -12,15 +12,23 @@ import ScalaGenerator._
 import SwaggerGenerator._
 
 object Http4s extends FunctionK[CodegenApplication, Target] {
-  val interpSP: CodegenApplicationSP ~> Target                   = ProtocolSupportTermInterp or ServerTermInterp
-  val interpMSP: CodegenApplicationMSP ~> Target                 = ModelProtocolTermInterp or interpSP
-  val interpEMSP: CodegenApplicationEMSP ~> Target               = EnumProtocolTermInterp or interpMSP
-  val interpCEMSP: CodegenApplicationCEMSP ~> Target             = ClientTermInterp or interpEMSP
-  val interpACEMSP: CodegenApplicationACEMSP ~> Target           = AliasProtocolTermInterp or interpCEMSP
-  val interpACEMSSP: CodegenApplicationACEMSSP ~> Target         = ScalaInterp or interpACEMSP
-  val interpACEMSSPR: CodegenApplicationACEMSSPR ~> Target       = ArrayProtocolTermInterp or interpACEMSSP
-  val interpACEMSSPRS: CodegenApplicationACEMSSPRS ~> Target     = SwaggerInterp or interpACEMSSPR
-  val interpACEMSSPRSF: CodegenApplicationACEMSSPRSF ~> Target   = FrameworkInterp or interpACEMSSPRS
-  val interpACEMSSPRSFP: CodegenApplicationACEMSSPRSFP ~> Target = PolyProtocolTermInterp or interpACEMSSPRSF
-  def apply[T](x: CodegenApplication[T]): Target[T]              = interpACEMSSPRSFP.apply(x)
+  val interpDefinitionPM: DefinitionPM ~> Target         = ProtocolSupportTermInterp or ModelProtocolTermInterp
+  val interpDefinitionPME: DefinitionPME ~> Target       = EnumProtocolTermInterp or interpDefinitionPM
+  val interpDefinitionPMEA: DefinitionPMEA ~> Target     = AliasProtocolTermInterp or interpDefinitionPME
+  val interpDefinitionPMEAA: DefinitionPMEAA ~> Target   = ArrayProtocolTermInterp or interpDefinitionPMEA
+  val interpDefinitionPMEAAP: DefinitionPMEAAP ~> Target = PolyProtocolTermInterp or interpDefinitionPMEAA
+
+  val interpModel: ModelInterpreters ~> Target = interpDefinitionPMEAAP
+
+  val interpFrameworkC: FrameworkC ~> Target     = ClientTermInterp or interpModel
+  val interpFrameworkCS: FrameworkCS ~> Target   = ServerTermInterp or interpFrameworkC
+  val interpFrameworkCSF: FrameworkCSF ~> Target = FrameworkInterp or interpFrameworkCS
+
+  val interpFramework: ClientServerTerms ~> Target = interpFrameworkCSF
+
+  val parser: Parser ~> Target = SwaggerInterp or interpFramework
+
+  val codegenApplication: CodegenApplication ~> Target = ScalaInterp or parser
+
+  def apply[T](x: CodegenApplication[T]): Target[T] = codegenApplication.apply(x)
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sClientGenerator.scala
@@ -163,7 +163,7 @@ object Http4sClientGenerator {
                                     formArgs: List[ScalaParameter],
                                     body: Option[ScalaParameter],
                                     headerArgs: List[ScalaParameter],
-                                    extraImplicits: List[Term.Param]): RenderedClientOperation = {
+                                    extraImplicits: List[Term.Param]): RenderedClientOperation[ScalaLanguage] = {
           val implicitParams = Option(extraImplicits).filter(_.nonEmpty)
           val defaultHeaders = param"headers: List[Header] = List.empty"
           val safeBody: Option[(Term, Type)] =
@@ -245,7 +245,7 @@ object Http4sClientGenerator {
             implicitParams
           ).flatten
 
-          RenderedClientOperation(
+          RenderedClientOperation[ScalaLanguage](
             q"""
               def ${Term
               .Name(methodName)}(...${arglists}): F[$responseTypeRef] = $methodBody

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sClientGenerator.scala
@@ -9,17 +9,16 @@ import cats.syntax.flatMap._
 import cats.syntax.functor._
 import cats.syntax.traverse._
 import com.twilio.guardrail.extract.ScalaPackage
+import com.twilio.guardrail.languages.ScalaLanguage
+import com.twilio.guardrail.protocol.terms.client._
 import com.twilio.guardrail.terms.RouteMeta
 import java.util.Locale
-
-import com.twilio.guardrail.protocol.terms.client._
-
 import scala.collection.JavaConverters._
 import scala.meta._
 
 object Http4sClientGenerator {
 
-  object ClientTermInterp extends FunctionK[ClientTerm, Target] {
+  object ClientTermInterp extends FunctionK[ClientTerm[ScalaLanguage, ?], Target] {
     def splitOperationParts(operationId: String): (List[String], String) = {
       val parts = operationId.split('.')
       (parts.drop(1).toList, parts.last)
@@ -47,7 +46,7 @@ object Http4sClientGenerator {
         }
         .fold(param"host: String")(v => param"host: String = ${Lit.String(v)}")
 
-    def apply[T](term: ClientTerm[T]): Target[T] = term match {
+    def apply[T](term: ClientTerm[ScalaLanguage, T]): Target[T] = term match {
       case GenerateClientOperation(className, RouteMeta(pathStr, httpMethod, operation), tracing, protocolElems) =>
         def generateUrlWithParams(path: String, pathArgs: List[ScalaParameter], qsArgs: List[ScalaParameter]): Target[Term] =
           for {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sGenerator.scala
@@ -9,6 +9,7 @@ import cats.syntax.flatMap._
 import cats.syntax.functor._
 import cats.syntax.traverse._
 import com.twilio.guardrail.extract.ScalaPackage
+import com.twilio.guardrail.languages.ScalaLanguage
 import com.twilio.guardrail.terms.RouteMeta
 import com.twilio.guardrail.terms.framework._
 import java.util.Locale
@@ -16,8 +17,8 @@ import scala.collection.JavaConverters._
 import scala.meta._
 
 object Http4sGenerator {
-  object FrameworkInterp extends FunctionK[FrameworkTerm, Target] {
-    def apply[T](term: FrameworkTerm[T]): Target[T] = term match {
+  object FrameworkInterp extends FunctionK[FrameworkTerm[ScalaLanguage, ?], Target] {
+    def apply[T](term: FrameworkTerm[ScalaLanguage, T]): Target[T] = term match {
       case GetFrameworkImports(tracing) =>
         Target.pure(
           List(

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sHelper.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sHelper.scala
@@ -6,6 +6,7 @@ import com.twilio.guardrail.generators.Http4sServerGenerator.ServerTermInterp.sp
 import com.twilio.guardrail.{ StrictProtocolElems, SwaggerUtil, Target }
 import io.swagger.models.{ Operation, Response }
 
+import com.twilio.guardrail.languages.ScalaLanguage
 import scala.collection.JavaConverters._
 import scala.meta._
 
@@ -81,7 +82,7 @@ object Http4sHelper {
 
   def getResponses(operationId: String,
                    responses: java.util.Map[String, Response],
-                   protocolElems: List[StrictProtocolElems]): Target[List[(Term.Name, Option[Type])]] =
+                   protocolElems: List[StrictProtocolElems[ScalaLanguage]]): Target[List[(Term.Name, Option[Type])]] =
     for {
       responses <- Target
         .fromOption(Option(responses).map(_.asScala), s"No responses defined for ${operationId}")
@@ -107,7 +108,7 @@ object Http4sHelper {
         .sequence
     } yield instances
 
-  def generateResponseDefinitions(operation: Operation, protocolElems: List[StrictProtocolElems]): Target[List[Defn]] =
+  def generateResponseDefinitions(operation: Operation, protocolElems: List[StrictProtocolElems[ScalaLanguage]]): Target[List[Defn]] =
     for {
       operationId <- Target.fromOption(Option(operation.getOperationId())
                                          .map(splitOperationParts)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
@@ -213,12 +213,12 @@ object Http4sServerGenerator {
       directivesFromParams(
         arg => {
           case t"String" =>
-            Target.pure(Param(None, Some(q"req.headers.get(${arg.argName.toLit}.ci).map(_.value)", p"Some(${Pat.Var(arg.paramName)})"), arg.paramName))
+            Target.pure(Param(None, Some((q"req.headers.get(${arg.argName.toLit}.ci).map(_.value)", p"Some(${Pat.Var(arg.paramName)})")), arg.paramName))
           case tpe =>
             Target.pure(
               Param(
                 None,
-                Some(q"req.headers.get(${arg.argName.toLit}.ci).map(_.value).map(Json.fromString(_).as[$tpe])", p"Some(Right(${Pat.Var(arg.paramName)}))"),
+                Some((q"req.headers.get(${arg.argName.toLit}.ci).map(_.value).map(Json.fromString(_).as[$tpe])", p"Some(Right(${Pat.Var(arg.paramName)}))")),
                 arg.paramName
               )
             )
@@ -231,7 +231,7 @@ object Http4sServerGenerator {
             Target.pure(
               Param(
                 None,
-                Some(q"req.headers.get(${arg.argName.toLit}.ci).map(_.value).map(Json.fromString(_).as[$tpe]).sequence", p"Right(${Pat.Var(arg.paramName)})"),
+                Some((q"req.headers.get(${arg.argName.toLit}.ci).map(_.value).map(Json.fromString(_).as[$tpe]).sequence", p"Right(${Pat.Var(arg.paramName)})")),
                 arg.paramName
               )
             )
@@ -254,23 +254,29 @@ object Http4sServerGenerator {
     def formToHttp4s: List[ScalaParameter] => Target[List[Param]] =
       directivesFromParams(
         arg => {
-          case t"String" => Target.pure(Param(None, Some(q"urlForm.values.get(${arg.argName.toLit})", p"Some(Seq(${Pat.Var(arg.paramName)}))"), arg.paramName))
+          case t"String" =>
+            Target.pure(Param(None, Some((q"urlForm.values.get(${arg.argName.toLit})", p"Some(Seq(${Pat.Var(arg.paramName)}))")), arg.paramName))
           case tpe =>
             Target.pure(
               Param(
                 None,
-                Some(q"urlForm.values.get(${arg.argName.toLit}).map(_.map(Json.fromString(_).as[$tpe]))", p"Some(Seq(Right(${Pat.Var(arg.paramName)})))"),
+                Some((q"urlForm.values.get(${arg.argName.toLit}).map(_.map(Json.fromString(_).as[$tpe]))", p"Some(Seq(Right(${Pat.Var(arg.paramName)})))")),
                 arg.paramName
               )
             )
         },
         arg => {
-          case t"String" => Target.pure(Param(None, Some(q"urlForm.values.get(${arg.argName.toLit})", p"Some(${Pat.Var(arg.paramName)})"), arg.paramName))
+          case t"String" => Target.pure(Param(None, Some((q"urlForm.values.get(${arg.argName.toLit})", p"Some(${Pat.Var(arg.paramName)})")), arg.paramName))
           case tpe =>
             Target.pure(
               Param(
                 None,
-                Some(q"urlForm.values.get(${arg.argName.toLit}).map(_.map(Json.fromString(_).as[$tpe]).sequence)", p"Some(Right(${Pat.Var(arg.paramName)}))"),
+                Some(
+                  (
+                    q"urlForm.values.get(${arg.argName.toLit}).map(_.map(Json.fromString(_).as[$tpe]).sequence)",
+                    p"Some(Right(${Pat.Var(arg.paramName)}))"
+                  )
+                ),
                 arg.paramName
               )
             )
@@ -281,21 +287,29 @@ object Http4sServerGenerator {
             Target.pure(
               Param(
                 None,
-                Some(q"urlForm.values.get(${arg.argName.toLit}).map(_.map(Json.fromString(_).as[$tpe]).sequence).sequence",
-                     p"Right(${Pat.Var(arg.paramName)})"),
+                Some(
+                  (
+                    q"urlForm.values.get(${arg.argName.toLit}).map(_.map(Json.fromString(_).as[$tpe]).sequence).sequence",
+                    p"Right(${Pat.Var(arg.paramName)})"
+                  )
+                ),
                 arg.paramName
               )
             )
         },
         arg => {
           case t"String" =>
-            Target.pure(Param(None, Some(q"urlForm.values.get(${arg.argName.toLit}).traverse(_.toList)", p"List(${Pat.Var(arg.paramName)})"), arg.paramName))
+            Target.pure(Param(None, Some((q"urlForm.values.get(${arg.argName.toLit}).traverse(_.toList)", p"List(${Pat.Var(arg.paramName)})")), arg.paramName))
           case tpe =>
             Target.pure(
               Param(
                 None,
-                Some(q"urlForm.values.get(${arg.argName.toLit}).traverse(_.toList).map(_.traverse(Json.fromString(_).as[$tpe]))",
-                     p"List(Right(${Pat.Var(arg.paramName)}))"),
+                Some(
+                  (
+                    q"urlForm.values.get(${arg.argName.toLit}).traverse(_.toList).map(_.traverse(Json.fromString(_).as[$tpe]))",
+                    p"List(Right(${Pat.Var(arg.paramName)}))"
+                  )
+                ),
                 arg.paramName
               )
             )
@@ -308,7 +322,9 @@ object Http4sServerGenerator {
           elemType =>
             if (arg.isFile) {
               Target.pure(
-                Param(None, Some(q"multipart.parts.find(_.name.contains(${arg.argName.toLit})).map(_.body)", p"Some(${Pat.Var(arg.paramName)})"), arg.paramName)
+                Param(None,
+                      Some((q"multipart.parts.find(_.name.contains(${arg.argName.toLit})).map(_.body)", p"Some(${Pat.Var(arg.paramName)})")),
+                      arg.paramName)
               )
             } else
               elemType match {
@@ -319,8 +335,10 @@ object Http4sServerGenerator {
                         enumerator"${Pat.Var(Term.Name(s"${arg.argName.value}Option"))} <- multipart.parts.find(_.name.contains(${arg.argName.toLit})).map(_.body.through(utf8Decode).compile.foldMonoid).sequence"
                       ),
                       Some(
-                        Term.Name(s"${arg.argName.value}Option"),
-                        p"Some(${Pat.Var(arg.paramName)})"
+                        (
+                          Term.Name(s"${arg.argName.value}Option"),
+                          p"Some(${Pat.Var(arg.paramName)})"
+                        )
                       ),
                       arg.paramName
                     )
@@ -332,8 +350,10 @@ object Http4sServerGenerator {
                         enumerator"${Pat.Var(Term.Name(s"${arg.argName.value}Option"))} <- multipart.parts.find(_.name.contains(${arg.argName.toLit})).map(_.body.through(utf8Decode).compile.foldMonoid.flatMap(str => E.fromEither(Json.fromString(str).as[$tpe]))).sequence"
                       ),
                       Some(
-                        Term.Name(s"${arg.argName.value}Option"),
-                        p"Some(${Pat.Var(arg.paramName)})"
+                        (
+                          Term.Name(s"${arg.argName.value}Option"),
+                          p"Some(${Pat.Var(arg.paramName)})"
+                        )
                       ),
                       arg.paramName
                     )

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
@@ -86,7 +86,7 @@ object Http4sServerGenerator {
                     .orElse(resourceName.lastOption.map(clientName => Lit.String(s"${clientName}:${operationId}"))),
                   "Missing client name"
                 )
-              } yield Some(TracingField(ScalaParameter.fromParam(param"traceBuilder: TraceBuilder[F]"), q"""trace(${label})"""))
+              } yield Some(TracingField[ScalaLanguage](ScalaParameter.fromParam(param"traceBuilder: TraceBuilder[F]"), q"""trace(${label})"""))
             } else Target.pure(None)
           } yield res
         }
@@ -103,7 +103,7 @@ object Http4sServerGenerator {
           combinedRouteTerms <- combineRouteTerms(routeTerms)
           methodSigs = renderedRoutes.map(_.methodSig)
         } yield {
-          RenderedRoutes(
+          RenderedRoutes[ScalaLanguage](
             combinedRouteTerms,
             methodSigs,
             renderedRoutes.flatMap(_.supportDefinitions),
@@ -427,7 +427,7 @@ object Http4sServerGenerator {
     def generateRoute(resourceName: String,
                       basePath: Option[String],
                       route: ServerRoute,
-                      tracingFields: Option[TracingField],
+                      tracingFields: Option[TracingField[ScalaLanguage]],
                       protocolElems: List[StrictProtocolElems]): Target[Option[RenderedRoute]] =
       // Generate the pair of the Handler method and the actual call to `complete(...)`
       for {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
@@ -428,7 +428,7 @@ object Http4sServerGenerator {
                       basePath: Option[String],
                       route: ServerRoute,
                       tracingFields: Option[TracingField[ScalaLanguage]],
-                      protocolElems: List[StrictProtocolElems]): Target[Option[RenderedRoute]] =
+                      protocolElems: List[StrictProtocolElems[ScalaLanguage]]): Target[Option[RenderedRoute]] =
       // Generate the pair of the Handler method and the actual call to `complete(...)`
       for {
         _ <- Target.log.debug("Http4sServerGenerator", "server")(s"generateRoute(${resourceName}, ${basePath}, ${route}, ${tracingFields})")
@@ -563,7 +563,7 @@ object Http4sServerGenerator {
         _      <- routes.traverse(route => Target.log.debug("Http4sServerGenerator", "server", "combineRouteTerms")(route.toString))
       } yield scala.meta.Term.PartialFunction(routes.toList)
 
-    def generateSupportDefinitions(route: ServerRoute, protocolElems: List[StrictProtocolElems]): Target[List[Defn]] =
+    def generateSupportDefinitions(route: ServerRoute, protocolElems: List[StrictProtocolElems[ScalaLanguage]]): Target[List[Defn]] =
       for {
         operation <- Target.pure(route.operation)
         parameters <- Option(operation.getParameters)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
@@ -9,8 +9,8 @@ import cats.syntax.flatMap._
 import cats.syntax.functor._
 import cats.syntax.traverse._
 import com.twilio.guardrail.extract.{ ScalaPackage, ScalaTracingLabel, ServerRawResponse }
+import com.twilio.guardrail.languages.ScalaLanguage
 import com.twilio.guardrail.protocol.terms.server._
-
 import scala.collection.JavaConverters._
 import scala.meta.{ Term, _ }
 
@@ -25,12 +25,12 @@ object Http4sServerGenerator {
       }
   }
 
-  object ServerTermInterp extends FunctionK[ServerTerm, Target] {
+  object ServerTermInterp extends FunctionK[ServerTerm[ScalaLanguage, ?], Target] {
     def splitOperationParts(operationId: String): (List[String], String) = {
       val parts = operationId.split('.')
       (parts.drop(1).toList, parts.last)
     }
-    def apply[T](term: ServerTerm[T]): Target[T] = term match {
+    def apply[T](term: ServerTerm[ScalaLanguage, T]): Target[T] = term match {
       case ExtractOperations(paths) =>
         for {
           _ <- Target.log.debug("Http4sServerGenerator", "server")(s"extractOperations(${paths})")

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
@@ -3,12 +3,13 @@ package generators
 
 import cats.syntax.either._
 import cats.~>
+import com.twilio.guardrail.languages.ScalaLanguage
 import com.twilio.guardrail.terms._
 import scala.meta._
 
 object ScalaGenerator {
-  object ScalaInterp extends (ScalaTerm ~> Target) {
-    def apply[T](term: ScalaTerm[T]): Target[T] = term match {
+  object ScalaInterp extends (ScalaTerm[ScalaLanguage, ?] ~> Target) {
+    def apply[T](term: ScalaTerm[ScalaLanguage, T]): Target[T] = term match {
       case RenderImplicits(pkgName, frameworkImports, jsonImports, customImports) =>
         val pkg: Term.Ref =
           pkgName.map(Term.Name.apply _).reduceLeft(Term.Select.apply _)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
@@ -9,6 +9,13 @@ import scala.meta._
 
 object ScalaGenerator {
   object ScalaInterp extends (ScalaTerm[ScalaLanguage, ?] ~> Target) {
+    // TODO: Very interesting bug. 2.11.12 barfs if these two definitions are
+    // defined inside `apply`. Once 2.11 is dropped, these can be moved back.
+    val matchImplicit: PartialFunction[Stat, Defn.Val] = {
+      case x: Defn.Val if (x match { case q"implicit val $_: $_ = $_" => true; case _ => false }) => x
+    }
+    val partitionImplicits: PartialFunction[Stat, Boolean] = matchImplicit.andThen(_ => true).orElse({ case _ => false })
+
     def apply[T](term: ScalaTerm[ScalaLanguage, T]): Target[T] = term match {
       case RenderImplicits(pkgName, frameworkImports, jsonImports, customImports) =>
         val pkg: Term.Ref =
@@ -107,6 +114,43 @@ object ScalaGenerator {
 
             ${frameworkImplicits}
           """
+        )
+
+      case WritePackageObject(dtoPackagePath, dtoComponents, customImports, packageObjectImports, protocolImports, packageObjectContents, extraTypes) =>
+        val dtoHead :: dtoRest = dtoComponents
+        val dtoPkg = dtoRest.init
+          .foldLeft[Term.Ref](Term.Name(dtoHead)) {
+            case (acc, next) => Term.Select(acc, Term.Name(next))
+          }
+        val companion = Term.Name(s"${dtoComponents.last}$$")
+
+        val (_, statements) =
+          packageObjectContents.partition(partitionImplicits)
+        val implicits: List[Defn.Val] = packageObjectContents.collect(matchImplicit)
+
+        val mirroredImplicits = implicits
+          .map({ stat =>
+            val List(Pat.Var(mirror)) = stat.pats
+            stat.copy(rhs = q"${companion}.${mirror}")
+          })
+
+        Target.pure(
+          WriteTree(
+            dtoPackagePath.resolve("package.scala"),
+            source"""
+            package ${dtoPkg}
+
+            ..${customImports ++ packageObjectImports ++ protocolImports}
+
+            object ${companion} {
+              ..${implicits.map(_.copy(mods = List.empty))}
+            }
+
+            package object ${Term.Name(dtoComponents.last)} {
+              ..${(mirroredImplicits ++ statements ++ extraTypes).to[List]}
+            }
+          """
+          )
         )
     }
   }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaParameter.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaParameter.scala
@@ -3,6 +3,7 @@ package generators
 
 import _root_.io.swagger.models.parameters.Parameter
 import com.twilio.guardrail.extract.{ Default, ScalaFileHashAlgorithm, ScalaType }
+import com.twilio.guardrail.languages.ScalaLanguage
 import java.util.Locale
 
 import scala.meta._
@@ -51,7 +52,7 @@ object ScalaParameter {
       new ScalaParameter(None, param, Term.Name(name.value), argName, tpe, required, None, innerTpe == gs.fileType)
   }
 
-  def fromParameter(protocolElems: List[StrictProtocolElems]): Parameter => Target[ScalaParameter] = { parameter =>
+  def fromParameter(protocolElems: List[StrictProtocolElems[ScalaLanguage]]): Parameter => Target[ScalaParameter] = { parameter =>
     def toCamelCase(s: String): String = {
       val fromSnakeOrDashed =
         "[_-]([a-z])".r.replaceAllIn(s, m => m.group(1).toUpperCase(Locale.US))
@@ -189,7 +190,7 @@ object ScalaParameter {
     }
   }
 
-  def fromParameters(protocolElems: List[StrictProtocolElems]): List[Parameter] => Target[List[ScalaParameter]] = { params =>
+  def fromParameters(protocolElems: List[StrictProtocolElems[ScalaLanguage]]): List[Parameter] => Target[List[ScalaParameter]] = { params =>
     for {
       parameters <- params.traverse(fromParameter(protocolElems))
       counts = parameters.groupBy(_.paramName.value).mapValues(_.length)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/SwaggerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/SwaggerGenerator.scala
@@ -6,18 +6,19 @@ import cats.implicits._
 import cats.syntax.either._
 import cats.~>
 import com.twilio.guardrail.extract.ScalaPackage
+import com.twilio.guardrail.languages.ScalaLanguage
 import com.twilio.guardrail.terms._
 import scala.collection.JavaConverters._
 import scala.meta._
 
 object SwaggerGenerator {
-  object SwaggerInterp extends (SwaggerTerm ~> Target) {
+  object SwaggerInterp extends (SwaggerTerm[ScalaLanguage, ?] ~> Target) {
     def splitOperationParts(operationId: String): (List[String], String) = {
       val parts = operationId.split('.')
       (parts.drop(1).toList, parts.last)
     }
 
-    def apply[T](term: SwaggerTerm[T]): Target[T] = term match {
+    def apply[T](term: SwaggerTerm[ScalaLanguage, T]): Target[T] = term match {
       case ExtractOperations(paths) =>
         paths
           .map({

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/SwaggerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/SwaggerGenerator.scala
@@ -9,7 +9,6 @@ import com.twilio.guardrail.extract.ScalaPackage
 import com.twilio.guardrail.languages.ScalaLanguage
 import com.twilio.guardrail.terms._
 import scala.collection.JavaConverters._
-import scala.meta._
 
 object SwaggerGenerator {
   object SwaggerInterp extends (SwaggerTerm[ScalaLanguage, ?] ~> Target) {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/languages/LanguageAbstraction.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/languages/LanguageAbstraction.scala
@@ -1,0 +1,28 @@
+package com.twilio.guardrail.languages
+
+class LanguageAbstraction {
+
+  type Statement
+
+  type Import
+
+  // Definitions
+  type Definition
+  type AbstractClass
+  type ClassDefinition
+  type InterfaceDefinition
+  type ObjectDefinition
+  type Trait
+
+  // Functions
+  type InstanceMethod
+  type StaticMethod
+
+  // Values
+  type ValueDefinition
+  type MethodParameter
+  type Type
+
+  // Result
+  type FileContents
+}

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/languages/LanguageAbstraction.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/languages/LanguageAbstraction.scala
@@ -6,6 +6,14 @@ class LanguageAbstraction {
 
   type Import
 
+  // Terms
+
+  type Term
+  type TermName
+
+  // Declarations
+  type MethodDeclaration
+
   // Definitions
   type Definition
   type AbstractClass

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/languages/LanguageAbstraction.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/languages/LanguageAbstraction.scala
@@ -30,6 +30,7 @@ class LanguageAbstraction {
   type ValueDefinition
   type MethodParameter
   type Type
+  type TypeName
 
   // Result
   type FileContents

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/languages/ScalaLanguage.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/languages/ScalaLanguage.scala
@@ -1,0 +1,28 @@
+package com.twilio.guardrail.languages
+
+class ScalaLanguage extends LanguageAbstraction {
+
+  type Statement = scala.meta.Stat
+
+  type Import = scala.meta.Import
+
+  // Definitions
+  type Definition          = scala.meta.Defn
+  type AbstractClass       = Nothing
+  type ClassDefinition     = scala.meta.Defn.Class
+  type InterfaceDefinition = Nothing
+  type ObjectDefinition    = scala.meta.Defn.Object
+  type Trait               = Nothing
+
+  // Functions
+  type InstanceMethod = Nothing
+  type StaticMethod   = Nothing
+
+  // Values
+  type ValueDefinition = Nothing
+  type MethodParameter = scala.meta.Term.Param
+  type Type            = scala.meta.Type
+
+  // Result
+  type FileContents = Nothing
+}

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/languages/ScalaLanguage.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/languages/ScalaLanguage.scala
@@ -30,6 +30,7 @@ class ScalaLanguage extends LanguageAbstraction {
   type ValueDefinition = scala.meta.Defn.Val
   type MethodParameter = scala.meta.Term.Param
   type Type            = scala.meta.Type
+  type TypeName        = scala.meta.Type.Name
 
   // Result
   type FileContents = scala.meta.Source

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/languages/ScalaLanguage.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/languages/ScalaLanguage.scala
@@ -6,23 +6,31 @@ class ScalaLanguage extends LanguageAbstraction {
 
   type Import = scala.meta.Import
 
+  // Terms
+
+  type Term     = scala.meta.Term
+  type TermName = scala.meta.Term.Name
+
+  // Declarations
+  type MethodDeclaration = scala.meta.Decl.Def
+
   // Definitions
   type Definition          = scala.meta.Defn
   type AbstractClass       = Nothing
   type ClassDefinition     = scala.meta.Defn.Class
   type InterfaceDefinition = Nothing
   type ObjectDefinition    = scala.meta.Defn.Object
-  type Trait               = Nothing
+  type Trait               = scala.meta.Defn.Trait
 
   // Functions
   type InstanceMethod = Nothing
   type StaticMethod   = Nothing
 
   // Values
-  type ValueDefinition = Nothing
+  type ValueDefinition = scala.meta.Defn.Val
   type MethodParameter = scala.meta.Term.Param
   type Type            = scala.meta.Type
 
   // Result
-  type FileContents = Nothing
+  type FileContents = scala.meta.Source
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/languages/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/languages/package.scala
@@ -1,0 +1,5 @@
+package com.twilio.guardrail
+
+package object languages {
+  type LA = LanguageAbstraction
+}

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
@@ -70,27 +70,23 @@ package guardrail {
 }
 
 package object guardrail {
-  type CodegenApplicationSP[T] = EitherK[ProtocolSupportTerm, ServerTerm, T]
-  type CodegenApplicationMSP[T] =
-    EitherK[ModelProtocolTerm, CodegenApplicationSP, T]
-  type CodegenApplicationEMSP[T] =
-    EitherK[EnumProtocolTerm, CodegenApplicationMSP, T]
-  type CodegenApplicationCEMSP[T] =
-    EitherK[ClientTerm, CodegenApplicationEMSP, T]
-  type CodegenApplicationACEMSP[T] =
-    EitherK[AliasProtocolTerm, CodegenApplicationCEMSP, T]
-  type CodegenApplicationACEMSSP[T] =
-    EitherK[ScalaTerm, CodegenApplicationACEMSP, T]
-  type CodegenApplicationACEMSSPR[T] =
-    EitherK[ArrayProtocolTerm, CodegenApplicationACEMSSP, T]
-  type CodegenApplicationACEMSSPRS[T] =
-    EitherK[SwaggerTerm, CodegenApplicationACEMSSPR, T]
-  type CodegenApplicationACEMSSPRSF[T] =
-    EitherK[FrameworkTerm, CodegenApplicationACEMSSPRS, T]
-  type CodegenApplicationACEMSSPRSFP[T] =
-    EitherK[PolyProtocolTerm, CodegenApplicationACEMSSPRSF, T]
+  type DefinitionPM[T]     = EitherK[ProtocolSupportTerm, ModelProtocolTerm, T]
+  type DefinitionPME[T]    = EitherK[EnumProtocolTerm, DefinitionPM, T]
+  type DefinitionPMEA[T]   = EitherK[AliasProtocolTerm, DefinitionPME, T]
+  type DefinitionPMEAA[T]  = EitherK[ArrayProtocolTerm, DefinitionPMEA, T]
+  type DefinitionPMEAAP[T] = EitherK[PolyProtocolTerm, DefinitionPMEAA, T]
 
-  type CodegenApplication[T] = CodegenApplicationACEMSSPRSFP[T]
+  type ModelInterpreters[T] = DefinitionPMEAAP[T]
+
+  type FrameworkC[T]   = EitherK[ClientTerm, ModelInterpreters, T]
+  type FrameworkCS[T]  = EitherK[ServerTerm, FrameworkC, T]
+  type FrameworkCSF[T] = EitherK[FrameworkTerm, FrameworkCS, T]
+
+  type ClientServerTerms[T] = FrameworkCSF[T]
+
+  type Parser[T] = EitherK[SwaggerTerm, ClientServerTerms, T]
+
+  type CodegenApplication[T] = EitherK[ScalaTerm, Parser, T]
 
   type Logger[T]     = WriterT[Id, StructuredLogger, T]
   type Settings[T]   = ReaderT[Logger, GeneratorSettings, T]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
@@ -17,7 +17,7 @@ import scala.meta._
 import com.twilio.swagger.core.StructuredLogger
 
 package guardrail {
-  case class CodegenDefinitions[L <: LA](clients: List[Client[L]], servers: List[Server])
+  case class CodegenDefinitions[L <: LA](clients: List[Client[L]], servers: List[Server[L]])
 
   object Target {
     val A                              = Applicative[Target]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
@@ -5,12 +5,13 @@ import cats.data.{ EitherK, EitherT, NonEmptyList, ReaderT, WriterT }
 import cats.instances.all._
 import cats.syntax.applicative._
 import cats.syntax.either._
+import com.twilio.guardrail.generators.GeneratorSettings
+import com.twilio.guardrail.languages.ScalaLanguage
 import com.twilio.guardrail.protocol.terms.client.ClientTerm
 import com.twilio.guardrail.protocol.terms.protocol._
 import com.twilio.guardrail.protocol.terms.server.ServerTerm
-import com.twilio.guardrail.terms.{ ScalaTerm, SwaggerTerm }
 import com.twilio.guardrail.terms.framework.FrameworkTerm
-import com.twilio.guardrail.generators.GeneratorSettings
+import com.twilio.guardrail.terms.{ ScalaTerm, SwaggerTerm }
 
 import scala.meta._
 import com.twilio.swagger.core.StructuredLogger
@@ -70,23 +71,23 @@ package guardrail {
 }
 
 package object guardrail {
-  type DefinitionPM[T]     = EitherK[ProtocolSupportTerm, ModelProtocolTerm, T]
-  type DefinitionPME[T]    = EitherK[EnumProtocolTerm, DefinitionPM, T]
-  type DefinitionPMEA[T]   = EitherK[AliasProtocolTerm, DefinitionPME, T]
-  type DefinitionPMEAA[T]  = EitherK[ArrayProtocolTerm, DefinitionPMEA, T]
-  type DefinitionPMEAAP[T] = EitherK[PolyProtocolTerm, DefinitionPMEAA, T]
+  type DefinitionPM[T]     = EitherK[ProtocolSupportTerm[ScalaLanguage, ?], ModelProtocolTerm[ScalaLanguage, ?], T]
+  type DefinitionPME[T]    = EitherK[EnumProtocolTerm[ScalaLanguage, ?], DefinitionPM, T]
+  type DefinitionPMEA[T]   = EitherK[AliasProtocolTerm[ScalaLanguage, ?], DefinitionPME, T]
+  type DefinitionPMEAA[T]  = EitherK[ArrayProtocolTerm[ScalaLanguage, ?], DefinitionPMEA, T]
+  type DefinitionPMEAAP[T] = EitherK[PolyProtocolTerm[ScalaLanguage, ?], DefinitionPMEAA, T]
 
   type ModelInterpreters[T] = DefinitionPMEAAP[T]
 
-  type FrameworkC[T]   = EitherK[ClientTerm, ModelInterpreters, T]
-  type FrameworkCS[T]  = EitherK[ServerTerm, FrameworkC, T]
-  type FrameworkCSF[T] = EitherK[FrameworkTerm, FrameworkCS, T]
+  type FrameworkC[T]   = EitherK[ClientTerm[ScalaLanguage, ?], ModelInterpreters, T]
+  type FrameworkCS[T]  = EitherK[ServerTerm[ScalaLanguage, ?], FrameworkC, T]
+  type FrameworkCSF[T] = EitherK[FrameworkTerm[ScalaLanguage, ?], FrameworkCS, T]
 
   type ClientServerTerms[T] = FrameworkCSF[T]
 
-  type Parser[T] = EitherK[SwaggerTerm, ClientServerTerms, T]
+  type Parser[T] = EitherK[SwaggerTerm[ScalaLanguage, ?], ClientServerTerms, T]
 
-  type CodegenApplication[T] = EitherK[ScalaTerm, Parser, T]
+  type CodegenApplication[T] = EitherK[ScalaTerm[ScalaLanguage, ?], Parser, T]
 
   type Logger[T]     = WriterT[Id, StructuredLogger, T]
   type Settings[T]   = ReaderT[Logger, GeneratorSettings, T]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
@@ -6,7 +6,7 @@ import cats.instances.all._
 import cats.syntax.applicative._
 import cats.syntax.either._
 import com.twilio.guardrail.generators.GeneratorSettings
-import com.twilio.guardrail.languages.ScalaLanguage
+import com.twilio.guardrail.languages.{ LA, ScalaLanguage }
 import com.twilio.guardrail.protocol.terms.client.ClientTerm
 import com.twilio.guardrail.protocol.terms.protocol._
 import com.twilio.guardrail.protocol.terms.server.ServerTerm
@@ -17,7 +17,7 @@ import scala.meta._
 import com.twilio.swagger.core.StructuredLogger
 
 package guardrail {
-  case class CodegenDefinitions(clients: List[Client], servers: List[Server])
+  case class CodegenDefinitions[L <: LA](clients: List[Client[L]], servers: List[Server])
 
   object Target {
     val A                              = Applicative[Target]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientGeneratorTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientGeneratorTerm.scala
@@ -9,7 +9,7 @@ import _root_.io.swagger.models.Operation
 
 sealed trait ClientTerm[L <: LA, T]
 case class GenerateClientOperation[L <: LA](className: List[String], route: RouteMeta, tracing: Boolean, protocolElems: List[StrictProtocolElems])
-    extends ClientTerm[L, RenderedClientOperation]
+    extends ClientTerm[L, RenderedClientOperation[L]]
 case class GetImports[L <: LA](tracing: Boolean)      extends ClientTerm[L, List[L#Import]]
 case class GetExtraImports[L <: LA](tracing: Boolean) extends ClientTerm[L, List[L#Import]]
 case class ClientClsArgs[L <: LA](tracingName: Option[String], schemes: List[String], host: Option[String], tracing: Boolean)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientGeneratorTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientGeneratorTerm.scala
@@ -2,32 +2,33 @@ package com.twilio.guardrail.protocol.terms.client
 
 import com.twilio.guardrail.{ RenderedClientOperation, StrictProtocolElems }
 import com.twilio.guardrail.terms.RouteMeta
+import com.twilio.guardrail.languages.LA
 import com.twilio.guardrail.generators.GeneratorSettings
 
-import scala.meta._
 import _root_.io.swagger.models.Operation
 
-sealed trait ClientTerm[T]
-case class GenerateClientOperation(className: List[String], route: RouteMeta, tracing: Boolean, protocolElems: List[StrictProtocolElems])
-    extends ClientTerm[RenderedClientOperation]
-case class GetImports(tracing: Boolean)                                                                              extends ClientTerm[List[Import]]
-case class GetExtraImports(tracing: Boolean)                                                                         extends ClientTerm[List[Import]]
-case class ClientClsArgs(tracingName: Option[String], schemes: List[String], host: Option[String], tracing: Boolean) extends ClientTerm[List[List[Term.Param]]]
-case class GenerateResponseDefinitions(operation: Operation, protocolElems: List[StrictProtocolElems])               extends ClientTerm[List[Defn]]
-case class BuildCompanion(clientName: String,
-                          tracingName: Option[String],
-                          schemes: List[String],
-                          host: Option[String],
-                          ctorArgs: List[List[Term.Param]],
-                          tracing: Boolean)
-    extends ClientTerm[Defn.Object]
-case class BuildClient(clientName: String,
-                       tracingName: Option[String],
-                       schemes: List[String],
-                       host: Option[String],
-                       basePath: Option[String],
-                       ctorArgs: List[List[Term.Param]],
-                       clientCalls: List[Defn],
-                       supportDefinitions: List[Defn],
-                       tracing: Boolean)
-    extends ClientTerm[Defn.Class]
+sealed trait ClientTerm[L <: LA, T]
+case class GenerateClientOperation[L <: LA](className: List[String], route: RouteMeta, tracing: Boolean, protocolElems: List[StrictProtocolElems])
+    extends ClientTerm[L, RenderedClientOperation]
+case class GetImports[L <: LA](tracing: Boolean)      extends ClientTerm[L, List[L#Import]]
+case class GetExtraImports[L <: LA](tracing: Boolean) extends ClientTerm[L, List[L#Import]]
+case class ClientClsArgs[L <: LA](tracingName: Option[String], schemes: List[String], host: Option[String], tracing: Boolean)
+    extends ClientTerm[L, List[List[L#MethodParameter]]]
+case class GenerateResponseDefinitions[L <: LA](operation: Operation, protocolElems: List[StrictProtocolElems]) extends ClientTerm[L, List[L#Definition]]
+case class BuildCompanion[L <: LA](clientName: String,
+                                   tracingName: Option[String],
+                                   schemes: List[String],
+                                   host: Option[String],
+                                   ctorArgs: List[List[L#MethodParameter]],
+                                   tracing: Boolean)
+    extends ClientTerm[L, L#ObjectDefinition]
+case class BuildClient[L <: LA](clientName: String,
+                                tracingName: Option[String],
+                                schemes: List[String],
+                                host: Option[String],
+                                basePath: Option[String],
+                                ctorArgs: List[List[L#MethodParameter]],
+                                clientCalls: List[L#Definition],
+                                supportDefinitions: List[L#Definition],
+                                tracing: Boolean)
+    extends ClientTerm[L, L#ClassDefinition]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientGeneratorTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientGeneratorTerm.scala
@@ -8,13 +8,13 @@ import com.twilio.guardrail.generators.GeneratorSettings
 import _root_.io.swagger.models.Operation
 
 sealed trait ClientTerm[L <: LA, T]
-case class GenerateClientOperation[L <: LA](className: List[String], route: RouteMeta, tracing: Boolean, protocolElems: List[StrictProtocolElems])
+case class GenerateClientOperation[L <: LA](className: List[String], route: RouteMeta, tracing: Boolean, protocolElems: List[StrictProtocolElems[L]])
     extends ClientTerm[L, RenderedClientOperation[L]]
 case class GetImports[L <: LA](tracing: Boolean)      extends ClientTerm[L, List[L#Import]]
 case class GetExtraImports[L <: LA](tracing: Boolean) extends ClientTerm[L, List[L#Import]]
 case class ClientClsArgs[L <: LA](tracingName: Option[String], schemes: List[String], host: Option[String], tracing: Boolean)
     extends ClientTerm[L, List[List[L#MethodParameter]]]
-case class GenerateResponseDefinitions[L <: LA](operation: Operation, protocolElems: List[StrictProtocolElems]) extends ClientTerm[L, List[L#Definition]]
+case class GenerateResponseDefinitions[L <: LA](operation: Operation, protocolElems: List[StrictProtocolElems[L]]) extends ClientTerm[L, List[L#Definition]]
 case class BuildCompanion[L <: LA](clientName: String,
                                    tracingName: Option[String],
                                    schemes: List[String],

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientGeneratorTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientGeneratorTerms.scala
@@ -10,7 +10,7 @@ import com.twilio.guardrail.terms.RouteMeta
 import _root_.io.swagger.models.Operation
 
 class ClientTerms[L <: LA, F[_]](implicit I: InjectK[ClientTerm[L, ?], F]) {
-  def generateClientOperation(className: List[String], tracing: Boolean, protocolElems: List[StrictProtocolElems])(
+  def generateClientOperation(className: List[String], tracing: Boolean, protocolElems: List[StrictProtocolElems[L]])(
       route: RouteMeta
   ): Free[F, RenderedClientOperation[L]] =
     Free.inject[ClientTerm[L, ?], F](GenerateClientOperation[L](className, route, tracing, protocolElems))
@@ -20,7 +20,7 @@ class ClientTerms[L <: LA, F[_]](implicit I: InjectK[ClientTerm[L, ?], F]) {
     Free.inject[ClientTerm[L, ?], F](GetExtraImports[L](tracing))
   def clientClsArgs(tracingName: Option[String], schemes: List[String], host: Option[String], tracing: Boolean): Free[F, List[List[L#MethodParameter]]] =
     Free.inject[ClientTerm[L, ?], F](ClientClsArgs[L](tracingName, schemes, host, tracing))
-  def generateResponseDefinitions(operation: Operation, protocolElems: List[StrictProtocolElems]): Free[F, List[L#Definition]] =
+  def generateResponseDefinitions(operation: Operation, protocolElems: List[StrictProtocolElems[L]]): Free[F, List[L#Definition]] =
     Free.inject[ClientTerm[L, ?], F](GenerateResponseDefinitions[L](operation, protocolElems))
   def buildCompanion(clientName: String,
                      tracingName: Option[String],

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientGeneratorTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientGeneratorTerms.scala
@@ -3,47 +3,47 @@ package com.twilio.guardrail.protocol.terms.client
 import cats.InjectK
 import cats.free.Free
 import com.twilio.guardrail.{ RenderedClientOperation, StrictProtocolElems }
-import com.twilio.guardrail.terms.RouteMeta
 import com.twilio.guardrail.generators.GeneratorSettings
+import com.twilio.guardrail.languages.LA
+import com.twilio.guardrail.terms.RouteMeta
 
-import scala.meta._
 import _root_.io.swagger.models.Operation
 
-class ClientTerms[F[_]](implicit I: InjectK[ClientTerm, F]) {
+class ClientTerms[L <: LA, F[_]](implicit I: InjectK[ClientTerm[L, ?], F]) {
   def generateClientOperation(className: List[String], tracing: Boolean, protocolElems: List[StrictProtocolElems])(
       route: RouteMeta
   ): Free[F, RenderedClientOperation] =
-    Free.inject[ClientTerm, F](GenerateClientOperation(className, route, tracing, protocolElems))
-  def getImports(tracing: Boolean): Free[F, List[Import]] =
-    Free.inject[ClientTerm, F](GetImports(tracing))
-  def getExtraImports(tracing: Boolean): Free[F, List[Import]] =
-    Free.inject[ClientTerm, F](GetExtraImports(tracing))
-  def clientClsArgs(tracingName: Option[String], schemes: List[String], host: Option[String], tracing: Boolean): Free[F, List[List[Term.Param]]] =
-    Free.inject[ClientTerm, F](ClientClsArgs(tracingName, schemes, host, tracing))
-  def generateResponseDefinitions(operation: Operation, protocolElems: List[StrictProtocolElems]): Free[F, List[Defn]] =
-    Free.inject[ClientTerm, F](GenerateResponseDefinitions(operation, protocolElems))
+    Free.inject[ClientTerm[L, ?], F](GenerateClientOperation[L](className, route, tracing, protocolElems))
+  def getImports(tracing: Boolean): Free[F, List[L#Import]] =
+    Free.inject[ClientTerm[L, ?], F](GetImports[L](tracing))
+  def getExtraImports(tracing: Boolean): Free[F, List[L#Import]] =
+    Free.inject[ClientTerm[L, ?], F](GetExtraImports[L](tracing))
+  def clientClsArgs(tracingName: Option[String], schemes: List[String], host: Option[String], tracing: Boolean): Free[F, List[List[L#MethodParameter]]] =
+    Free.inject[ClientTerm[L, ?], F](ClientClsArgs[L](tracingName, schemes, host, tracing))
+  def generateResponseDefinitions(operation: Operation, protocolElems: List[StrictProtocolElems]): Free[F, List[L#Definition]] =
+    Free.inject[ClientTerm[L, ?], F](GenerateResponseDefinitions[L](operation, protocolElems))
   def buildCompanion(clientName: String,
                      tracingName: Option[String],
                      schemes: List[String],
                      host: Option[String],
-                     ctorArgs: List[List[Term.Param]],
-                     tracing: Boolean): Free[F, Defn.Object] =
-    Free.inject[ClientTerm, F](BuildCompanion(clientName, tracingName, schemes, host, ctorArgs, tracing))
+                     ctorArgs: List[List[L#MethodParameter]],
+                     tracing: Boolean): Free[F, L#ObjectDefinition] =
+    Free.inject[ClientTerm[L, ?], F](BuildCompanion[L](clientName, tracingName, schemes, host, ctorArgs, tracing))
   def buildClient(clientName: String,
                   tracingName: Option[String],
                   schemes: List[String],
                   host: Option[String],
                   basePath: Option[String],
-                  ctorArgs: List[List[Term.Param]],
-                  clientCalls: List[Defn],
-                  supportDefinitions: List[Defn],
-                  tracing: Boolean): Free[F, Defn.Class] =
-    Free.inject[ClientTerm, F](
-      BuildClient(clientName, tracingName, schemes, host, basePath, ctorArgs, clientCalls, supportDefinitions, tracing)
+                  ctorArgs: List[List[L#MethodParameter]],
+                  clientCalls: List[L#Definition],
+                  supportDefinitions: List[L#Definition],
+                  tracing: Boolean): Free[F, L#ClassDefinition] =
+    Free.inject[ClientTerm[L, ?], F](
+      BuildClient[L](clientName, tracingName, schemes, host, basePath, ctorArgs, clientCalls, supportDefinitions, tracing)
     )
 }
 
 object ClientTerms {
-  implicit def enumTerms[F[_]](implicit I: InjectK[ClientTerm, F]): ClientTerms[F] =
-    new ClientTerms[F]
+  implicit def enumTerms[L <: LA, F[_]](implicit I: InjectK[ClientTerm[L, ?], F]): ClientTerms[L, F] =
+    new ClientTerms[L, F]
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientGeneratorTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientGeneratorTerms.scala
@@ -12,7 +12,7 @@ import _root_.io.swagger.models.Operation
 class ClientTerms[L <: LA, F[_]](implicit I: InjectK[ClientTerm[L, ?], F]) {
   def generateClientOperation(className: List[String], tracing: Boolean, protocolElems: List[StrictProtocolElems])(
       route: RouteMeta
-  ): Free[F, RenderedClientOperation] =
+  ): Free[F, RenderedClientOperation[L]] =
     Free.inject[ClientTerm[L, ?], F](GenerateClientOperation[L](className, route, tracing, protocolElems))
   def getImports(tracing: Boolean): Free[F, List[L#Import]] =
     Free.inject[ClientTerm[L, ?], F](GetImports[L](tracing))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/AliasProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/AliasProtocolTerm.scala
@@ -1,3 +1,5 @@
 package com.twilio.guardrail.protocol.terms.protocol
 
-sealed trait AliasProtocolTerm[T]
+import com.twilio.guardrail.languages.LA
+
+sealed trait AliasProtocolTerm[L <: LA, T]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/AliasProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/AliasProtocolTerms.scala
@@ -1,9 +1,10 @@
 package com.twilio.guardrail.protocol.terms.protocol
 
+import com.twilio.guardrail.languages.LA
 import cats.InjectK
 
-class AliasProtocolTerms[F[_]](implicit I: InjectK[AliasProtocolTerm, F]) {}
+class AliasProtocolTerms[L <: LA, F[_]](implicit I: InjectK[AliasProtocolTerm[L, ?], F]) {}
 object AliasProtocolTerms {
-  implicit def aliasProtocolTerm[F[_]](implicit I: InjectK[AliasProtocolTerm, F]): AliasProtocolTerms[F] =
-    new AliasProtocolTerms[F]
+  implicit def aliasProtocolTerm[L <: LA, F[_]](implicit I: InjectK[AliasProtocolTerm[L, ?], F]): AliasProtocolTerms[L, F] =
+    new AliasProtocolTerms[L, F]
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ArrayProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ArrayProtocolTerm.scala
@@ -2,8 +2,7 @@ package com.twilio.guardrail.protocol.terms.protocol
 
 import _root_.io.swagger.models.ArrayModel
 import com.twilio.guardrail.generators.GeneratorSettings
+import com.twilio.guardrail.languages.LA
 
-import scala.meta._
-
-sealed trait ArrayProtocolTerm[T]
-case class ExtractArrayType(arr: ArrayModel, concreteTypes: List[PropMeta]) extends ArrayProtocolTerm[Type]
+sealed trait ArrayProtocolTerm[L <: LA, T]
+case class ExtractArrayType[L <: LA](arr: ArrayModel, concreteTypes: List[PropMeta]) extends ArrayProtocolTerm[L, L#Type]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ArrayProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ArrayProtocolTerms.scala
@@ -4,15 +4,14 @@ import _root_.io.swagger.models.ArrayModel
 import cats.InjectK
 import cats.free.Free
 import com.twilio.guardrail.generators.GeneratorSettings
+import com.twilio.guardrail.languages.LA
 
-import scala.meta._
-
-class ArrayProtocolTerms[F[_]](implicit I: InjectK[ArrayProtocolTerm, F]) {
-  def extractArrayType(arr: ArrayModel, concreteTypes: List[PropMeta]): Free[F, Type] =
-    Free.inject[ArrayProtocolTerm, F](ExtractArrayType(arr, concreteTypes))
+class ArrayProtocolTerms[L <: LA, F[_]](implicit I: InjectK[ArrayProtocolTerm[L, ?], F]) {
+  def extractArrayType(arr: ArrayModel, concreteTypes: List[PropMeta]): Free[F, L#Type] =
+    Free.inject[ArrayProtocolTerm[L, ?], F](ExtractArrayType[L](arr, concreteTypes))
 }
 
 object ArrayProtocolTerms {
-  implicit def arrayProtocolTerms[F[_]](implicit I: InjectK[ArrayProtocolTerm, F]): ArrayProtocolTerms[F] =
-    new ArrayProtocolTerms[F]
+  implicit def arrayProtocolTerms[L <: LA, F[_]](implicit I: InjectK[ArrayProtocolTerm[L, ?], F]): ArrayProtocolTerms[L, F] =
+    new ArrayProtocolTerms[L, F]
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/EnumProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/EnumProtocolTerm.scala
@@ -2,15 +2,19 @@ package com.twilio.guardrail.protocol.terms.protocol
 
 import _root_.io.swagger.models.ModelImpl
 import com.twilio.guardrail.generators.GeneratorSettings
+import com.twilio.guardrail.languages.LA
 
-import scala.meta._
-
-sealed trait EnumProtocolTerm[T]
-case class ExtractEnum(swagger: ModelImpl)                                        extends EnumProtocolTerm[Either[String, List[String]]]
-case class ExtractType(swagger: ModelImpl)                                        extends EnumProtocolTerm[Either[String, Type]]
-case class RenderMembers(clsName: String, elems: List[(String, Term.Name, Term)]) extends EnumProtocolTerm[Defn.Object]
-case class EncodeEnum(clsName: String)                                            extends EnumProtocolTerm[Defn.Val]
-case class DecodeEnum(clsName: String)                                            extends EnumProtocolTerm[Defn.Val]
-case class RenderClass(clsName: String, tpe: Type)                                extends EnumProtocolTerm[Defn.Class]
-case class RenderCompanion(clsName: String, members: Defn.Object, accessors: List[meta.Defn.Val], values: meta.Defn.Val, encoder: Defn.Val, decoder: Defn.Val)
-    extends EnumProtocolTerm[Defn.Object]
+sealed trait EnumProtocolTerm[L <: LA, T]
+case class ExtractEnum[L <: LA](swagger: ModelImpl)                                           extends EnumProtocolTerm[L, Either[String, List[String]]]
+case class ExtractType[L <: LA](swagger: ModelImpl)                                           extends EnumProtocolTerm[L, Either[String, L#Type]]
+case class RenderMembers[L <: LA](clsName: String, elems: List[(String, L#TermName, L#Term)]) extends EnumProtocolTerm[L, L#ObjectDefinition]
+case class EncodeEnum[L <: LA](clsName: String)                                               extends EnumProtocolTerm[L, L#ValueDefinition]
+case class DecodeEnum[L <: LA](clsName: String)                                               extends EnumProtocolTerm[L, L#ValueDefinition]
+case class RenderClass[L <: LA](clsName: String, tpe: L#Type)                                 extends EnumProtocolTerm[L, L#ClassDefinition]
+case class RenderCompanion[L <: LA](clsName: String,
+                                    members: L#ObjectDefinition,
+                                    accessors: List[L#ValueDefinition],
+                                    values: L#ValueDefinition,
+                                    encoder: L#ValueDefinition,
+                                    decoder: L#ValueDefinition)
+    extends EnumProtocolTerm[L, L#ObjectDefinition]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/EnumProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/EnumProtocolTerms.scala
@@ -4,32 +4,31 @@ import _root_.io.swagger.models.ModelImpl
 import cats.InjectK
 import cats.free.Free
 import com.twilio.guardrail.generators.GeneratorSettings
+import com.twilio.guardrail.languages.LA
 
-import scala.meta._
-
-class EnumProtocolTerms[F[_]](implicit I: InjectK[EnumProtocolTerm, F]) {
+class EnumProtocolTerms[L <: LA, F[_]](implicit I: InjectK[EnumProtocolTerm[L, ?], F]) {
   def extractEnum(swagger: ModelImpl): Free[F, Either[String, List[String]]] =
-    Free.inject[EnumProtocolTerm, F](ExtractEnum(swagger))
-  def extractType(swagger: ModelImpl): Free[F, Either[String, Type]] =
-    Free.inject[EnumProtocolTerm, F](ExtractType(swagger))
-  def renderMembers(clsName: String, elems: List[(String, Term.Name, Term)]): Free[F, Defn.Object] =
-    Free.inject[EnumProtocolTerm, F](RenderMembers(clsName, elems))
-  def encodeEnum(clsName: String): Free[F, Defn.Val] =
-    Free.inject[EnumProtocolTerm, F](EncodeEnum(clsName))
-  def decodeEnum(clsName: String): Free[F, Defn.Val] =
-    Free.inject[EnumProtocolTerm, F](DecodeEnum(clsName))
-  def renderClass(clsName: String, tpe: Type): Free[F, Defn.Class] =
-    Free.inject[EnumProtocolTerm, F](RenderClass(clsName, tpe))
+    Free.inject[EnumProtocolTerm[L, ?], F](ExtractEnum[L](swagger))
+  def extractType(swagger: ModelImpl): Free[F, Either[String, L#Type]] =
+    Free.inject[EnumProtocolTerm[L, ?], F](ExtractType[L](swagger))
+  def renderMembers(clsName: String, elems: List[(String, L#TermName, L#Term)]): Free[F, L#ObjectDefinition] =
+    Free.inject[EnumProtocolTerm[L, ?], F](RenderMembers[L](clsName, elems))
+  def encodeEnum(clsName: String): Free[F, L#ValueDefinition] =
+    Free.inject[EnumProtocolTerm[L, ?], F](EncodeEnum[L](clsName))
+  def decodeEnum(clsName: String): Free[F, L#ValueDefinition] =
+    Free.inject[EnumProtocolTerm[L, ?], F](DecodeEnum[L](clsName))
+  def renderClass(clsName: String, tpe: L#Type): Free[F, L#ClassDefinition] =
+    Free.inject[EnumProtocolTerm[L, ?], F](RenderClass[L](clsName, tpe))
   def renderCompanion(clsName: String,
-                      members: Defn.Object,
-                      accessors: List[Defn.Val],
-                      values: Defn.Val,
-                      encoder: Defn.Val,
-                      decoder: Defn.Val): Free[F, Defn.Object] =
-    Free.inject[EnumProtocolTerm, F](RenderCompanion(clsName, members, accessors, values, encoder, decoder))
+                      members: L#ObjectDefinition,
+                      accessors: List[L#ValueDefinition],
+                      values: L#ValueDefinition,
+                      encoder: L#ValueDefinition,
+                      decoder: L#ValueDefinition): Free[F, L#ObjectDefinition] =
+    Free.inject[EnumProtocolTerm[L, ?], F](RenderCompanion[L](clsName, members, accessors, values, encoder, decoder))
 }
 
 object EnumProtocolTerms {
-  implicit def enumProtocolTerms[F[_]](implicit I: InjectK[EnumProtocolTerm, F]): EnumProtocolTerms[F] =
-    new EnumProtocolTerms[F]
+  implicit def enumProtocolTerms[L <: LA, F[_]](implicit I: InjectK[EnumProtocolTerm[L, ?], F]): EnumProtocolTerms[L, F] =
+    new EnumProtocolTerms[L, F]
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerm.scala
@@ -9,12 +9,12 @@ import com.twilio.guardrail.languages.LA
 sealed trait ModelProtocolTerm[L <: LA, T]
 case class ExtractProperties[L <: LA](swagger: Model) extends ModelProtocolTerm[L, List[(String, Property)]]
 case class TransformProperty[L <: LA](clsName: String, name: String, prop: Property, needCamelSnakeConversion: Boolean, concreteTypes: List[PropMeta])
-    extends ModelProtocolTerm[L, ProtocolParameter]
-case class RenderDTOClass[L <: LA](clsName: String, terms: List[L#MethodParameter], parents: List[SuperClass] = Nil)
+    extends ModelProtocolTerm[L, ProtocolParameter[L]]
+case class RenderDTOClass[L <: LA](clsName: String, terms: List[L#MethodParameter], parents: List[SuperClass[L]] = Nil)
     extends ModelProtocolTerm[L, L#ClassDefinition]
-case class EncodeModel[L <: LA](clsName: String, needCamelSnakeConversion: Boolean, params: List[ProtocolParameter], parents: List[SuperClass] = Nil)
+case class EncodeModel[L <: LA](clsName: String, needCamelSnakeConversion: Boolean, params: List[ProtocolParameter[L]], parents: List[SuperClass[L]] = Nil)
     extends ModelProtocolTerm[L, L#Statement]
-case class DecodeModel[L <: LA](clsName: String, needCamelSnakeConversion: Boolean, params: List[ProtocolParameter], parents: List[SuperClass] = Nil)
+case class DecodeModel[L <: LA](clsName: String, needCamelSnakeConversion: Boolean, params: List[ProtocolParameter[L]], parents: List[SuperClass[L]] = Nil)
     extends ModelProtocolTerm[L, L#Statement]
 case class RenderDTOCompanion[L <: LA](clsName: String, deps: List[L#TermName], encoder: L#Statement, decoder: L#Statement)
     extends ModelProtocolTerm[L, L#ObjectDefinition]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerm.scala
@@ -4,16 +4,17 @@ import _root_.io.swagger.models.{ ComposedModel, Model, ModelImpl }
 import _root_.io.swagger.models.properties.Property
 import com.twilio.guardrail.{ ProtocolParameter, SuperClass }
 import com.twilio.guardrail.generators.GeneratorSettings
+import com.twilio.guardrail.languages.LA
 
-import scala.meta._
-
-sealed trait ModelProtocolTerm[T]
-case class ExtractProperties(swagger: Model) extends ModelProtocolTerm[List[(String, Property)]]
-case class TransformProperty(clsName: String, name: String, prop: Property, needCamelSnakeConversion: Boolean, concreteTypes: List[PropMeta])
-    extends ModelProtocolTerm[ProtocolParameter]
-case class RenderDTOClass(clsName: String, terms: List[Term.Param], parents: List[SuperClass] = Nil) extends ModelProtocolTerm[Defn.Class]
-case class EncodeModel(clsName: String, needCamelSnakeConversion: Boolean, params: List[ProtocolParameter], parents: List[SuperClass] = Nil)
-    extends ModelProtocolTerm[Stat]
-case class DecodeModel(clsName: String, needCamelSnakeConversion: Boolean, params: List[ProtocolParameter], parents: List[SuperClass] = Nil)
-    extends ModelProtocolTerm[Stat]
-case class RenderDTOCompanion(clsName: String, deps: List[Term.Name], encoder: Stat, decoder: Stat) extends ModelProtocolTerm[Defn.Object]
+sealed trait ModelProtocolTerm[L <: LA, T]
+case class ExtractProperties[L <: LA](swagger: Model) extends ModelProtocolTerm[L, List[(String, Property)]]
+case class TransformProperty[L <: LA](clsName: String, name: String, prop: Property, needCamelSnakeConversion: Boolean, concreteTypes: List[PropMeta])
+    extends ModelProtocolTerm[L, ProtocolParameter]
+case class RenderDTOClass[L <: LA](clsName: String, terms: List[L#MethodParameter], parents: List[SuperClass] = Nil)
+    extends ModelProtocolTerm[L, L#ClassDefinition]
+case class EncodeModel[L <: LA](clsName: String, needCamelSnakeConversion: Boolean, params: List[ProtocolParameter], parents: List[SuperClass] = Nil)
+    extends ModelProtocolTerm[L, L#Statement]
+case class DecodeModel[L <: LA](clsName: String, needCamelSnakeConversion: Boolean, params: List[ProtocolParameter], parents: List[SuperClass] = Nil)
+    extends ModelProtocolTerm[L, L#Statement]
+case class RenderDTOCompanion[L <: LA](clsName: String, deps: List[L#TermName], encoder: L#Statement, decoder: L#Statement)
+    extends ModelProtocolTerm[L, L#ObjectDefinition]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerms.scala
@@ -7,6 +7,7 @@ import cats.free.Free
 import com.twilio.guardrail.{ ProtocolParameter, SuperClass }
 import com.twilio.guardrail.generators.GeneratorSettings
 import com.twilio.guardrail.languages.LA
+import com.twilio.guardrail.languages.ScalaLanguage
 
 class ModelProtocolTerms[L <: LA, F[_]](implicit I: InjectK[ModelProtocolTerm[L, ?], F]) {
   def extractProperties(swagger: Model): Free[F, List[(String, Property)]] =
@@ -14,13 +15,19 @@ class ModelProtocolTerms[L <: LA, F[_]](implicit I: InjectK[ModelProtocolTerm[L,
   def transformProperty(clsName: String, needCamelSnakeConversion: Boolean, concreteTypes: List[PropMeta])(
       name: String,
       prop: Property
-  ): Free[F, ProtocolParameter] =
+  ): Free[F, ProtocolParameter[L]] =
     Free.inject[ModelProtocolTerm[L, ?], F](TransformProperty[L](clsName, name, prop, needCamelSnakeConversion, concreteTypes))
-  def renderDTOClass(clsName: String, terms: List[L#MethodParameter], parents: List[SuperClass] = Nil): Free[F, L#ClassDefinition] =
+  def renderDTOClass(clsName: String, terms: List[L#MethodParameter], parents: List[SuperClass[L]] = Nil): Free[F, L#ClassDefinition] =
     Free.inject[ModelProtocolTerm[L, ?], F](RenderDTOClass[L](clsName, terms, parents))
-  def encodeModel(clsName: String, needCamelSnakeConversion: Boolean, params: List[ProtocolParameter], parents: List[SuperClass] = Nil): Free[F, L#Statement] =
+  def encodeModel(clsName: String,
+                  needCamelSnakeConversion: Boolean,
+                  params: List[ProtocolParameter[L]],
+                  parents: List[SuperClass[L]] = Nil): Free[F, L#Statement] =
     Free.inject[ModelProtocolTerm[L, ?], F](EncodeModel[L](clsName, needCamelSnakeConversion, params, parents))
-  def decodeModel(clsName: String, needCamelSnakeConversion: Boolean, params: List[ProtocolParameter], parents: List[SuperClass] = Nil): Free[F, L#Statement] =
+  def decodeModel(clsName: String,
+                  needCamelSnakeConversion: Boolean,
+                  params: List[ProtocolParameter[L]],
+                  parents: List[SuperClass[L]] = Nil): Free[F, L#Statement] =
     Free.inject[ModelProtocolTerm[L, ?], F](DecodeModel[L](clsName, needCamelSnakeConversion, params, parents))
   def renderDTOCompanion(clsName: String, deps: List[L#TermName], encoder: L#Statement, decoder: L#Statement): Free[F, L#ObjectDefinition] =
     Free.inject[ModelProtocolTerm[L, ?], F](RenderDTOCompanion[L](clsName, deps, encoder, decoder))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerms.scala
@@ -6,27 +6,26 @@ import cats.InjectK
 import cats.free.Free
 import com.twilio.guardrail.{ ProtocolParameter, SuperClass }
 import com.twilio.guardrail.generators.GeneratorSettings
+import com.twilio.guardrail.languages.LA
 
-import scala.meta._
-
-class ModelProtocolTerms[F[_]](implicit I: InjectK[ModelProtocolTerm, F]) {
+class ModelProtocolTerms[L <: LA, F[_]](implicit I: InjectK[ModelProtocolTerm[L, ?], F]) {
   def extractProperties(swagger: Model): Free[F, List[(String, Property)]] =
-    Free.inject[ModelProtocolTerm, F](ExtractProperties(swagger))
+    Free.inject[ModelProtocolTerm[L, ?], F](ExtractProperties[L](swagger))
   def transformProperty(clsName: String, needCamelSnakeConversion: Boolean, concreteTypes: List[PropMeta])(
       name: String,
       prop: Property
   ): Free[F, ProtocolParameter] =
-    Free.inject[ModelProtocolTerm, F](TransformProperty(clsName, name, prop, needCamelSnakeConversion, concreteTypes))
-  def renderDTOClass(clsName: String, terms: List[Term.Param], parents: List[SuperClass] = Nil): Free[F, Defn.Class] =
-    Free.inject[ModelProtocolTerm, F](RenderDTOClass(clsName, terms, parents))
-  def encodeModel(clsName: String, needCamelSnakeConversion: Boolean, params: List[ProtocolParameter], parents: List[SuperClass] = Nil): Free[F, Stat] =
-    Free.inject[ModelProtocolTerm, F](EncodeModel(clsName, needCamelSnakeConversion, params, parents))
-  def decodeModel(clsName: String, needCamelSnakeConversion: Boolean, params: List[ProtocolParameter], parents: List[SuperClass] = Nil): Free[F, Stat] =
-    Free.inject[ModelProtocolTerm, F](DecodeModel(clsName, needCamelSnakeConversion, params, parents))
-  def renderDTOCompanion(clsName: String, deps: List[Term.Name], encoder: Stat, decoder: Stat): Free[F, Defn.Object] =
-    Free.inject[ModelProtocolTerm, F](RenderDTOCompanion(clsName, deps, encoder, decoder))
+    Free.inject[ModelProtocolTerm[L, ?], F](TransformProperty[L](clsName, name, prop, needCamelSnakeConversion, concreteTypes))
+  def renderDTOClass(clsName: String, terms: List[L#MethodParameter], parents: List[SuperClass] = Nil): Free[F, L#ClassDefinition] =
+    Free.inject[ModelProtocolTerm[L, ?], F](RenderDTOClass[L](clsName, terms, parents))
+  def encodeModel(clsName: String, needCamelSnakeConversion: Boolean, params: List[ProtocolParameter], parents: List[SuperClass] = Nil): Free[F, L#Statement] =
+    Free.inject[ModelProtocolTerm[L, ?], F](EncodeModel[L](clsName, needCamelSnakeConversion, params, parents))
+  def decodeModel(clsName: String, needCamelSnakeConversion: Boolean, params: List[ProtocolParameter], parents: List[SuperClass] = Nil): Free[F, L#Statement] =
+    Free.inject[ModelProtocolTerm[L, ?], F](DecodeModel[L](clsName, needCamelSnakeConversion, params, parents))
+  def renderDTOCompanion(clsName: String, deps: List[L#TermName], encoder: L#Statement, decoder: L#Statement): Free[F, L#ObjectDefinition] =
+    Free.inject[ModelProtocolTerm[L, ?], F](RenderDTOCompanion[L](clsName, deps, encoder, decoder))
 }
 object ModelProtocolTerms {
-  implicit def modelProtocolTerm[F[_]](implicit I: InjectK[ModelProtocolTerm, F]): ModelProtocolTerms[F] =
-    new ModelProtocolTerms[F]
+  implicit def modelProtocolTerm[L <: LA, F[_]](implicit I: InjectK[ModelProtocolTerm[L, ?], F]): ModelProtocolTerms[L, F] =
+    new ModelProtocolTerms[L, F]
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/PolyProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/PolyProtocolTerm.scala
@@ -13,7 +13,7 @@ sealed trait PolyProtocolTerm[L <: LA, T]
 
 case class ExtractSuperClass[L <: LA](swagger: Model, definitions: List[(String, Model)]) extends PolyProtocolTerm[L, List[(String, Model, List[RefModel])]]
 
-case class RenderSealedTrait[L <: LA](className: String, terms: List[L#MethodParameter], discriminator: String, parents: List[SuperClass] = Nil)
+case class RenderSealedTrait[L <: LA](className: String, terms: List[L#MethodParameter], discriminator: String, parents: List[SuperClass[L]] = Nil)
     extends PolyProtocolTerm[L, L#Trait]
 
 case class EncodeADT[L <: LA](clsName: String, children: List[String] = Nil) extends PolyProtocolTerm[L, L#Statement]
@@ -30,7 +30,7 @@ class PolyProtocolTerms[L <: LA, F[_]](implicit I: InjectK[PolyProtocolTerm[L, ?
       className: String,
       terms: List[L#MethodParameter],
       discriminator: String,
-      parents: List[SuperClass] = Nil
+      parents: List[SuperClass[L]] = Nil
   ): Free[F, L#Trait] =
     Free.inject[PolyProtocolTerm[L, ?], F](RenderSealedTrait(className, terms, discriminator, parents))
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/PolyProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/PolyProtocolTerm.scala
@@ -1,55 +1,56 @@
 package com.twilio.guardrail.protocol.terms.protocol
+
 import cats.InjectK
 import cats.free.Free
 import com.twilio.guardrail.SuperClass
+import com.twilio.guardrail.languages.LA
 import io.swagger.models.{ Model, RefModel }
-
-import scala.meta.{ Defn, Stat, Term }
 
 /**
   * Protocol for Polymorphic models
   */
-sealed trait PolyProtocolTerm[T]
+sealed trait PolyProtocolTerm[L <: LA, T]
 
-case class ExtractSuperClass(swagger: Model, definitions: List[(String, Model)]) extends PolyProtocolTerm[List[(String, Model, List[RefModel])]]
+case class ExtractSuperClass[L <: LA](swagger: Model, definitions: List[(String, Model)]) extends PolyProtocolTerm[L, List[(String, Model, List[RefModel])]]
 
-case class RenderSealedTrait(className: String, terms: List[Term.Param], discriminator: String, parents: List[SuperClass] = Nil)
-    extends PolyProtocolTerm[Defn.Trait]
+case class RenderSealedTrait[L <: LA](className: String, terms: List[L#MethodParameter], discriminator: String, parents: List[SuperClass] = Nil)
+    extends PolyProtocolTerm[L, L#Trait]
 
-case class EncodeADT(clsName: String, children: List[String] = Nil) extends PolyProtocolTerm[Stat]
+case class EncodeADT[L <: LA](clsName: String, children: List[String] = Nil) extends PolyProtocolTerm[L, L#Statement]
 
-case class DecodeADT(clsName: String, children: List[String] = Nil) extends PolyProtocolTerm[Stat]
+case class DecodeADT[L <: LA](clsName: String, children: List[String] = Nil) extends PolyProtocolTerm[L, L#Statement]
 
-case class RenderADTCompanion(clsName: String, discriminator: String, encoder: Stat, decoder: Stat) extends PolyProtocolTerm[Defn.Object]
+case class RenderADTCompanion[L <: LA](clsName: String, discriminator: String, encoder: L#Statement, decoder: L#Statement)
+    extends PolyProtocolTerm[L, L#ObjectDefinition]
 
-class PolyProtocolTerms[F[_]](implicit I: InjectK[PolyProtocolTerm, F]) {
+class PolyProtocolTerms[L <: LA, F[_]](implicit I: InjectK[PolyProtocolTerm[L, ?], F]) {
   def extractSuperClass(swagger: Model, definitions: List[(String, Model)]): Free[F, List[(String, Model, List[RefModel])]] =
-    Free.inject[PolyProtocolTerm, F](ExtractSuperClass(swagger, definitions))
+    Free.inject[PolyProtocolTerm[L, ?], F](ExtractSuperClass(swagger, definitions))
   def renderSealedTrait(
       className: String,
-      terms: List[Term.Param],
+      terms: List[L#MethodParameter],
       discriminator: String,
       parents: List[SuperClass] = Nil
-  ): Free[F, Defn.Trait] =
-    Free.inject[PolyProtocolTerm, F](RenderSealedTrait(className, terms, discriminator, parents))
+  ): Free[F, L#Trait] =
+    Free.inject[PolyProtocolTerm[L, ?], F](RenderSealedTrait(className, terms, discriminator, parents))
 
-  def encodeADT(clsName: String, children: List[String] = Nil): Free[F, Stat] =
-    Free.inject[PolyProtocolTerm, F](EncodeADT(clsName, children))
+  def encodeADT(clsName: String, children: List[String] = Nil): Free[F, L#Statement] =
+    Free.inject[PolyProtocolTerm[L, ?], F](EncodeADT(clsName, children))
 
-  def decodeADT(clsName: String, children: List[String] = Nil): Free[F, Stat] =
-    Free.inject[PolyProtocolTerm, F](DecodeADT(clsName, children))
+  def decodeADT(clsName: String, children: List[String] = Nil): Free[F, L#Statement] =
+    Free.inject[PolyProtocolTerm[L, ?], F](DecodeADT(clsName, children))
 
   def renderADTCompanion(
       clsName: String,
       discriminator: String,
-      encoder: Stat,
-      decoder: Stat
-  ): Free[F, Defn.Object] =
-    Free.inject[PolyProtocolTerm, F](RenderADTCompanion(clsName, discriminator, encoder, decoder))
+      encoder: L#Statement,
+      decoder: L#Statement
+  ): Free[F, L#ObjectDefinition] =
+    Free.inject[PolyProtocolTerm[L, ?], F](RenderADTCompanion(clsName, discriminator, encoder, decoder))
 
 }
 
 object PolyProtocolTerms {
-  implicit def polyProtocolTerms[F[_]](implicit I: InjectK[PolyProtocolTerm, F]): PolyProtocolTerms[F] =
-    new PolyProtocolTerms[F]()
+  implicit def polyProtocolTerms[L <: LA, F[_]](implicit I: InjectK[PolyProtocolTerm[L, ?], F]): PolyProtocolTerms[L, F] =
+    new PolyProtocolTerms[L, F]()
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ProtocolSupportTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ProtocolSupportTerm.scala
@@ -1,14 +1,13 @@
 package com.twilio.guardrail.protocol.terms.protocol
 
 import _root_.io.swagger.models.Model
+import com.twilio.guardrail.languages.{ LA, ScalaLanguage }
 import com.twilio.guardrail.{ ProtocolElems, StrictProtocolElems }
 
-import scala.meta._
-
-case class PropMeta(clsName: String, tpe: Type)
-sealed trait ProtocolSupportTerm[T]
-case class ExtractConcreteTypes(models: List[(String, Model)]) extends ProtocolSupportTerm[List[PropMeta]]
-case class ProtocolImports()                                   extends ProtocolSupportTerm[List[Import]]
-case class PackageObjectImports()                              extends ProtocolSupportTerm[List[Import]]
-case class PackageObjectContents()                             extends ProtocolSupportTerm[List[Defn.Val]]
-case class ResolveProtocolElems(elems: List[ProtocolElems])    extends ProtocolSupportTerm[List[StrictProtocolElems]]
+case class PropMeta(clsName: String, tpe: ScalaLanguage#Type)
+sealed trait ProtocolSupportTerm[L <: LA, T]
+case class ExtractConcreteTypes[L <: LA](models: List[(String, Model)]) extends ProtocolSupportTerm[L, List[PropMeta]]
+case class ProtocolImports[L <: LA]()                                   extends ProtocolSupportTerm[L, List[L#Import]]
+case class PackageObjectImports[L <: LA]()                              extends ProtocolSupportTerm[L, List[L#Import]]
+case class PackageObjectContents[L <: LA]()                             extends ProtocolSupportTerm[L, List[L#ValueDefinition]]
+case class ResolveProtocolElems[L <: LA](elems: List[ProtocolElems])    extends ProtocolSupportTerm[L, List[StrictProtocolElems]]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ProtocolSupportTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ProtocolSupportTerm.scala
@@ -10,4 +10,4 @@ case class ExtractConcreteTypes[L <: LA](models: List[(String, Model)]) extends 
 case class ProtocolImports[L <: LA]()                                   extends ProtocolSupportTerm[L, List[L#Import]]
 case class PackageObjectImports[L <: LA]()                              extends ProtocolSupportTerm[L, List[L#Import]]
 case class PackageObjectContents[L <: LA]()                             extends ProtocolSupportTerm[L, List[L#ValueDefinition]]
-case class ResolveProtocolElems[L <: LA](elems: List[ProtocolElems])    extends ProtocolSupportTerm[L, List[StrictProtocolElems]]
+case class ResolveProtocolElems[L <: LA](elems: List[ProtocolElems[L]]) extends ProtocolSupportTerm[L, List[StrictProtocolElems[L]]]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ProtocolSupportTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ProtocolSupportTerms.scala
@@ -3,23 +3,22 @@ package com.twilio.guardrail.protocol.terms.protocol
 import _root_.io.swagger.models.Model
 import cats.InjectK
 import cats.free.Free
+import com.twilio.guardrail.languages.LA
 import com.twilio.guardrail.{ ProtocolElems, StrictProtocolElems }
 
-import scala.meta._
-
-class ProtocolSupportTerms[F[_]](implicit I: InjectK[ProtocolSupportTerm, F]) {
+class ProtocolSupportTerms[L <: LA, F[_]](implicit I: InjectK[ProtocolSupportTerm[L, ?], F]) {
   def extractConcreteTypes(models: List[(String, Model)]): Free[F, List[PropMeta]] =
-    Free.inject[ProtocolSupportTerm, F](ExtractConcreteTypes(models))
-  def protocolImports(): Free[F, List[Import]] =
-    Free.inject[ProtocolSupportTerm, F](ProtocolImports())
-  def packageObjectImports(): Free[F, List[Import]] =
-    Free.inject[ProtocolSupportTerm, F](PackageObjectImports())
-  def packageObjectContents(): Free[F, List[Defn.Val]] =
-    Free.inject[ProtocolSupportTerm, F](PackageObjectContents())
+    Free.inject[ProtocolSupportTerm[L, ?], F](ExtractConcreteTypes(models))
+  def protocolImports(): Free[F, List[L#Import]] =
+    Free.inject[ProtocolSupportTerm[L, ?], F](ProtocolImports())
+  def packageObjectImports(): Free[F, List[L#Import]] =
+    Free.inject[ProtocolSupportTerm[L, ?], F](PackageObjectImports())
+  def packageObjectContents(): Free[F, List[L#ValueDefinition]] =
+    Free.inject[ProtocolSupportTerm[L, ?], F](PackageObjectContents())
   def resolveProtocolElems(elems: List[ProtocolElems]): Free[F, List[StrictProtocolElems]] =
-    Free.inject[ProtocolSupportTerm, F](ResolveProtocolElems(elems))
+    Free.inject[ProtocolSupportTerm[L, ?], F](ResolveProtocolElems(elems))
 }
 object ProtocolSupportTerms {
-  implicit def protocolSupportTerms[F[_]](implicit I: InjectK[ProtocolSupportTerm, F]): ProtocolSupportTerms[F] =
-    new ProtocolSupportTerms[F]
+  implicit def protocolSupportTerms[L <: LA, F[_]](implicit I: InjectK[ProtocolSupportTerm[L, ?], F]): ProtocolSupportTerms[L, F] =
+    new ProtocolSupportTerms[L, F]
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ProtocolSupportTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ProtocolSupportTerms.scala
@@ -15,7 +15,7 @@ class ProtocolSupportTerms[L <: LA, F[_]](implicit I: InjectK[ProtocolSupportTer
     Free.inject[ProtocolSupportTerm[L, ?], F](PackageObjectImports())
   def packageObjectContents(): Free[F, List[L#ValueDefinition]] =
     Free.inject[ProtocolSupportTerm[L, ?], F](PackageObjectContents())
-  def resolveProtocolElems(elems: List[ProtocolElems]): Free[F, List[StrictProtocolElems]] =
+  def resolveProtocolElems(elems: List[ProtocolElems[L]]): Free[F, List[StrictProtocolElems[L]]] =
     Free.inject[ProtocolSupportTerm[L, ?], F](ResolveProtocolElems(elems))
 }
 object ProtocolSupportTerms {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerm.scala
@@ -3,27 +3,27 @@ package com.twilio.guardrail.protocol.terms.server
 import _root_.io.swagger.models.{ Operation, Path }
 import com.twilio.guardrail.generators.GeneratorSettings
 import com.twilio.guardrail.{ RenderedRoutes, ServerRoute, StrictProtocolElems, TracingField }
+import com.twilio.guardrail.languages.LA
 
-import scala.meta._
+sealed trait ServerTerm[L <: LA, T]
+case class ExtractOperations[L <: LA](paths: List[(String, Path)]) extends ServerTerm[L, List[ServerRoute]]
 
-sealed trait ServerTerm[T]
-case class ExtractOperations(paths: List[(String, Path)]) extends ServerTerm[List[ServerRoute]]
-
-case class GetClassName(operation: Operation)                                                     extends ServerTerm[List[String]]
-case class BuildTracingFields(operation: Operation, resourceName: List[String], tracing: Boolean) extends ServerTerm[Option[TracingField]]
-case class GenerateRoutes(resourceName: String,
-                          basePath: Option[String],
-                          routes: List[(Option[TracingField], ServerRoute)],
-                          protocolElems: List[StrictProtocolElems])
-    extends ServerTerm[RenderedRoutes]
-case class GetExtraRouteParams(tracing: Boolean)                                                       extends ServerTerm[List[Term.Param]]
-case class GenerateResponseDefinitions(operation: Operation, protocolElems: List[StrictProtocolElems]) extends ServerTerm[List[Defn]]
-case class RenderClass(className: String,
-                       handlerName: String,
-                       combinedRouteTerms: Term,
-                       extraRouteParams: List[Term.Param],
-                       responseDefinitions: List[Defn],
-                       supportDefinitions: List[Defn])
-    extends ServerTerm[List[Stat]]
-case class RenderHandler(handlerName: String, methodSigs: List[Decl.Def], handlerDefinitions: List[Stat]) extends ServerTerm[Stat]
-case class GetExtraImports(tracing: Boolean)                                                              extends ServerTerm[List[Import]]
+case class GetClassName[L <: LA](operation: Operation)                                                     extends ServerTerm[L, List[String]]
+case class BuildTracingFields[L <: LA](operation: Operation, resourceName: List[String], tracing: Boolean) extends ServerTerm[L, Option[TracingField]]
+case class GenerateRoutes[L <: LA](resourceName: String,
+                                   basePath: Option[String],
+                                   routes: List[(Option[TracingField], ServerRoute)],
+                                   protocolElems: List[StrictProtocolElems])
+    extends ServerTerm[L, RenderedRoutes]
+case class GetExtraRouteParams[L <: LA](tracing: Boolean)                                                       extends ServerTerm[L, List[L#MethodParameter]]
+case class GenerateResponseDefinitions[L <: LA](operation: Operation, protocolElems: List[StrictProtocolElems]) extends ServerTerm[L, List[L#Definition]]
+case class RenderClass[L <: LA](className: String,
+                                handlerName: String,
+                                combinedRouteTerms: L#Term,
+                                extraRouteParams: List[L#MethodParameter],
+                                responseDefinitions: List[L#Definition],
+                                supportDefinitions: List[L#Definition])
+    extends ServerTerm[L, List[L#Statement]]
+case class RenderHandler[L <: LA](handlerName: String, methodSigs: List[L#MethodDeclaration], handlerDefinitions: List[L#Statement])
+    extends ServerTerm[L, L#Statement]
+case class GetExtraImports[L <: LA](tracing: Boolean) extends ServerTerm[L, List[L#Import]]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerm.scala
@@ -9,12 +9,12 @@ sealed trait ServerTerm[L <: LA, T]
 case class ExtractOperations[L <: LA](paths: List[(String, Path)]) extends ServerTerm[L, List[ServerRoute]]
 
 case class GetClassName[L <: LA](operation: Operation)                                                     extends ServerTerm[L, List[String]]
-case class BuildTracingFields[L <: LA](operation: Operation, resourceName: List[String], tracing: Boolean) extends ServerTerm[L, Option[TracingField]]
+case class BuildTracingFields[L <: LA](operation: Operation, resourceName: List[String], tracing: Boolean) extends ServerTerm[L, Option[TracingField[L]]]
 case class GenerateRoutes[L <: LA](resourceName: String,
                                    basePath: Option[String],
-                                   routes: List[(Option[TracingField], ServerRoute)],
+                                   routes: List[(Option[TracingField[L]], ServerRoute)],
                                    protocolElems: List[StrictProtocolElems])
-    extends ServerTerm[L, RenderedRoutes]
+    extends ServerTerm[L, RenderedRoutes[L]]
 case class GetExtraRouteParams[L <: LA](tracing: Boolean)                                                       extends ServerTerm[L, List[L#MethodParameter]]
 case class GenerateResponseDefinitions[L <: LA](operation: Operation, protocolElems: List[StrictProtocolElems]) extends ServerTerm[L, List[L#Definition]]
 case class RenderClass[L <: LA](className: String,

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerm.scala
@@ -13,10 +13,10 @@ case class BuildTracingFields[L <: LA](operation: Operation, resourceName: List[
 case class GenerateRoutes[L <: LA](resourceName: String,
                                    basePath: Option[String],
                                    routes: List[(Option[TracingField[L]], ServerRoute)],
-                                   protocolElems: List[StrictProtocolElems])
+                                   protocolElems: List[StrictProtocolElems[L]])
     extends ServerTerm[L, RenderedRoutes[L]]
-case class GetExtraRouteParams[L <: LA](tracing: Boolean)                                                       extends ServerTerm[L, List[L#MethodParameter]]
-case class GenerateResponseDefinitions[L <: LA](operation: Operation, protocolElems: List[StrictProtocolElems]) extends ServerTerm[L, List[L#Definition]]
+case class GetExtraRouteParams[L <: LA](tracing: Boolean)                                                          extends ServerTerm[L, List[L#MethodParameter]]
+case class GenerateResponseDefinitions[L <: LA](operation: Operation, protocolElems: List[StrictProtocolElems[L]]) extends ServerTerm[L, List[L#Definition]]
 case class RenderClass[L <: LA](className: String,
                                 handlerName: String,
                                 combinedRouteTerms: L#Term,

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerms.scala
@@ -17,11 +17,11 @@ class ServerTerms[L <: LA, F[_]](implicit I: InjectK[ServerTerm[L, ?], F]) {
   def generateRoutes(resourceName: String,
                      basePath: Option[String],
                      routes: List[(Option[TracingField[L]], ServerRoute)],
-                     protocolElems: List[StrictProtocolElems]): Free[F, RenderedRoutes[L]] =
+                     protocolElems: List[StrictProtocolElems[L]]): Free[F, RenderedRoutes[L]] =
     Free.inject[ServerTerm[L, ?], F](GenerateRoutes(resourceName, basePath, routes, protocolElems))
   def getExtraRouteParams(tracing: Boolean): Free[F, List[L#MethodParameter]] =
     Free.inject[ServerTerm[L, ?], F](GetExtraRouteParams(tracing))
-  def generateResponseDefinitions(operation: Operation, protocolElems: List[StrictProtocolElems]): Free[F, List[L#Definition]] =
+  def generateResponseDefinitions(operation: Operation, protocolElems: List[StrictProtocolElems[L]]): Free[F, List[L#Definition]] =
     Free.inject[ServerTerm[L, ?], F](GenerateResponseDefinitions(operation, protocolElems))
   def renderClass(resourceName: String,
                   handlerName: String,

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerms.scala
@@ -5,39 +5,38 @@ import cats.InjectK
 import cats.free.Free
 import com.twilio.guardrail.generators.GeneratorSettings
 import com.twilio.guardrail.{ RenderedRoutes, ServerRoute, StrictProtocolElems, TracingField }
+import com.twilio.guardrail.languages.LA
 
-import scala.meta._
-
-class ServerTerms[F[_]](implicit I: InjectK[ServerTerm, F]) {
+class ServerTerms[L <: LA, F[_]](implicit I: InjectK[ServerTerm[L, ?], F]) {
   def extractOperations(paths: List[(String, Path)]): Free[F, List[ServerRoute]] =
-    Free.inject(ExtractOperations(paths))
+    Free.inject[ServerTerm[L, ?], F](ExtractOperations(paths))
   def getClassName(operation: Operation): Free[F, List[String]] =
-    Free.inject(GetClassName(operation))
+    Free.inject[ServerTerm[L, ?], F](GetClassName(operation))
   def buildTracingFields(operation: Operation, resourceName: List[String], tracing: Boolean): Free[F, Option[TracingField]] =
-    Free.inject(BuildTracingFields(operation, resourceName, tracing))
+    Free.inject[ServerTerm[L, ?], F](BuildTracingFields(operation, resourceName, tracing))
   def generateRoutes(resourceName: String,
                      basePath: Option[String],
                      routes: List[(Option[TracingField], ServerRoute)],
                      protocolElems: List[StrictProtocolElems]): Free[F, RenderedRoutes] =
-    Free.inject(GenerateRoutes(resourceName, basePath, routes, protocolElems))
-  def getExtraRouteParams(tracing: Boolean): Free[F, List[Term.Param]] =
-    Free.inject(GetExtraRouteParams(tracing))
-  def generateResponseDefinitions(operation: Operation, protocolElems: List[StrictProtocolElems]): Free[F, List[Defn]] =
-    Free.inject(GenerateResponseDefinitions(operation, protocolElems))
+    Free.inject[ServerTerm[L, ?], F](GenerateRoutes(resourceName, basePath, routes, protocolElems))
+  def getExtraRouteParams(tracing: Boolean): Free[F, List[L#MethodParameter]] =
+    Free.inject[ServerTerm[L, ?], F](GetExtraRouteParams(tracing))
+  def generateResponseDefinitions(operation: Operation, protocolElems: List[StrictProtocolElems]): Free[F, List[L#Definition]] =
+    Free.inject[ServerTerm[L, ?], F](GenerateResponseDefinitions(operation, protocolElems))
   def renderClass(resourceName: String,
                   handlerName: String,
-                  combinedRouteTerms: Term,
-                  extraRouteParams: List[Term.Param],
-                  responseDefinitions: List[Defn],
-                  supportDefinitions: List[Defn]): Free[F, List[Stat]] =
-    Free.inject(RenderClass(resourceName, handlerName, combinedRouteTerms, extraRouteParams, responseDefinitions, supportDefinitions))
-  def renderHandler(handlerName: String, methodSigs: List[Decl.Def], handlerDefinitions: List[Stat]) =
-    Free.inject(RenderHandler(handlerName, methodSigs, handlerDefinitions))
-  def getExtraImports(tracing: Boolean): Free[F, List[Import]] =
-    Free.inject(GetExtraImports(tracing))
+                  combinedRouteTerms: L#Term,
+                  extraRouteParams: List[L#MethodParameter],
+                  responseDefinitions: List[L#Definition],
+                  supportDefinitions: List[L#Definition]): Free[F, List[L#Statement]] =
+    Free.inject[ServerTerm[L, ?], F](RenderClass(resourceName, handlerName, combinedRouteTerms, extraRouteParams, responseDefinitions, supportDefinitions))
+  def renderHandler(handlerName: String, methodSigs: List[L#MethodDeclaration], handlerDefinitions: List[L#Statement]) =
+    Free.inject[ServerTerm[L, ?], F](RenderHandler(handlerName, methodSigs, handlerDefinitions))
+  def getExtraImports(tracing: Boolean): Free[F, List[L#Import]] =
+    Free.inject[ServerTerm[L, ?], F](GetExtraImports(tracing))
 }
 
 object ServerTerms {
-  implicit def serverTerms[F[_]](implicit I: InjectK[ServerTerm, F]): ServerTerms[F] =
-    new ServerTerms[F]
+  implicit def serverTerms[L <: LA, F[_]](implicit I: InjectK[ServerTerm[L, ?], F]): ServerTerms[L, F] =
+    new ServerTerms[L, F]
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerms.scala
@@ -12,12 +12,12 @@ class ServerTerms[L <: LA, F[_]](implicit I: InjectK[ServerTerm[L, ?], F]) {
     Free.inject[ServerTerm[L, ?], F](ExtractOperations(paths))
   def getClassName(operation: Operation): Free[F, List[String]] =
     Free.inject[ServerTerm[L, ?], F](GetClassName(operation))
-  def buildTracingFields(operation: Operation, resourceName: List[String], tracing: Boolean): Free[F, Option[TracingField]] =
+  def buildTracingFields(operation: Operation, resourceName: List[String], tracing: Boolean): Free[F, Option[TracingField[L]]] =
     Free.inject[ServerTerm[L, ?], F](BuildTracingFields(operation, resourceName, tracing))
   def generateRoutes(resourceName: String,
                      basePath: Option[String],
-                     routes: List[(Option[TracingField], ServerRoute)],
-                     protocolElems: List[StrictProtocolElems]): Free[F, RenderedRoutes] =
+                     routes: List[(Option[TracingField[L]], ServerRoute)],
+                     protocolElems: List[StrictProtocolElems]): Free[F, RenderedRoutes[L]] =
     Free.inject[ServerTerm[L, ?], F](GenerateRoutes(resourceName, basePath, routes, protocolElems))
   def getExtraRouteParams(tracing: Boolean): Free[F, List[L#MethodParameter]] =
     Free.inject[ServerTerm[L, ?], F](GetExtraRouteParams(tracing))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/CoreTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/CoreTerm.scala
@@ -3,7 +3,6 @@ package terms
 
 import cats.arrow.FunctionK
 import cats.data.NonEmptyList
-import scala.meta._
 import com.twilio.guardrail.generators.GeneratorSettings
 
 sealed trait CoreTerm[T]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/CoreTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/CoreTerms.scala
@@ -5,7 +5,6 @@ import cats.InjectK
 import cats.arrow.FunctionK
 import cats.data.NonEmptyList
 import cats.free.Free
-import com.twilio.guardrail.{ CodegenApplication, Target }
 import com.twilio.guardrail.generators.GeneratorSettings
 
 import scala.meta._

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/CoreTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/CoreTerms.scala
@@ -7,8 +7,6 @@ import cats.data.NonEmptyList
 import cats.free.Free
 import com.twilio.guardrail.generators.GeneratorSettings
 
-import scala.meta._
-
 class CoreTerms[F[_]](implicit I: InjectK[CoreTerm, F]) {
   def getDefaultFramework: Free[F, String] =
     Free.inject[CoreTerm, F](GetDefaultFramework)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerm.scala
@@ -1,10 +1,13 @@
 package com.twilio.guardrail
 package terms
 
-import scala.meta._
+import com.twilio.guardrail.languages.LA
 
-sealed trait ScalaTerm[T]
-case class RenderImplicits(pkgName: List[String], frameworkImports: List[Import], jsonImports: List[Import], customImports: List[Import])
-    extends ScalaTerm[Source]
-case class RenderFrameworkImplicits(pkgName: List[String], frameworkImports: List[Import], jsonImports: List[Import], frameworkImplicits: Defn.Object)
-    extends ScalaTerm[Source]
+sealed trait ScalaTerm[L <: LA, T]
+case class RenderImplicits[L <: LA](pkgName: List[String], frameworkImports: List[L#Import], jsonImports: List[L#Import], customImports: List[L#Import])
+    extends ScalaTerm[L, L#FileContents]
+case class RenderFrameworkImplicits[L <: LA](pkgName: List[String],
+                                             frameworkImports: List[L#Import],
+                                             jsonImports: List[L#Import],
+                                             frameworkImplicits: L#ObjectDefinition)
+    extends ScalaTerm[L, L#FileContents]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerm.scala
@@ -2,6 +2,7 @@ package com.twilio.guardrail
 package terms
 
 import com.twilio.guardrail.languages.LA
+import java.nio.file.Path
 
 sealed trait ScalaTerm[L <: LA, T]
 case class RenderImplicits[L <: LA](pkgName: List[String], frameworkImports: List[L#Import], jsonImports: List[L#Import], customImports: List[L#Import])
@@ -11,3 +12,11 @@ case class RenderFrameworkImplicits[L <: LA](pkgName: List[String],
                                              jsonImports: List[L#Import],
                                              frameworkImplicits: L#ObjectDefinition)
     extends ScalaTerm[L, L#FileContents]
+case class WritePackageObject[L <: LA](dtoPackagePath: Path,
+                                       dtoComponents: List[String],
+                                       customImports: List[L#Import],
+                                       packageObjectImports: List[L#Import],
+                                       protocolImports: List[L#Import],
+                                       packageObjectContents: List[L#Statement],
+                                       extraTypes: List[L#Statement])
+    extends ScalaTerm[L, WriteTree]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerms.scala
@@ -4,6 +4,7 @@ package terms
 import cats.InjectK
 import cats.free.Free
 import com.twilio.guardrail.languages.LA
+import java.nio.file.Path
 
 class ScalaTerms[L <: LA, F[_]](implicit I: InjectK[ScalaTerm[L, ?], F]) {
   def renderImplicits(pkgName: List[String],
@@ -16,6 +17,17 @@ class ScalaTerms[L <: LA, F[_]](implicit I: InjectK[ScalaTerm[L, ?], F]) {
                                jsonImports: List[L#Import],
                                frameworkImplicits: L#ObjectDefinition): Free[F, L#FileContents] =
     Free.inject[ScalaTerm[L, ?], F](RenderFrameworkImplicits(pkgName, frameworkImports, jsonImports, frameworkImplicits))
+
+  def writePackageObject(dtoPackagePath: Path,
+                         dtoComponents: List[String],
+                         customImports: List[L#Import],
+                         packageObjectImports: List[L#Import],
+                         protocolImports: List[L#Import],
+                         packageObjectContents: List[L#Statement],
+                         extraTypes: List[L#Statement]): Free[F, WriteTree] =
+    Free.inject[ScalaTerm[L, ?], F](
+      WritePackageObject(dtoPackagePath, dtoComponents, customImports, packageObjectImports, protocolImports, packageObjectContents, extraTypes)
+    )
 }
 object ScalaTerms {
   implicit def scalaTerm[L <: LA, F[_]](implicit I: InjectK[ScalaTerm[L, ?], F]): ScalaTerms[L, F] = new ScalaTerms[L, F]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerms.scala
@@ -3,18 +3,20 @@ package terms
 
 import cats.InjectK
 import cats.free.Free
+import com.twilio.guardrail.languages.LA
 
-import scala.meta._
-
-class ScalaTerms[F[_]](implicit I: InjectK[ScalaTerm, F]) {
-  def renderImplicits(pkgName: List[String], frameworkImports: List[Import], jsonImports: List[Import], customImports: List[Import]): Free[F, Source] =
-    Free.inject[ScalaTerm, F](RenderImplicits(pkgName, frameworkImports, jsonImports, customImports))
+class ScalaTerms[L <: LA, F[_]](implicit I: InjectK[ScalaTerm[L, ?], F]) {
+  def renderImplicits(pkgName: List[String],
+                      frameworkImports: List[L#Import],
+                      jsonImports: List[L#Import],
+                      customImports: List[L#Import]): Free[F, L#FileContents] =
+    Free.inject[ScalaTerm[L, ?], F](RenderImplicits(pkgName, frameworkImports, jsonImports, customImports))
   def renderFrameworkImplicits(pkgName: List[String],
-                               frameworkImports: List[Import],
-                               jsonImports: List[Import],
-                               frameworkImplicits: Defn.Object): Free[F, Source] =
-    Free.inject[ScalaTerm, F](RenderFrameworkImplicits(pkgName, frameworkImports, jsonImports, frameworkImplicits))
+                               frameworkImports: List[L#Import],
+                               jsonImports: List[L#Import],
+                               frameworkImplicits: L#ObjectDefinition): Free[F, L#FileContents] =
+    Free.inject[ScalaTerm[L, ?], F](RenderFrameworkImplicits(pkgName, frameworkImports, jsonImports, frameworkImplicits))
 }
 object ScalaTerms {
-  implicit def scalaTerm[F[_]](implicit I: InjectK[ScalaTerm, F]): ScalaTerms[F] = new ScalaTerms[F]
+  implicit def scalaTerm[L <: LA, F[_]](implicit I: InjectK[ScalaTerm[L, ?], F]): ScalaTerms[L, F] = new ScalaTerms[L, F]
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
@@ -2,10 +2,10 @@ package com.twilio.guardrail
 package terms
 
 import _root_.io.swagger.models._
-import scala.meta._
+import com.twilio.guardrail.languages.LA
 
 case class RouteMeta(path: String, method: HttpMethod, operation: Operation)
 
-sealed trait SwaggerTerm[T]
-case class ExtractOperations(paths: List[(String, Path)]) extends SwaggerTerm[List[RouteMeta]]
-case class GetClassName(operation: Operation)             extends SwaggerTerm[List[String]]
+sealed trait SwaggerTerm[L <: LA, T]
+case class ExtractOperations[L <: LA](paths: List[(String, Path)]) extends SwaggerTerm[L, List[RouteMeta]]
+case class GetClassName[L <: LA](operation: Operation)             extends SwaggerTerm[L, List[String]]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerms.scala
@@ -4,16 +4,15 @@ package terms
 import _root_.io.swagger.models.{ ModelImpl, Operation, Path }
 import cats.InjectK
 import cats.free.Free
+import com.twilio.guardrail.languages.LA
 
-import scala.meta._
-
-class SwaggerTerms[F[_]](implicit I: InjectK[SwaggerTerm, F]) {
+class SwaggerTerms[L <: LA, F[_]](implicit I: InjectK[SwaggerTerm[L, ?], F]) {
   def extractOperations(paths: List[(String, Path)]): Free[F, List[RouteMeta]] =
-    Free.inject[SwaggerTerm, F](ExtractOperations(paths))
+    Free.inject[SwaggerTerm[L, ?], F](ExtractOperations(paths))
   def getClassName(operation: Operation): Free[F, List[String]] =
-    Free.inject[SwaggerTerm, F](GetClassName(operation))
+    Free.inject[SwaggerTerm[L, ?], F](GetClassName(operation))
 }
 object SwaggerTerms {
-  implicit def swaggerTerm[F[_]](implicit I: InjectK[SwaggerTerm, F]): SwaggerTerms[F] =
-    new SwaggerTerms[F]
+  implicit def swaggerTerm[L <: LA, F[_]](implicit I: InjectK[SwaggerTerm[L, ?], F]): SwaggerTerms[L, F] =
+    new SwaggerTerms[L, F]
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/framework/FrameworkTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/framework/FrameworkTerm.scala
@@ -1,10 +1,10 @@
 package com.twilio.guardrail
 package terms.framework
+
 import com.twilio.guardrail.generators.GeneratorSettings
+import com.twilio.guardrail.languages.LA
 
-import scala.meta._
-
-sealed trait FrameworkTerm[T]
-case class GetFrameworkImports(tracing: Boolean) extends FrameworkTerm[List[Import]]
-case class GetFrameworkImplicits()               extends FrameworkTerm[Defn.Object]
-case class GetGeneratorSettings()                extends FrameworkTerm[GeneratorSettings]
+sealed trait FrameworkTerm[L <: LA, T]
+case class GetFrameworkImports[L <: LA](tracing: Boolean) extends FrameworkTerm[L, List[L#Import]]
+case class GetFrameworkImplicits[L <: LA]()               extends FrameworkTerm[L, L#ObjectDefinition]
+case class GetGeneratorSettings[L <: LA]()                extends FrameworkTerm[L, GeneratorSettings]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/framework/FrameworkTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/framework/FrameworkTerms.scala
@@ -3,20 +3,19 @@ package terms.framework
 
 import cats.InjectK
 import cats.free.Free
-
-import scala.meta._
 import com.twilio.guardrail.generators.GeneratorSettings
+import com.twilio.guardrail.languages.LA
 
-class FrameworkTerms[F[_]](implicit I: InjectK[FrameworkTerm, F]) {
-  def getFrameworkImports(tracing: Boolean): Free[F, List[Import]] =
-    Free.inject(GetFrameworkImports(tracing))
-  def getFrameworkImplicits(): Free[F, Defn.Object] =
-    Free.inject(GetFrameworkImplicits())
+class FrameworkTerms[L <: LA, F[_]](implicit I: InjectK[FrameworkTerm[L, ?], F]) {
+  def getFrameworkImports(tracing: Boolean): Free[F, List[L#Import]] =
+    Free.inject[FrameworkTerm[L, ?], F](GetFrameworkImports[L](tracing))
+  def getFrameworkImplicits(): Free[F, L#ObjectDefinition] =
+    Free.inject[FrameworkTerm[L, ?], F](GetFrameworkImplicits[L]())
   def getGeneratorSettings(): Free[F, GeneratorSettings] =
-    Free.inject(GetGeneratorSettings())
+    Free.inject[FrameworkTerm[L, ?], F](GetGeneratorSettings[L]())
 }
 
 object FrameworkTerms {
-  implicit def serverTerms[F[_]](implicit I: InjectK[FrameworkTerm, F]): FrameworkTerms[F] =
-    new FrameworkTerms[F]
+  implicit def serverTerms[L <: LA, F[_]](implicit I: InjectK[FrameworkTerm[L, ?], F]): FrameworkTerms[L, F] =
+    new FrameworkTerms[L, F]
 }

--- a/modules/codegen/src/test/scala/core/issues/Issue122.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue122.scala
@@ -61,11 +61,9 @@ class Issue122 extends FunSuite with Matchers with SwaggerSpecRunner {
   test("Ensure clients are able to pass sequences of values for array form parameters") {
     val (
       _,
-      Clients(Client(tags, className, statements) :: _),
+      Clients(Client(tags, className, imports, cmp, cls, _) :: _),
       _
     ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
-
-    val List(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])
 
     val client = q"""
       class UsersClient(host: String = "http://localhost:1234")(implicit httpClient: HttpRequest => Future[HttpResponse], ec: ExecutionContext, mat: Materializer) {

--- a/modules/codegen/src/test/scala/support/SwaggerSpecRunner.scala
+++ b/modules/codegen/src/test/scala/support/SwaggerSpecRunner.scala
@@ -15,14 +15,14 @@ trait SwaggerSpecRunner {
 
   def runSwaggerSpec(
       spec: String
-  ): (Context, FunctionK[CodegenApplication, Target], GeneratorSettings) => (ProtocolDefinitions, Clients, Servers) =
+  ): (Context, FunctionK[CodegenApplication, Target], GeneratorSettings) => (ProtocolDefinitions, Clients[ScalaLanguage], Servers) =
     runSwagger(new SwaggerParser().parse(spec)) _
 
   def runSwagger(swagger: Swagger)(context: Context, framework: FunctionK[CodegenApplication, Target], generatorSettings: GeneratorSettings)(
       implicit F: FrameworkTerms[ScalaLanguage, CodegenApplication],
       Sc: ScalaTerms[ScalaLanguage, CodegenApplication],
       Sw: SwaggerTerms[ScalaLanguage, CodegenApplication]
-  ): (ProtocolDefinitions, Clients, Servers) = {
+  ): (ProtocolDefinitions, Clients[ScalaLanguage], Servers) = {
     import F._
     import Sw._
 
@@ -48,7 +48,7 @@ trait SwaggerSpecRunner {
       frameworkImports <- getFrameworkImports(context.tracing)
 
       clients <- ClientGenerator
-        .fromSwagger[CodegenApplication](context, frameworkImports)(schemes, host, basePath, groupedRoutes)(definitions)
+        .fromSwagger[ScalaLanguage, CodegenApplication](context, frameworkImports)(schemes, host, basePath, groupedRoutes)(definitions)
       servers <- ServerGenerator
         .fromSwagger[CodegenApplication](context, swagger, frameworkImports)(definitions)
     } yield (protocol, clients, servers)

--- a/modules/codegen/src/test/scala/support/SwaggerSpecRunner.scala
+++ b/modules/codegen/src/test/scala/support/SwaggerSpecRunner.scala
@@ -15,14 +15,17 @@ trait SwaggerSpecRunner {
 
   def runSwaggerSpec(
       spec: String
-  ): (Context, FunctionK[CodegenApplication, Target], GeneratorSettings) => (ProtocolDefinitions, Clients[ScalaLanguage], Servers[ScalaLanguage]) =
+  )
+    : (Context, FunctionK[CodegenApplication, Target], GeneratorSettings) => (ProtocolDefinitions[ScalaLanguage],
+                                                                              Clients[ScalaLanguage],
+                                                                              Servers[ScalaLanguage]) =
     runSwagger(new SwaggerParser().parse(spec)) _
 
   def runSwagger(swagger: Swagger)(context: Context, framework: FunctionK[CodegenApplication, Target], generatorSettings: GeneratorSettings)(
       implicit F: FrameworkTerms[ScalaLanguage, CodegenApplication],
       Sc: ScalaTerms[ScalaLanguage, CodegenApplication],
       Sw: SwaggerTerms[ScalaLanguage, CodegenApplication]
-  ): (ProtocolDefinitions, Clients[ScalaLanguage], Servers[ScalaLanguage]) = {
+  ): (ProtocolDefinitions[ScalaLanguage], Clients[ScalaLanguage], Servers[ScalaLanguage]) = {
     import F._
     import Sw._
 

--- a/modules/codegen/src/test/scala/support/SwaggerSpecRunner.scala
+++ b/modules/codegen/src/test/scala/support/SwaggerSpecRunner.scala
@@ -15,14 +15,14 @@ trait SwaggerSpecRunner {
 
   def runSwaggerSpec(
       spec: String
-  ): (Context, FunctionK[CodegenApplication, Target], GeneratorSettings) => (ProtocolDefinitions, Clients[ScalaLanguage], Servers) =
+  ): (Context, FunctionK[CodegenApplication, Target], GeneratorSettings) => (ProtocolDefinitions, Clients[ScalaLanguage], Servers[ScalaLanguage]) =
     runSwagger(new SwaggerParser().parse(spec)) _
 
   def runSwagger(swagger: Swagger)(context: Context, framework: FunctionK[CodegenApplication, Target], generatorSettings: GeneratorSettings)(
       implicit F: FrameworkTerms[ScalaLanguage, CodegenApplication],
       Sc: ScalaTerms[ScalaLanguage, CodegenApplication],
       Sw: SwaggerTerms[ScalaLanguage, CodegenApplication]
-  ): (ProtocolDefinitions, Clients[ScalaLanguage], Servers) = {
+  ): (ProtocolDefinitions, Clients[ScalaLanguage], Servers[ScalaLanguage]) = {
     import F._
     import Sw._
 
@@ -50,7 +50,7 @@ trait SwaggerSpecRunner {
       clients <- ClientGenerator
         .fromSwagger[ScalaLanguage, CodegenApplication](context, frameworkImports)(schemes, host, basePath, groupedRoutes)(definitions)
       servers <- ServerGenerator
-        .fromSwagger[CodegenApplication](context, swagger, frameworkImports)(definitions)
+        .fromSwagger[ScalaLanguage, CodegenApplication](context, swagger, frameworkImports)(definitions)
     } yield (protocol, clients, servers)
 
     Target.unsafeExtract(prog.foldMap(framework), generatorSettings)

--- a/modules/codegen/src/test/scala/support/SwaggerSpecRunner.scala
+++ b/modules/codegen/src/test/scala/support/SwaggerSpecRunner.scala
@@ -7,10 +7,10 @@ trait SwaggerSpecRunner {
   import cats.arrow.FunctionK
   import cats.implicits._
   import com.twilio.guardrail._
+  import com.twilio.guardrail.generators.GeneratorSettings
+  import com.twilio.guardrail.languages.ScalaLanguage
   import com.twilio.guardrail.terms.framework.FrameworkTerms
   import com.twilio.guardrail.terms.{ ScalaTerms, SwaggerTerms }
-  import com.twilio.guardrail.generators.GeneratorSettings
-
   import scala.collection.JavaConverters._
 
   def runSwaggerSpec(
@@ -19,9 +19,9 @@ trait SwaggerSpecRunner {
     runSwagger(new SwaggerParser().parse(spec)) _
 
   def runSwagger(swagger: Swagger)(context: Context, framework: FunctionK[CodegenApplication, Target], generatorSettings: GeneratorSettings)(
-      implicit F: FrameworkTerms[CodegenApplication],
-      Sc: ScalaTerms[CodegenApplication],
-      Sw: SwaggerTerms[CodegenApplication]
+      implicit F: FrameworkTerms[ScalaLanguage, CodegenApplication],
+      Sc: ScalaTerms[ScalaLanguage, CodegenApplication],
+      Sw: SwaggerTerms[ScalaLanguage, CodegenApplication]
   ): (ProtocolDefinitions, Clients, Servers) = {
     import F._
     import Sw._

--- a/modules/codegen/src/test/scala/tests/core/BacktickTest.scala
+++ b/modules/codegen/src/test/scala/tests/core/BacktickTest.scala
@@ -68,13 +68,11 @@ class BacktickTest extends FunSuite with Matchers with SwaggerSpecRunner {
   test("Ensure paths are generated with escapes") {
     val (
       _,
-      Clients(Client(tags, className, statements) :: _),
+      Clients(Client(tags, className, imports, cmp, cls, _) :: _),
       _
     ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     tags should equal(Seq("dashy-package"))
-
-    val List(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])
 
     val client = q"""
     class `Dashy-packageClient`(host: String = "http://localhost:1234")(implicit httpClient: HttpRequest => Future[HttpResponse], ec: ExecutionContext, mat: Materializer) {

--- a/modules/codegen/src/test/scala/tests/core/DereferencingAliasesSpec.scala
+++ b/modules/codegen/src/test/scala/tests/core/DereferencingAliasesSpec.scala
@@ -64,11 +64,9 @@ class DereferencingAliasesSpec extends FunSuite with Matchers with SwaggerSpecRu
   test("All types should be dereferenced") {
     val (
       ProtocolDefinitions(_ :: _ :: _ :: ClassDefinition(_, _, cls, cmp, _) :: _, _, _, _),
-      Clients(Client(_, _, statements) :: _),
+      Clients(Client(_, _, _, clientCmp, clientCls, _) :: _),
       _
     ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
-    val List(clientCmp, clientCls) =
-      statements.dropWhile(_.isInstanceOf[Import])
 
     val definition = q"""
       case class propRef(param: Option[Long] = None, array: Option[IndexedSeq[Long]] = None, arrayArray: Option[IndexedSeq[IndexedSeq[Long]]] = None)

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/AkkaHttpClientGeneratorTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/AkkaHttpClientGeneratorTest.scala
@@ -112,13 +112,11 @@ class AkkaHttpClientGeneratorTest extends FunSuite with Matchers with SwaggerSpe
   test("Ensure responses are generated") {
     val (
       _,
-      Clients(Client(tags, className, statements) :: Nil),
+      Clients(Client(tags, className, _, cmp, cls, _) :: Nil),
       _
     ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     tags should equal(Seq("store"))
-
-    val List(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])
 
     val companion = q"""
     object StoreClient {
@@ -168,13 +166,11 @@ class AkkaHttpClientGeneratorTest extends FunSuite with Matchers with SwaggerSpe
   test("Ensure traced responses are generated") {
     val (
       _,
-      Clients(List(Client(tags, className, statements))),
+      Clients(List(Client(tags, className, _, cmp, cls, _))),
       _
     ) = runSwaggerSpec(swagger)(Context.empty.copy(framework = Some("akka-http"), tracing = true), AkkaHttp, defaults.akkaGeneratorSettings)
 
     tags should equal(Seq("store"))
-
-    val List(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])
 
     val companion = q"""
     object StoreClient {

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/EnumTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/EnumTest.scala
@@ -92,11 +92,9 @@ class EnumTest extends FunSuite with Matchers with SwaggerSpecRunner {
   test("Use enums") {
     val (
       _,
-      Clients(Client(tags, className, statements) :: _),
+      Clients(Client(tags, className, _, cmp, cls, _) :: _),
       _
     ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
-
-    val List(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])
 
     val client = q"""
       class Client(host: String = "http://localhost:1234")(implicit httpClient: HttpRequest => Future[HttpResponse], ec: ExecutionContext, mat: Materializer) {

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/AkkaHttpClientTracingTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/AkkaHttpClientTracingTest.scala
@@ -33,10 +33,8 @@ class AkkaHttpClientTracingTest extends FunSuite with Matchers with SwaggerSpecR
       |          description: Success
       |""".stripMargin
 
-    val (_, Clients(Client(_, _, statements) :: _), _) =
+    val (_, Clients(Client(_, _, _, _, cls, _) :: _), _) =
       runSwaggerSpec(swagger)(Context.empty.copy(tracing = true), AkkaHttp, defaults.akkaGeneratorSettings)
-
-    val List(_, cls) = statements.dropWhile(_.isInstanceOf[Import])
 
     val client = q"""
       class BarBazClient(host: String = "http://localhost:1234", clientName: String = "foo-bar-baz")(implicit httpClient: HttpRequest => Future[HttpResponse], ec: ExecutionContext, mat: Materializer) {
@@ -92,11 +90,9 @@ class AkkaHttpClientTracingTest extends FunSuite with Matchers with SwaggerSpecR
 
     val (
       _,
-      Clients(Client(tags, className, statements) :: _),
+      Clients(Client(tags, className, _, cmp, cls, _) :: _),
       _
     ) = runSwaggerSpec(swagger)(Context.empty.copy(tracing = true), AkkaHttp, defaults.akkaGeneratorSettings)
-
-    val List(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])
 
     val client = q"""
       class BarBazClient(host: String = "http://localhost:1234", clientName: String = "foo-bar-baz")(implicit httpClient: HttpRequest => Future[HttpResponse], ec: ExecutionContext, mat: Materializer) {

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/BasicTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/BasicTest.scala
@@ -106,10 +106,9 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
   test("Properly handle all methods") {
     val (
       _,
-      Clients(Client(tags, className, statements) :: _),
+      Clients(Client(tags, className, _, cmp, cls, _) :: _),
       _
-    )                  = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
-    val List(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     val client = q"""
       class Client(host: String = "http://localhost:1234")(implicit httpClient: HttpRequest => Future[HttpResponse], ec: ExecutionContext, mat: Materializer) {

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/DefaultParametersTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/DefaultParametersTest.scala
@@ -123,13 +123,11 @@ class DefaultParametersTest extends FunSuite with Matchers with SwaggerSpecRunne
   test("Ensure responses are generated") {
     val (
       _,
-      Clients(Client(tags, className, statements) :: _),
+      Clients(Client(tags, className, _, cmp, cls, _) :: _),
       _
     ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     tags should equal(Seq("store"))
-
-    val List(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])
 
     val companion = q"""
       object StoreClient {

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/FormFieldsTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/FormFieldsTest.scala
@@ -44,11 +44,9 @@ class FormFieldsTest extends FunSuite with Matchers with SwaggerSpecRunner {
   test("Properly handle all methods") {
     val (
       _,
-      Clients(Client(tags, className, statements) :: _),
+      Clients(Client(tags, className, _, cmp, cls, _) :: _),
       _
     ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
-
-    val Seq(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])
 
     val client = q"""
       class Client(host: String = "http://localhost:1234")(implicit httpClient: HttpRequest => Future[HttpResponse], ec: ExecutionContext, mat: Materializer) {

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/HardcodedQSSpec.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/HardcodedQSSpec.scala
@@ -48,11 +48,9 @@ class HardcodedQSSpec extends FunSuite with Matchers with SwaggerSpecRunner {
   test("Test all cases") {
     val (
       _,
-      Clients(Client(tags, className, statements) :: _),
+      Clients(Client(tags, className, _, cmp, cls, _) :: _),
       _
     ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
-
-    val Seq(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])
 
     val client = q"""
       class Client(host: String = "http://localhost:1234")(implicit httpClient: HttpRequest => Future[HttpResponse], ec: ExecutionContext, mat: Materializer) {

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/HttpBodiesTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/HttpBodiesTest.scala
@@ -86,11 +86,9 @@ class HttpBodiesTest extends FunSuite with Matchers with SwaggerSpecRunner {
   test("Properly handle all methods") {
     val (
       _,
-      Clients(Client(tags, className, statements) :: _),
+      Clients(Client(tags, className, _, cmp, cls, _) :: _),
       _
     ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
-
-    val Seq(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])
 
     val client = q"""
       class Client(host: String = "http://localhost:1234")(implicit httpClient: HttpRequest => Future[HttpResponse], ec: ExecutionContext, mat: Materializer) {

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/MultipartTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/MultipartTest.scala
@@ -49,10 +49,9 @@ class MultipartTest extends FunSuite with Matchers with SwaggerSpecRunner {
   test("Multipart form data") {
     val (
       _,
-      Clients(Client(_, className, statements) :: _),
+      Clients(Client(_, className, _, _, cls, _) :: _),
       _
-    )                = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
-    val List(_, cls) = statements.dropWhile(_.isInstanceOf[Import])
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     val client = q"""
       class Client(host: String = "http://localhost:1234")(implicit httpClient: HttpRequest => Future[HttpResponse], ec: ExecutionContext, mat: Materializer) {

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/ParamConflictsTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/ParamConflictsTest.scala
@@ -44,11 +44,9 @@ class ParamConflictsTest extends FunSuite with Matchers with SwaggerSpecRunner {
   test("Generate non-conflicting names in clients") {
     val (
       _,
-      Clients(Client(tags, className, statements) :: _),
+      Clients(Client(tags, className, _, cmp, cls, _) :: _),
       _
     ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
-
-    val List(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])
 
     val client = q"""
       class Client(host: String = "http://localhost:1234")(implicit httpClient: HttpRequest => Future[HttpResponse], ec: ExecutionContext, mat: Materializer) {

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/SchemeTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/SchemeTest.scala
@@ -35,10 +35,8 @@ class SchemeTest extends FunSuite with Matchers with SwaggerSpecRunner {
     |""".stripMargin
 
   test("Use first scheme") {
-    val (_, Clients(Client(_, _, statements) :: _), _) =
+    val (_, Clients(Client(_, _, _, cmp, cls, _) :: _), _) =
       runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
-
-    val List(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])
 
     val companion = q"""
     object Client {

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/contentType/TextPlainTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/contentType/TextPlainTest.scala
@@ -36,10 +36,9 @@ class TextPlainTest extends FunSuite with Matchers with SwaggerSpecRunner {
   test("Properly handle all methods") {
     val (
       _,
-      Clients(Client(tags, className, statements) :: _),
+      Clients(Client(tags, className, _, cmp, cls, _) :: _),
       _
-    )                  = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
-    val List(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])
+    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp, defaults.akkaGeneratorSettings)
 
     val companion = q"""
       object Client {

--- a/modules/codegen/src/test/scala/tests/generators/http4s/BasicTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/http4s/BasicTest.scala
@@ -106,10 +106,10 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
   test("Properly handle all methods") {
     val (
       _,
-      Clients(Client(tags, className, statements) :: _),
+      Clients(Client(tags, className, _, cls, cmp, statements) :: _),
       _
     )          = runSwaggerSpec(swagger)(Context.empty, Http4s, defaults.http4sGeneratorSettings)
-    val actual = statements.dropWhile(_.isInstanceOf[Import])
+    val actual = cls +: cmp +: statements
 
     val expected = List(
       q"""object Client {

--- a/modules/codegen/src/test/scala/tests/generators/http4s/client/DefaultParametersTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/http4s/client/DefaultParametersTest.scala
@@ -123,13 +123,13 @@ class DefaultParametersTest extends FunSuite with Matchers with SwaggerSpecRunne
   test("Ensure responses are generated") {
     val (
       _,
-      Clients(Client(tags, className, statements) :: _),
+      Clients(Client(tags, className, _, cls, cmp, statements) :: _),
       _
     ) = runSwaggerSpec(swagger)(Context.empty, Http4s, defaults.http4sGeneratorSettings)
 
     tags should equal(Seq("store"))
 
-    val actual = statements.dropWhile(_.isInstanceOf[Import])
+    val actual = cls +: cmp +: statements
 
     val expected = List(
       q"""object StoreClient {


### PR DESCRIPTION
Working towards #133. This PR adds:

- `LanguageAbstraction`/`ScalaLanguage`
- Starting to break out language-scoped types in datatypes
- Converted `ClientGenerator` and `ServerGenerator` to be independent of language