### PR TITLE
Coreterm LanguageAbstraction

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,10 +23,9 @@ val scalatestVersion  = "3.0.5"
 
 mainClass in assembly := Some("com.twilio.guardrail.CLI")
 
-lazy val runExample: TaskKey[Unit] = taskKey[Unit]("Run with example args")
-// TODO: akka.NotUsed should exist in all generated sources, but there are no import verifying tests yet.
+lazy val runScalaExample: TaskKey[Unit] = taskKey[Unit]("Run scala generator with example args")
 fullRunTask(
-  runExample,
+  runScalaExample,
   Test,
   "com.twilio.guardrail.CLI",
   """
@@ -93,8 +92,9 @@ resetSample := {
   "git clean -fdx modules/sample/src modules/sample/target" !
 }
 
-addCommandAlias("example", "; resetSample ; runExample ; sample/test")
-addCommandAlias("testSuite", "; codegen/test ; resetSample; runExample ; sample/test")
+addCommandAlias("example", "; resetSample ; runScalaExample ; sample/test")
+addCommandAlias("scalaTestSuite", "; codegen/test ; resetSample; runScalaExample ; sample/test")
+addCommandAlias("testSuite", "; scalaTestSuite")
 
 addCommandAlias(
   "publishBintray",

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/CLI.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/CLI.scala
@@ -138,7 +138,7 @@ object CLI extends CLICommon {
   import com.twilio.guardrail.generators.{ AkkaHttp, Http4s }
   import scala.meta._
   val scalaInterpreter = CoreTermInterp[ScalaLanguage](
-    {
+    "akka-http", {
       case "akka-http" => AkkaHttp
       case "http4s"    => Http4s
     }, {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/CLI.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/CLI.scala
@@ -9,11 +9,12 @@ import cats.~>
 import com.twilio.guardrail.core.CoreTermInterp
 import com.twilio.guardrail.terms.CoreTerm
 import com.twilio.swagger.core.{ LogLevel, LogLevels }
+import com.twilio.guardrail.languages.{ LA, ScalaLanguage }
 
 import scala.io.AnsiColor
 
 object CLICommon {
-  def run(args: Array[String])(interpreter: CoreTerm ~> CoreTarget): Unit = {
+  def run[L <: LA](args: Array[String])(interpreter: CoreTerm[L, ?] ~> CoreTarget): Unit = {
     // Hacky loglevel parsing, only supports levels that come before absolutely
     // every other argument due to arguments being a small configuration
     // language themselves.
@@ -23,7 +24,7 @@ object CLICommon {
 
     val fallback = List.empty[ReadSwagger[Target[List[WriteTree]]]]
     val result = Common
-      .runM[CoreTerm](newArgs)
+      .runM[L, CoreTerm[L, ?]](newArgs)
       .foldMap(interpreter)
       .fold[List[ReadSwagger[Target[List[WriteTree]]]]](
         {
@@ -123,7 +124,7 @@ object CLICommon {
 }
 
 trait CLICommon {
-  val interpreter: CoreTerm ~> CoreTarget
+  val interpreter: CoreTerm[ScalaLanguage, ?] ~> CoreTarget
 
   def main(args: Array[String]): Unit =
     CLICommon.run(args)(interpreter)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/CLI.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/CLI.scala
@@ -124,12 +124,18 @@ object CLICommon {
 }
 
 trait CLICommon {
-  val interpreter: CoreTerm[ScalaLanguage, ?] ~> CoreTarget
+  val scalaInterpreter: CoreTerm[ScalaLanguage, ?] ~> CoreTarget
 
-  def main(args: Array[String]): Unit =
-    CLICommon.run(args)(interpreter)
+  val handleLanguage: PartialFunction[String, Array[String] => Unit] = {
+    case "scala" => CLICommon.run(_)(scalaInterpreter)
+  }
+
+  def main(args: Array[String]): Unit = {
+    val (language, strippedArgs) = args.partition(handleLanguage.isDefinedAt _)
+    handleLanguage(language.lastOption.getOrElse("scala"))(strippedArgs)
+  }
 }
 
 object CLI extends CLICommon {
-  val interpreter = CoreTermInterp
+  val scalaInterpreter = CoreTermInterp
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/CLI.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/CLI.scala
@@ -137,5 +137,9 @@ trait CLICommon {
 }
 
 object CLI extends CLICommon {
-  val scalaInterpreter = CoreTermInterp
+  import com.twilio.guardrail.generators.{ AkkaHttp, Http4s }
+  val scalaInterpreter = CoreTermInterp[ScalaLanguage]({
+    case "akka-http" => AkkaHttp
+    case "http4s"    => Http4s
+  })
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/CLI.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/CLI.scala
@@ -2,9 +2,7 @@ package com.twilio.guardrail
 
 import java.nio.file.Path
 import cats.Applicative
-import cats.instances.all._
-import cats.syntax.show._
-import cats.syntax.traverse._
+import cats.implicits._
 import cats.~>
 import com.twilio.guardrail.core.CoreTermInterp
 import com.twilio.guardrail.terms.CoreTerm
@@ -138,8 +136,13 @@ trait CLICommon {
 
 object CLI extends CLICommon {
   import com.twilio.guardrail.generators.{ AkkaHttp, Http4s }
-  val scalaInterpreter = CoreTermInterp[ScalaLanguage]({
-    case "akka-http" => AkkaHttp
-    case "http4s"    => Http4s
-  })
+  import scala.meta._
+  val scalaInterpreter = CoreTermInterp[ScalaLanguage](
+    {
+      case "akka-http" => AkkaHttp
+      case "http4s"    => Http4s
+    }, {
+      _.parse[Importer].toEither.bimap(err => UnparseableArgument("import", err.toString), importer => Import(List(importer)))
+    }
+  )
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -128,9 +128,9 @@ object Common {
       ).toList
   }
 
-  def processArgs[F[_]](
+  def processArgs[L <: LA, F[_]](
       args: NonEmptyList[Args]
-  )(implicit C: CoreTerms[F]): Free[F, NonEmptyList[ReadSwagger[Target[List[WriteTree]]]]] = {
+  )(implicit C: CoreTerms[L, F]): Free[F, NonEmptyList[ReadSwagger[Target[List[WriteTree]]]]] = {
     import C._
     args.traverse(
       arg =>
@@ -141,9 +141,9 @@ object Common {
     )
   }
 
-  def runM[F[_]](
+  def runM[L <: LA, F[_]](
       args: Array[String]
-  )(implicit C: CoreTerms[F]): Free[F, NonEmptyList[ReadSwagger[Target[List[WriteTree]]]]] = {
+  )(implicit C: CoreTerms[L, F]): Free[F, NonEmptyList[ReadSwagger[Target[List[WriteTree]]]]] = {
     import C._
 
     for {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
@@ -14,12 +14,13 @@ import scala.io.AnsiColor
 import scala.meta._
 
 object CoreTermInterp {
-  def apply[L <: LA](frameworkMapping: PartialFunction[String, CodegenApplication[L, ?] ~> Target], handleImport: String => Either[Error, L#Import]) =
+  def apply[L <: LA](defaultFramework: String,
+                     frameworkMapping: PartialFunction[String, CodegenApplication[L, ?] ~> Target],
+                     handleImport: String => Either[Error, L#Import]) =
     new (CoreTerm[L, ?] ~> CoreTarget) {
       def apply[T](x: CoreTerm[L, T]): CoreTarget[T] = x match {
         case GetDefaultFramework() =>
-          CoreTarget.log.debug("core", "extractGenerator")("Using default framework") >> CoreTarget
-            .pure("akka-http")
+          CoreTarget.log.debug("core", "extractGenerator")("Using default framework") >> CoreTarget.pure(defaultFramework)
 
         case ExtractGenerator(context) =>
           for {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
@@ -7,129 +7,133 @@ import cats.syntax.flatMap._
 import cats.syntax.either._
 import cats.syntax.traverse._
 import cats.{ FlatMap, ~> }
-import com.twilio.guardrail.generators.{ AkkaHttp, Http4s }
-import com.twilio.guardrail.languages.ScalaLanguage
+import com.twilio.guardrail.languages.{ LA, ScalaLanguage }
 import com.twilio.guardrail.terms._
 import java.nio.file.Paths
 import scala.io.AnsiColor
 import scala.meta._
 
-object CoreTermInterp extends (CoreTerm[ScalaLanguage, ?] ~> CoreTarget) {
-  def apply[T](x: CoreTerm[ScalaLanguage, T]): CoreTarget[T] = x match {
-    case GetDefaultFramework() =>
-      CoreTarget.log.debug("core", "extractGenerator")("Using default framework") >> CoreTarget
-        .pure("akka-http")
+object CoreTermInterp {
+  def apply[L <: LA](frameworkMapping: PartialFunction[String, CodegenApplication[ScalaLanguage, ?] ~> Target]) =
+    new (CoreTerm[ScalaLanguage, ?] ~> CoreTarget) {
+      def apply[T](x: CoreTerm[ScalaLanguage, T]): CoreTarget[T] = x match {
+        case GetDefaultFramework() =>
+          CoreTarget.log.debug("core", "extractGenerator")("Using default framework") >> CoreTarget
+            .pure("akka-http")
 
-    case ExtractGenerator(context) =>
-      for {
-        _ <- CoreTarget.log.debug("core", "extractGenerator")("Looking up framework")
-        framework <- context.framework.fold(CoreTarget.raiseError[cats.arrow.FunctionK[CodegenApplication[ScalaLanguage, ?], Target]](NoFramework))({
-          case "akka-http" => CoreTarget.pure(AkkaHttp)
-          case "http4s"    => CoreTarget.pure(Http4s)
-          case unknown     => CoreTarget.raiseError(UnknownFramework(unknown))
-        })
-        _ <- CoreTarget.log.debug("core", "extractGenerator")(s"Found: $framework")
-      } yield framework
-
-    case ValidateArgs(parsed) =>
-      for {
-        args <- CoreTarget.pure(parsed.filterNot(_.defaults))
-        args <- CoreTarget.fromOption(NonEmptyList.fromList(args.filterNot(Args.isEmpty)), NoArgsSpecified)
-        args <- if (args.exists(_.printHelp))
-          CoreTarget.raiseError[NonEmptyList[Args]](PrintHelp)
-        else CoreTarget.pure(args)
-      } yield args
-
-    case ParseArgs(args, defaultFramework) => {
-      def expandTilde(path: String): String =
-        path.replaceFirst("^~", System.getProperty("user.home"))
-      val defaultArgs =
-        Args.empty.copy(context = Args.empty.context.copy(framework = Some(defaultFramework)), defaults = true)
-
-      type From = (List[Args], List[String])
-      type To   = List[Args]
-      val start: From = (List.empty[Args], args.toList)
-      import CoreTarget.log.debug
-      FlatMap[CoreTarget].tailRecM[From, To](start)({
-        case pair @ (sofar, rest) =>
-          val empty = sofar
-            .filter(_.defaults)
-            .reverse
-            .headOption
-            .getOrElse(defaultArgs)
-            .copy(defaults = false)
-          def Continue(x: From): CoreTarget[Either[From, To]] = CoreTarget.pure(Either.left(x))
-          def Return(x: To): CoreTarget[Either[From, To]]     = CoreTarget.pure(Either.right(x))
-          def Bail(x: Error): CoreTarget[Either[From, To]]    = CoreTarget.raiseError(x)
+        case ExtractGenerator(context) =>
           for {
-            _ <- debug("core", "parseArgs")(s"Processing: ${rest.take(5).mkString(" ")}${if (rest.length > 3) "..." else ""} of ${rest.length}")
-            step <- pair match {
-              case (already, Nil) =>
-                debug("core", "parseArgs")("Finished") >> Return(already)
-              case (Nil, xs @ (_ :: _)) => Continue((empty :: Nil, xs))
-              case (sofar :: already, "--defaults" :: xs) =>
-                Continue((empty.copy(defaults = true) :: sofar :: already, xs))
-              case (sofar :: already, "--client" :: xs) =>
-                Continue((empty :: sofar :: already, xs))
-              case (sofar :: already, "--server" :: xs) =>
-                Continue((empty.copy(kind = CodegenTarget.Server) :: sofar :: already, xs))
-              case (sofar :: already, "--framework" :: value :: xs) =>
-                Continue((sofar.copy(context = sofar.context.copy(framework = Some(value))) :: already, xs))
-              case (sofar :: already, "--help" :: xs) =>
-                Continue((sofar.copy(printHelp = true) :: already, List.empty))
-              case (sofar :: already, "--specPath" :: value :: xs) =>
-                Continue((sofar.copy(specPath = Option(expandTilde(value))) :: already, xs))
-              case (sofar :: already, "--tracing" :: xs) =>
-                Continue((sofar.copy(context = sofar.context.copy(tracing = true)) :: already, xs))
-              case (sofar :: already, "--outputPath" :: value :: xs) =>
-                Continue((sofar.copy(outputPath = Option(expandTilde(value))) :: already, xs))
-              case (sofar :: already, "--packageName" :: value :: xs) =>
-                Continue((sofar.copy(packageName = Option(value.trim.split('.').to[List])) :: already, xs))
-              case (sofar :: already, "--dtoPackage" :: value :: xs) =>
-                Continue((sofar.copy(dtoPackage = value.trim.split('.').to[List]) :: already, xs))
-              case (sofar :: already, "--import" :: value :: xs) =>
-                Continue((sofar.copy(imports = sofar.imports :+ value) :: already, xs))
-              case (_, unknown) =>
-                debug("core", "parseArgs")("Unknown argument") >> Bail(UnknownArguments(unknown))
-            }
-          } yield step
-      })
-    }
+            _             <- CoreTarget.log.debug("core", "extractGenerator")("Looking up framework")
+            frameworkName <- CoreTarget.fromOption(context.framework, NoFramework)
+            framework     <- CoreTarget.fromOption(PartialFunction.condOpt(frameworkName)(frameworkMapping), UnknownFramework(frameworkName))
+            _             <- CoreTarget.log.debug("core", "extractGenerator")(s"Found: $framework")
+          } yield framework
 
-    case ProcessArgSet(targetInterpreter, args) =>
-      import scala.meta.parsers.Parsed
-      implicit def parsed2Either[Z]: Parsed[Z] => Either[Parsed.Error, Z] = {
-        case x: Parsed.Error      => Left(x)
-        case Parsed.Success(tree) => Right(tree)
-      }
-      for {
-        _          <- CoreTarget.log.debug("core", "processArgSet")("Processing arguments")
-        specPath   <- CoreTarget.fromOption(args.specPath, MissingArg(args, Error.ArgName("--specPath")))
-        outputPath <- CoreTarget.fromOption(args.outputPath, MissingArg(args, Error.ArgName("--outputPath")))
-        pkgName    <- CoreTarget.fromOption(args.packageName, MissingArg(args, Error.ArgName("--packageName")))
-        kind       = args.kind
-        dtoPackage = args.dtoPackage
-        context    = args.context
-        customImports <- args.imports
-          .map(
-            x =>
+        case ValidateArgs(parsed) =>
+          for {
+            args <- CoreTarget.pure(parsed.filterNot(_.defaults))
+            args <- CoreTarget.fromOption(NonEmptyList.fromList(args.filterNot(Args.isEmpty)), NoArgsSpecified)
+            args <- if (args.exists(_.printHelp))
+              CoreTarget.raiseError[NonEmptyList[Args]](PrintHelp)
+            else CoreTarget.pure(args)
+          } yield args
+
+        case ParseArgs(args, defaultFramework) => {
+          def expandTilde(path: String): String =
+            path.replaceFirst("^~", System.getProperty("user.home"))
+          val defaultArgs =
+            Args.empty.copy(context = Args.empty.context.copy(framework = Some(defaultFramework)), defaults = true)
+
+          type From = (List[Args], List[String])
+          type To   = List[Args]
+          val start: From = (List.empty[Args], args.toList)
+          import CoreTarget.log.debug
+          FlatMap[CoreTarget].tailRecM[From, To](start)({
+            case pair @ (sofar, rest) =>
+              val empty = sofar
+                .filter(_.defaults)
+                .reverse
+                .headOption
+                .getOrElse(defaultArgs)
+                .copy(defaults = false)
+              def Continue(x: From): CoreTarget[Either[From, To]] = CoreTarget.pure(Either.left(x))
+              def Return(x: To): CoreTarget[Either[From, To]]     = CoreTarget.pure(Either.right(x))
+              def Bail(x: Error): CoreTarget[Either[From, To]]    = CoreTarget.raiseError(x)
               for {
-                _ <- CoreTarget.log.debug("core", "processArgSet")(s"Attempting to parse $x as an import directive")
-                importer <- x
-                  .parse[Importer]
-                  .fold[CoreTarget[Importer]](err => CoreTarget.raiseError(UnparseableArgument("import", err.toString)), CoreTarget.pure(_))
-              } yield Import(List(importer))
-          )
-          .sequence[CoreTarget, Import]
-        _ <- CoreTarget.log.debug("core", "processArgSet")("Finished processing arguments")
-      } yield {
-        ReadSwagger(
-          Paths.get(specPath), { swagger =>
-            Common
-              .writePackage[ScalaLanguage, CodegenApplication[ScalaLanguage, ?]](kind, context, swagger, Paths.get(outputPath), pkgName, dtoPackage, customImports)
-              .foldMap(targetInterpreter)
+                _ <- debug("core", "parseArgs")(s"Processing: ${rest.take(5).mkString(" ")}${if (rest.length > 3) "..." else ""} of ${rest.length}")
+                step <- pair match {
+                  case (already, Nil) =>
+                    debug("core", "parseArgs")("Finished") >> Return(already)
+                  case (Nil, xs @ (_ :: _)) => Continue((empty :: Nil, xs))
+                  case (sofar :: already, "--defaults" :: xs) =>
+                    Continue((empty.copy(defaults = true) :: sofar :: already, xs))
+                  case (sofar :: already, "--client" :: xs) =>
+                    Continue((empty :: sofar :: already, xs))
+                  case (sofar :: already, "--server" :: xs) =>
+                    Continue((empty.copy(kind = CodegenTarget.Server) :: sofar :: already, xs))
+                  case (sofar :: already, "--framework" :: value :: xs) =>
+                    Continue((sofar.copy(context = sofar.context.copy(framework = Some(value))) :: already, xs))
+                  case (sofar :: already, "--help" :: xs) =>
+                    Continue((sofar.copy(printHelp = true) :: already, List.empty))
+                  case (sofar :: already, "--specPath" :: value :: xs) =>
+                    Continue((sofar.copy(specPath = Option(expandTilde(value))) :: already, xs))
+                  case (sofar :: already, "--tracing" :: xs) =>
+                    Continue((sofar.copy(context = sofar.context.copy(tracing = true)) :: already, xs))
+                  case (sofar :: already, "--outputPath" :: value :: xs) =>
+                    Continue((sofar.copy(outputPath = Option(expandTilde(value))) :: already, xs))
+                  case (sofar :: already, "--packageName" :: value :: xs) =>
+                    Continue((sofar.copy(packageName = Option(value.trim.split('.').to[List])) :: already, xs))
+                  case (sofar :: already, "--dtoPackage" :: value :: xs) =>
+                    Continue((sofar.copy(dtoPackage = value.trim.split('.').to[List]) :: already, xs))
+                  case (sofar :: already, "--import" :: value :: xs) =>
+                    Continue((sofar.copy(imports = sofar.imports :+ value) :: already, xs))
+                  case (_, unknown) =>
+                    debug("core", "parseArgs")("Unknown argument") >> Bail(UnknownArguments(unknown))
+                }
+              } yield step
+          })
+        }
+
+        case ProcessArgSet(targetInterpreter, args) =>
+          import scala.meta.parsers.Parsed
+          implicit def parsed2Either[Z]: Parsed[Z] => Either[Parsed.Error, Z] = {
+            case x: Parsed.Error      => Left(x)
+            case Parsed.Success(tree) => Right(tree)
           }
-        )
+          for {
+            _          <- CoreTarget.log.debug("core", "processArgSet")("Processing arguments")
+            specPath   <- CoreTarget.fromOption(args.specPath, MissingArg(args, Error.ArgName("--specPath")))
+            outputPath <- CoreTarget.fromOption(args.outputPath, MissingArg(args, Error.ArgName("--outputPath")))
+            pkgName    <- CoreTarget.fromOption(args.packageName, MissingArg(args, Error.ArgName("--packageName")))
+            kind       = args.kind
+            dtoPackage = args.dtoPackage
+            context    = args.context
+            customImports <- args.imports
+              .traverse(
+                x =>
+                  for {
+                    _ <- CoreTarget.log.debug("core", "processArgSet")(s"Attempting to parse $x as an import directive")
+                    importer <- x
+                      .parse[Importer]
+                      .fold[CoreTarget[Importer]](err => CoreTarget.raiseError(UnparseableArgument("import", err.toString)), CoreTarget.pure(_))
+                  } yield Import(List(importer))
+              )
+            _ <- CoreTarget.log.debug("core", "processArgSet")("Finished processing arguments")
+          } yield {
+            ReadSwagger(
+              Paths.get(specPath), { swagger =>
+                Common
+                  .writePackage[ScalaLanguage, CodegenApplication[ScalaLanguage, ?]](kind,
+                                                                                     context,
+                                                                                     swagger,
+                                                                                     Paths.get(outputPath),
+                                                                                     pkgName,
+                                                                                     dtoPackage,
+                                                                                     customImports)
+                  .foldMap(targetInterpreter)
+              }
+            )
+          }
       }
-  }
+    }
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
@@ -23,7 +23,7 @@ object CoreTermInterp extends (CoreTerm[ScalaLanguage, ?] ~> CoreTarget) {
     case ExtractGenerator(context) =>
       for {
         _ <- CoreTarget.log.debug("core", "extractGenerator")("Looking up framework")
-        framework <- context.framework.fold(CoreTarget.raiseError[cats.arrow.FunctionK[CodegenApplication, Target]](NoFramework))({
+        framework <- context.framework.fold(CoreTarget.raiseError[cats.arrow.FunctionK[CodegenApplication[ScalaLanguage, ?], Target]](NoFramework))({
           case "akka-http" => CoreTarget.pure(AkkaHttp)
           case "http4s"    => CoreTarget.pure(Http4s)
           case unknown     => CoreTarget.raiseError(UnknownFramework(unknown))
@@ -126,7 +126,7 @@ object CoreTermInterp extends (CoreTerm[ScalaLanguage, ?] ~> CoreTarget) {
         ReadSwagger(
           Paths.get(specPath), { swagger =>
             Common
-              .writePackage[ScalaLanguage, CodegenApplication](kind, context, swagger, Paths.get(outputPath), pkgName, dtoPackage, customImports)
+              .writePackage[ScalaLanguage, CodegenApplication[ScalaLanguage, ?]](kind, context, swagger, Paths.get(outputPath), pkgName, dtoPackage, customImports)
               .foldMap(targetInterpreter)
           }
         )

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
@@ -14,9 +14,9 @@ import java.nio.file.Paths
 import scala.io.AnsiColor
 import scala.meta._
 
-object CoreTermInterp extends (CoreTerm ~> CoreTarget) {
-  def apply[T](x: CoreTerm[T]): CoreTarget[T] = x match {
-    case GetDefaultFramework =>
+object CoreTermInterp extends (CoreTerm[ScalaLanguage, ?] ~> CoreTarget) {
+  def apply[T](x: CoreTerm[ScalaLanguage, T]): CoreTarget[T] = x match {
+    case GetDefaultFramework() =>
       CoreTarget.log.debug("core", "extractGenerator")("Using default framework") >> CoreTarget
         .pure("akka-http")
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttp.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttp.scala
@@ -1,8 +1,8 @@
 package com.twilio.guardrail
 package generators
 
+import com.twilio.guardrail.languages.ScalaLanguage
 import cats.~>
-import cats.arrow.FunctionK
 
 import AkkaHttpClientGenerator._
 import AkkaHttpServerGenerator._
@@ -11,23 +11,23 @@ import ScalaGenerator._
 import SwaggerGenerator._
 import AkkaHttpGenerator._
 
-object AkkaHttp extends FunctionK[CodegenApplication, Target] {
-  val interpDefinitionPM: DefinitionPM ~> Target       = ProtocolSupportTermInterp or ModelProtocolTermInterp
-  val interpDefinitionPME: DefinitionPME ~> Target     = EnumProtocolTermInterp or interpDefinitionPM
-  val interpDefinitionPMEA: DefinitionPMEA ~> Target   = ArrayProtocolTermInterp or interpDefinitionPME
-  val interpDefinitionPMEAP: DefinitionPMEAP ~> Target = PolyProtocolTermInterp or interpDefinitionPMEA
+object AkkaHttp extends (CodegenApplication[ScalaLanguage, ?] ~> Target) {
+  val interpDefinitionPM: DefinitionPM[ScalaLanguage, ?] ~> Target       = ProtocolSupportTermInterp or ModelProtocolTermInterp
+  val interpDefinitionPME: DefinitionPME[ScalaLanguage, ?] ~> Target     = EnumProtocolTermInterp or interpDefinitionPM
+  val interpDefinitionPMEA: DefinitionPMEA[ScalaLanguage, ?] ~> Target   = ArrayProtocolTermInterp or interpDefinitionPME
+  val interpDefinitionPMEAP: DefinitionPMEAP[ScalaLanguage, ?] ~> Target = PolyProtocolTermInterp or interpDefinitionPMEA
 
-  val interpModel: ModelInterpreters ~> Target = interpDefinitionPMEAP
+  val interpModel: ModelInterpreters[ScalaLanguage, ?] ~> Target = interpDefinitionPMEAP
 
-  val interpFrameworkC: FrameworkC ~> Target     = ClientTermInterp or interpModel
-  val interpFrameworkCS: FrameworkCS ~> Target   = ServerTermInterp or interpFrameworkC
-  val interpFrameworkCSF: FrameworkCSF ~> Target = FrameworkInterp or interpFrameworkCS
+  val interpFrameworkC: FrameworkC[ScalaLanguage, ?] ~> Target     = ClientTermInterp or interpModel
+  val interpFrameworkCS: FrameworkCS[ScalaLanguage, ?] ~> Target   = ServerTermInterp or interpFrameworkC
+  val interpFrameworkCSF: FrameworkCSF[ScalaLanguage, ?] ~> Target = FrameworkInterp or interpFrameworkCS
 
-  val interpFramework: ClientServerTerms ~> Target = interpFrameworkCSF
+  val interpFramework: ClientServerTerms[ScalaLanguage, ?] ~> Target = interpFrameworkCSF
 
-  val parser: Parser ~> Target = SwaggerInterp or interpFramework
+  val parser: Parser[ScalaLanguage, ?] ~> Target = SwaggerInterp or interpFramework
 
-  val codegenApplication: CodegenApplication ~> Target = ScalaInterp or parser
+  val codegenApplication: CodegenApplication[ScalaLanguage, ?] ~> Target = ScalaInterp or parser
 
-  def apply[T](x: CodegenApplication[T]): Target[T] = codegenApplication.apply(x)
+  def apply[T](x: CodegenApplication[ScalaLanguage, T]): Target[T] = codegenApplication.apply(x)
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4s.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4s.scala
@@ -1,8 +1,8 @@
 package com.twilio.guardrail
 package generators
 
+import com.twilio.guardrail.languages.ScalaLanguage
 import cats.~>
-import cats.arrow.FunctionK
 
 import Http4sClientGenerator._
 import Http4sServerGenerator._
@@ -11,23 +11,23 @@ import CirceProtocolGenerator._
 import ScalaGenerator._
 import SwaggerGenerator._
 
-object Http4s extends FunctionK[CodegenApplication, Target] {
-  val interpDefinitionPM: DefinitionPM ~> Target       = ProtocolSupportTermInterp or ModelProtocolTermInterp
-  val interpDefinitionPME: DefinitionPME ~> Target     = EnumProtocolTermInterp or interpDefinitionPM
-  val interpDefinitionPMEA: DefinitionPMEA ~> Target   = ArrayProtocolTermInterp or interpDefinitionPME
-  val interpDefinitionPMEAP: DefinitionPMEAP ~> Target = PolyProtocolTermInterp or interpDefinitionPMEA
+object Http4s extends (CodegenApplication[ScalaLanguage, ?] ~> Target) {
+  val interpDefinitionPM: DefinitionPM[ScalaLanguage, ?] ~> Target       = ProtocolSupportTermInterp or ModelProtocolTermInterp
+  val interpDefinitionPME: DefinitionPME[ScalaLanguage, ?] ~> Target     = EnumProtocolTermInterp or interpDefinitionPM
+  val interpDefinitionPMEA: DefinitionPMEA[ScalaLanguage, ?] ~> Target   = ArrayProtocolTermInterp or interpDefinitionPME
+  val interpDefinitionPMEAP: DefinitionPMEAP[ScalaLanguage, ?] ~> Target = PolyProtocolTermInterp or interpDefinitionPMEA
 
-  val interpModel: ModelInterpreters ~> Target = interpDefinitionPMEAP
+  val interpModel: ModelInterpreters[ScalaLanguage, ?] ~> Target = interpDefinitionPMEAP
 
-  val interpFrameworkC: FrameworkC ~> Target     = ClientTermInterp or interpModel
-  val interpFrameworkCS: FrameworkCS ~> Target   = ServerTermInterp or interpFrameworkC
-  val interpFrameworkCSF: FrameworkCSF ~> Target = FrameworkInterp or interpFrameworkCS
+  val interpFrameworkC: FrameworkC[ScalaLanguage, ?] ~> Target     = ClientTermInterp or interpModel
+  val interpFrameworkCS: FrameworkCS[ScalaLanguage, ?] ~> Target   = ServerTermInterp or interpFrameworkC
+  val interpFrameworkCSF: FrameworkCSF[ScalaLanguage, ?] ~> Target = FrameworkInterp or interpFrameworkCS
 
-  val interpFramework: ClientServerTerms ~> Target = interpFrameworkCSF
+  val interpFramework: ClientServerTerms[ScalaLanguage, ?] ~> Target = interpFrameworkCSF
 
-  val parser: Parser ~> Target = SwaggerInterp or interpFramework
+  val parser: Parser[ScalaLanguage, ?] ~> Target = SwaggerInterp or interpFramework
 
-  val codegenApplication: CodegenApplication ~> Target = ScalaInterp or parser
+  val codegenApplication: CodegenApplication[ScalaLanguage, ?] ~> Target = ScalaInterp or parser
 
-  def apply[T](x: CodegenApplication[T]): Target[T] = codegenApplication.apply(x)
+  def apply[T](x: CodegenApplication[ScalaLanguage, T]): Target[T] = codegenApplication.apply(x)
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
@@ -68,22 +68,22 @@ package guardrail {
 }
 
 package object guardrail {
-  type DefinitionPM[T]    = EitherK[ProtocolSupportTerm[ScalaLanguage, ?], ModelProtocolTerm[ScalaLanguage, ?], T]
-  type DefinitionPME[T]   = EitherK[EnumProtocolTerm[ScalaLanguage, ?], DefinitionPM, T]
-  type DefinitionPMEA[T]  = EitherK[ArrayProtocolTerm[ScalaLanguage, ?], DefinitionPME, T]
-  type DefinitionPMEAP[T] = EitherK[PolyProtocolTerm[ScalaLanguage, ?], DefinitionPMEA, T]
+  type DefinitionPM[L <: LA, T]    = EitherK[ProtocolSupportTerm[L, ?], ModelProtocolTerm[L, ?], T]
+  type DefinitionPME[L <: LA, T]   = EitherK[EnumProtocolTerm[L, ?], DefinitionPM[L, ?], T]
+  type DefinitionPMEA[L <: LA, T]  = EitherK[ArrayProtocolTerm[L, ?], DefinitionPME[L, ?], T]
+  type DefinitionPMEAP[L <: LA, T] = EitherK[PolyProtocolTerm[L, ?], DefinitionPMEA[L, ?], T]
 
-  type ModelInterpreters[T] = DefinitionPMEAP[T]
+  type ModelInterpreters[L <: LA, T] = DefinitionPMEAP[L, T]
 
-  type FrameworkC[T]   = EitherK[ClientTerm[ScalaLanguage, ?], ModelInterpreters, T]
-  type FrameworkCS[T]  = EitherK[ServerTerm[ScalaLanguage, ?], FrameworkC, T]
-  type FrameworkCSF[T] = EitherK[FrameworkTerm[ScalaLanguage, ?], FrameworkCS, T]
+  type FrameworkC[L <: LA, T]   = EitherK[ClientTerm[L, ?], ModelInterpreters[L, ?], T]
+  type FrameworkCS[L <: LA, T]  = EitherK[ServerTerm[L, ?], FrameworkC[L, ?], T]
+  type FrameworkCSF[L <: LA, T] = EitherK[FrameworkTerm[L, ?], FrameworkCS[L, ?], T]
 
-  type ClientServerTerms[T] = FrameworkCSF[T]
+  type ClientServerTerms[L <: LA, T] = FrameworkCSF[L, T]
 
-  type Parser[T] = EitherK[SwaggerTerm[ScalaLanguage, ?], ClientServerTerms, T]
+  type Parser[L <: LA, T] = EitherK[SwaggerTerm[L, ?], ClientServerTerms[L, ?], T]
 
-  type CodegenApplication[T] = EitherK[ScalaTerm[ScalaLanguage, ?], Parser, T]
+  type CodegenApplication[L <: LA, T] = EitherK[ScalaTerm[L, ?], Parser[L, ?], T]
 
   type Logger[T]     = WriterT[Id, StructuredLogger, T]
   type Target[A]     = EitherT[Logger, String, A]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/CoreTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/CoreTerm.scala
@@ -1,13 +1,14 @@
 package com.twilio.guardrail
 package terms
 
+import cats.~>
 import cats.arrow.FunctionK
 import cats.data.NonEmptyList
 import com.twilio.guardrail.languages.LA
 
 sealed trait CoreTerm[L <: LA, T]
-case class GetDefaultFramework[L <: LA]()                                                              extends CoreTerm[L, String]
-case class ExtractGenerator[L <: LA](context: Context)                                                 extends CoreTerm[L, FunctionK[CodegenApplication, Target]]
-case class ParseArgs[L <: LA](args: Array[String], defaultFramework: String)                           extends CoreTerm[L, List[Args]]
-case class ValidateArgs[L <: LA](parsed: List[Args])                                                   extends CoreTerm[L, NonEmptyList[Args]]
-case class ProcessArgSet[L <: LA](targetInterpreter: FunctionK[CodegenApplication, Target], arg: Args) extends CoreTerm[L, ReadSwagger[Target[List[WriteTree]]]]
+case class GetDefaultFramework[L <: LA]()                                                           extends CoreTerm[L, String]
+case class ExtractGenerator[L <: LA](context: Context)                                              extends CoreTerm[L, CodegenApplication[L, ?] ~> Target]
+case class ParseArgs[L <: LA](args: Array[String], defaultFramework: String)                        extends CoreTerm[L, List[Args]]
+case class ValidateArgs[L <: LA](parsed: List[Args])                                                extends CoreTerm[L, NonEmptyList[Args]]
+case class ProcessArgSet[L <: LA](targetInterpreter: CodegenApplication[L, ?] ~> Target, arg: Args) extends CoreTerm[L, ReadSwagger[Target[List[WriteTree]]]]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/CoreTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/CoreTerm.scala
@@ -3,10 +3,11 @@ package terms
 
 import cats.arrow.FunctionK
 import cats.data.NonEmptyList
+import com.twilio.guardrail.languages.LA
 
-sealed trait CoreTerm[T]
-case object GetDefaultFramework                                                               extends CoreTerm[String]
-case class ExtractGenerator(context: Context)                                                 extends CoreTerm[FunctionK[CodegenApplication, Target]]
-case class ParseArgs(args: Array[String], defaultFramework: String)                           extends CoreTerm[List[Args]]
-case class ValidateArgs(parsed: List[Args])                                                   extends CoreTerm[NonEmptyList[Args]]
-case class ProcessArgSet(targetInterpreter: FunctionK[CodegenApplication, Target], arg: Args) extends CoreTerm[ReadSwagger[Target[List[WriteTree]]]]
+sealed trait CoreTerm[L <: LA, T]
+case class GetDefaultFramework[L <: LA]()                                                              extends CoreTerm[L, String]
+case class ExtractGenerator[L <: LA](context: Context)                                                 extends CoreTerm[L, FunctionK[CodegenApplication, Target]]
+case class ParseArgs[L <: LA](args: Array[String], defaultFramework: String)                           extends CoreTerm[L, List[Args]]
+case class ValidateArgs[L <: LA](parsed: List[Args])                                                   extends CoreTerm[L, NonEmptyList[Args]]
+case class ProcessArgSet[L <: LA](targetInterpreter: FunctionK[CodegenApplication, Target], arg: Args) extends CoreTerm[L, ReadSwagger[Target[List[WriteTree]]]]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/CoreTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/CoreTerms.scala
@@ -1,8 +1,8 @@
 package com.twilio.guardrail
 package terms
 
+import cats.~>
 import cats.InjectK
-import cats.arrow.FunctionK
 import cats.data.NonEmptyList
 import cats.free.Free
 import com.twilio.guardrail.languages.LA
@@ -10,13 +10,13 @@ import com.twilio.guardrail.languages.LA
 class CoreTerms[L <: LA, F[_]](implicit I: InjectK[CoreTerm[L, ?], F]) {
   def getDefaultFramework: Free[F, String] =
     Free.inject[CoreTerm[L, ?], F](GetDefaultFramework())
-  def extractGenerator(context: Context): Free[F, FunctionK[CodegenApplication, Target]] =
+  def extractGenerator(context: Context): Free[F, CodegenApplication[L, ?] ~> Target] =
     Free.inject[CoreTerm[L, ?], F](ExtractGenerator(context))
   def parseArgs(args: Array[String], defaultFramework: String): Free[F, List[Args]] =
     Free.inject[CoreTerm[L, ?], F](ParseArgs(args, defaultFramework))
   def validateArgs(parsed: List[Args]): Free[F, NonEmptyList[Args]] =
     Free.inject[CoreTerm[L, ?], F](ValidateArgs(parsed))
-  def processArgSet(targetInterpreter: FunctionK[CodegenApplication, Target])(args: Args): Free[F, ReadSwagger[Target[List[WriteTree]]]] =
+  def processArgSet(targetInterpreter: CodegenApplication[L, ?] ~> Target)(args: Args): Free[F, ReadSwagger[Target[List[WriteTree]]]] =
     Free.inject[CoreTerm[L, ?], F](ProcessArgSet(targetInterpreter, args))
 }
 object CoreTerms {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/CoreTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/CoreTerms.scala
@@ -5,20 +5,21 @@ import cats.InjectK
 import cats.arrow.FunctionK
 import cats.data.NonEmptyList
 import cats.free.Free
+import com.twilio.guardrail.languages.LA
 
-class CoreTerms[F[_]](implicit I: InjectK[CoreTerm, F]) {
+class CoreTerms[L <: LA, F[_]](implicit I: InjectK[CoreTerm[L, ?], F]) {
   def getDefaultFramework: Free[F, String] =
-    Free.inject[CoreTerm, F](GetDefaultFramework)
+    Free.inject[CoreTerm[L, ?], F](GetDefaultFramework())
   def extractGenerator(context: Context): Free[F, FunctionK[CodegenApplication, Target]] =
-    Free.inject[CoreTerm, F](ExtractGenerator(context))
+    Free.inject[CoreTerm[L, ?], F](ExtractGenerator(context))
   def parseArgs(args: Array[String], defaultFramework: String): Free[F, List[Args]] =
-    Free.inject[CoreTerm, F](ParseArgs(args, defaultFramework))
+    Free.inject[CoreTerm[L, ?], F](ParseArgs(args, defaultFramework))
   def validateArgs(parsed: List[Args]): Free[F, NonEmptyList[Args]] =
-    Free.inject[CoreTerm, F](ValidateArgs(parsed))
+    Free.inject[CoreTerm[L, ?], F](ValidateArgs(parsed))
   def processArgSet(targetInterpreter: FunctionK[CodegenApplication, Target])(args: Args): Free[F, ReadSwagger[Target[List[WriteTree]]]] =
-    Free.inject[CoreTerm, F](ProcessArgSet(targetInterpreter, args))
+    Free.inject[CoreTerm[L, ?], F](ProcessArgSet(targetInterpreter, args))
 }
 object CoreTerms {
-  implicit def coreTerm[F[_]](implicit I: InjectK[CoreTerm, F]): CoreTerms[F] =
-    new CoreTerms[F]
+  implicit def coreTerm[L <: LA, F[_]](implicit I: InjectK[CoreTerm[L, ?], F]): CoreTerms[L, F] =
+    new CoreTerms[L, F]
 }

--- a/modules/codegen/src/test/scala/codegen/WritePackageSpec.scala
+++ b/modules/codegen/src/test/scala/codegen/WritePackageSpec.scala
@@ -78,7 +78,7 @@ class WritePackageSpec extends FunSuite with Matchers {
       .unsafeExtract(
         Common
           .processArgs[ScalaLanguage, CoreTerm[ScalaLanguage, ?]](args)
-          .foldMap(CoreTermInterp[ScalaLanguage]({
+          .foldMap(CoreTermInterp[ScalaLanguage]("akka-http", {
             case "akka-http" => AkkaHttp
           }, {
             _.parse[Importer].toEither.bimap(err => UnparseableArgument("import", err.toString), importer => Import(List(importer)))
@@ -135,7 +135,7 @@ class WritePackageSpec extends FunSuite with Matchers {
       .unsafeExtract(
         Common
           .processArgs[ScalaLanguage, CoreTerm[ScalaLanguage, ?]](args)
-          .foldMap(CoreTermInterp[ScalaLanguage]({
+          .foldMap(CoreTermInterp[ScalaLanguage]("akka-http", {
             case "akka-http" => AkkaHttp
           }, {
             _.parse[Importer].toEither.bimap(err => UnparseableArgument("import", err.toString), importer => Import(List(importer)))

--- a/modules/codegen/src/test/scala/codegen/WritePackageSpec.scala
+++ b/modules/codegen/src/test/scala/codegen/WritePackageSpec.scala
@@ -8,6 +8,7 @@ import cats.data.NonEmptyList
 import com.twilio.guardrail._
 import com.twilio.guardrail.core.CoreTermInterp
 import com.twilio.guardrail.terms.CoreTerm
+import com.twilio.guardrail.languages.ScalaLanguage
 import org.scalatest.{ FunSuite, Matchers }
 
 import scala.meta._
@@ -72,7 +73,7 @@ class WritePackageSpec extends FunSuite with Matchers {
     )
 
     val result: List[WriteTree] = CoreTarget
-      .unsafeExtract(Common.processArgs[CoreTerm](args).foldMap(CoreTermInterp))
+      .unsafeExtract(Common.processArgs[ScalaLanguage, CoreTerm[ScalaLanguage, ?]](args).foldMap(CoreTermInterp))
       .toList
       .flatMap(x => Target.unsafeExtract(injectSwagger(swagger, x)))
 
@@ -120,7 +121,7 @@ class WritePackageSpec extends FunSuite with Matchers {
     )
 
     val result: List[WriteTree] = CoreTarget
-      .unsafeExtract(Common.processArgs[CoreTerm](args).foldMap(CoreTermInterp))
+      .unsafeExtract(Common.processArgs[ScalaLanguage, CoreTerm[ScalaLanguage, ?]](args).foldMap(CoreTermInterp))
       .toList
       .flatMap(x => Target.unsafeExtract(injectSwagger(swagger, x)))
 

--- a/modules/codegen/src/test/scala/codegen/WritePackageSpec.scala
+++ b/modules/codegen/src/test/scala/codegen/WritePackageSpec.scala
@@ -5,6 +5,7 @@ import java.nio.file.{ Path, Paths }
 import _root_.io.swagger.models.Swagger
 import _root_.io.swagger.parser.SwaggerParser
 import cats.data.NonEmptyList
+import cats.implicits._
 import com.twilio.guardrail._
 import com.twilio.guardrail.core.CoreTermInterp
 import com.twilio.guardrail.terms.CoreTerm
@@ -79,6 +80,8 @@ class WritePackageSpec extends FunSuite with Matchers {
           .processArgs[ScalaLanguage, CoreTerm[ScalaLanguage, ?]](args)
           .foldMap(CoreTermInterp[ScalaLanguage]({
             case "akka-http" => AkkaHttp
+          }, {
+            _.parse[Importer].toEither.bimap(err => UnparseableArgument("import", err.toString), importer => Import(List(importer)))
           }))
       )
       .toList
@@ -134,6 +137,8 @@ class WritePackageSpec extends FunSuite with Matchers {
           .processArgs[ScalaLanguage, CoreTerm[ScalaLanguage, ?]](args)
           .foldMap(CoreTermInterp[ScalaLanguage]({
             case "akka-http" => AkkaHttp
+          }, {
+            _.parse[Importer].toEither.bimap(err => UnparseableArgument("import", err.toString), importer => Import(List(importer)))
           }))
       )
       .toList

--- a/modules/codegen/src/test/scala/codegen/WritePackageSpec.scala
+++ b/modules/codegen/src/test/scala/codegen/WritePackageSpec.scala
@@ -72,8 +72,15 @@ class WritePackageSpec extends FunSuite with Matchers {
       List.empty
     )
 
+    import com.twilio.guardrail.generators.AkkaHttp
     val result: List[WriteTree] = CoreTarget
-      .unsafeExtract(Common.processArgs[ScalaLanguage, CoreTerm[ScalaLanguage, ?]](args).foldMap(CoreTermInterp))
+      .unsafeExtract(
+        Common
+          .processArgs[ScalaLanguage, CoreTerm[ScalaLanguage, ?]](args)
+          .foldMap(CoreTermInterp[ScalaLanguage]({
+            case "akka-http" => AkkaHttp
+          }))
+      )
       .toList
       .flatMap(x => Target.unsafeExtract(injectSwagger(swagger, x)))
 
@@ -120,8 +127,15 @@ class WritePackageSpec extends FunSuite with Matchers {
       List.empty
     )
 
+    import com.twilio.guardrail.generators.AkkaHttp
     val result: List[WriteTree] = CoreTarget
-      .unsafeExtract(Common.processArgs[ScalaLanguage, CoreTerm[ScalaLanguage, ?]](args).foldMap(CoreTermInterp))
+      .unsafeExtract(
+        Common
+          .processArgs[ScalaLanguage, CoreTerm[ScalaLanguage, ?]](args)
+          .foldMap(CoreTermInterp[ScalaLanguage]({
+            case "akka-http" => AkkaHttp
+          }))
+      )
       .toList
       .flatMap(x => Target.unsafeExtract(injectSwagger(swagger, x)))
 


### PR DESCRIPTION
Breaking out `ScalaLanguage` from the last little bits of `CoreTerm`/`CodegenApplication`

This pushes language evaluation to the very edge of the world for the CLI interpreter by prepending the language desired for processing all arguments to the first CLI argument (ie: `cli.sh scala --client ...`)