### PR TITLE
Exposing helpful error messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ modules/sample/target/
 modules/sample/src/main/scala/*
 !modules/sample/src/main/scala/App.scala
 !modules/sample/src/main/scala/support
+!modules/sample/src/test/resources/
 
 .idea

--- a/build.sbt
+++ b/build.sbt
@@ -30,10 +30,10 @@ fullRunTask(
   "com.twilio.guardrail.CLI",
   """
   --defaults --import support.PositiveLong
-  --client --specPath modules/sample/src/main/resources/polymorphism.yaml --outputPath modules/sample/src/main/scala --packageName issues.issue43.client.http4s --framework http4s
-  --client --specPath modules/sample/src/main/resources/polymorphism.yaml --outputPath modules/sample/src/main/scala --packageName issues.issue43.client.akkaHttp --framework akka-http
-  --server --specPath modules/sample/src/main/resources/polymorphism.yaml --outputPath modules/sample/src/main/scala --packageName issues.issue43.server.http4s --framework http4s
-  --server --specPath modules/sample/src/main/resources/polymorphism.yaml --outputPath modules/sample/src/main/scala --packageName issues.issue43.server.akkaHttp --framework akka-http
+  --client --specPath modules/sample/src/main/resources/polymorphism.yaml --outputPath modules/sample/src/main/scala --packageName polymorphism.client.http4s --framework http4s
+  --client --specPath modules/sample/src/main/resources/polymorphism.yaml --outputPath modules/sample/src/main/scala --packageName polymorphism.client.akkaHttp --framework akka-http
+  --server --specPath modules/sample/src/main/resources/polymorphism.yaml --outputPath modules/sample/src/main/scala --packageName polymorphism.server.http4s --framework http4s
+  --server --specPath modules/sample/src/main/resources/polymorphism.yaml --outputPath modules/sample/src/main/scala --packageName polymorphism.server.akkaHttp --framework akka-http
   --client --specPath modules/sample/src/main/resources/petstore.json --outputPath modules/sample/src/main/scala --packageName clients.http4s --framework http4s
   --client --specPath modules/sample/src/main/resources/petstore.json --outputPath modules/sample/src/main/scala --packageName clients.akkaHttp --framework akka-http
   --server --specPath modules/sample/src/main/resources/petstore.json --outputPath modules/sample/src/main/scala --packageName servers.http4s --framework http4s

--- a/build.sbt
+++ b/build.sbt
@@ -69,6 +69,10 @@ fullRunTask(
   --server --specPath modules/sample/src/main/resources/formData.yaml --outputPath modules/sample/src/main/scala --packageName form.server.http4s --framework http4s
   --server --specPath modules/sample/src/main/resources/formData.yaml --outputPath modules/sample/src/main/scala --packageName form.server.akkaHttp --framework akka-http
   --server --specPath modules/sample/src/main/resources/issues/issue127.yaml --outputPath modules/sample/src/main/scala --packageName issues.issue127
+  --client --specPath modules/sample/src/main/resources/issues/issue148.yaml --outputPath modules/sample/src/main/scala --packageName issues.issue148.client.http4s --framework http4s
+  --client --specPath modules/sample/src/main/resources/issues/issue148.yaml --outputPath modules/sample/src/main/scala --packageName issues.issue148.client.akkaHttp --framework akka-http
+  --server --specPath modules/sample/src/main/resources/issues/issue148.yaml --outputPath modules/sample/src/main/scala --packageName issues.issue148.server.http4s --framework http4s
+  --server --specPath modules/sample/src/main/resources/issues/issue148.yaml --outputPath modules/sample/src/main/scala --packageName issues.issue148.server.akkaHttp --framework akka-http
 """.replaceAllLiterally("\n", " ").split(' ').filter(_.nonEmpty): _*
 )
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpGenerator.scala
@@ -29,7 +29,7 @@ object AkkaHttpGenerator {
             q"import akka.http.scaladsl.unmarshalling.{Unmarshal, Unmarshaller, FromEntityUnmarshaller, FromStringUnmarshaller}",
             q"import akka.http.scaladsl.marshalling.{Marshal, Marshaller, Marshalling, ToEntityMarshaller, ToResponseMarshaller}",
             q"import akka.http.scaladsl.server.Directives._",
-            q"import akka.http.scaladsl.server.{Directive, Directive0, Directive1, ExceptionHandler, MissingFormFieldRejection, Rejection, Route}",
+            q"import akka.http.scaladsl.server.{Directive, Directive0, Directive1, ExceptionHandler, MalformedHeaderRejection, MissingFormFieldRejection, Rejection, Route}",
             q"import akka.http.scaladsl.util.FastFuture",
             q"import akka.stream.{IOResult, Materializer}",
             q"import akka.stream.scaladsl.{FileIO, Keep, Sink, Source}",

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpGenerator.scala
@@ -127,7 +127,7 @@ object AkkaHttpGenerator {
 
             implicit def jsonDecoderUnmarshaller[A](implicit J: ${jsonDecoderTypeclass}[A]): FromStringUnmarshaller[A] = {
               jsonStringUnmarshaller
-                .flatMap(_ => _ => json => J.decodeJson(json).fold(_ => FastFuture.failed(Unmarshaller.NoContentException), FastFuture.successful))
+                .flatMap(_ => _ => json => J.decodeJson(json).fold(FastFuture.failed, FastFuture.successful))
             }
 
             implicit val ignoredUnmarshaller: FromEntityUnmarshaller[IgnoredEntity] =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpGenerator.scala
@@ -115,7 +115,7 @@ object AkkaHttpGenerator {
 
             implicit def jsonEntityUnmarshaller[A](implicit J: ${jsonDecoderTypeclass}[A]): FromEntityUnmarshaller[A] = {
               Unmarshaller.firstOf(structuredJsonEntityUnmarshaller, stringyJsonEntityUnmarshaller)
-                .flatMap(_ => _ => json => J.decodeJson(json).fold(_ => FastFuture.failed(Unmarshaller.NoContentException), FastFuture.successful))
+                .flatMap(_ => _ => json => J.decodeJson(json).fold(FastFuture.failed, FastFuture.successful))
             }
 
             final val jsonStringUnmarshaller: FromStringUnmarshaller[${jsonType}] = Unmarshaller.strict {

--- a/modules/codegen/src/test/scala/codegen/WritePackageSpec.scala
+++ b/modules/codegen/src/test/scala/codegen/WritePackageSpec.scala
@@ -78,11 +78,15 @@ class WritePackageSpec extends FunSuite with Matchers {
       .unsafeExtract(
         Common
           .processArgs[ScalaLanguage, CoreTerm[ScalaLanguage, ?]](args)
-          .foldMap(CoreTermInterp[ScalaLanguage]("akka-http", {
-            case "akka-http" => AkkaHttp
-          }, {
-            _.parse[Importer].toEither.bimap(err => UnparseableArgument("import", err.toString), importer => Import(List(importer)))
-          }))
+          .foldMap(
+            CoreTermInterp[ScalaLanguage](
+              "akka-http", {
+                case "akka-http" => AkkaHttp
+              }, {
+                _.parse[Importer].toEither.bimap(err => UnparseableArgument("import", err.toString), importer => Import(List(importer)))
+              }
+            )
+          )
       )
       .toList
       .flatMap(x => Target.unsafeExtract(injectSwagger(swagger, x)))
@@ -135,11 +139,15 @@ class WritePackageSpec extends FunSuite with Matchers {
       .unsafeExtract(
         Common
           .processArgs[ScalaLanguage, CoreTerm[ScalaLanguage, ?]](args)
-          .foldMap(CoreTermInterp[ScalaLanguage]("akka-http", {
-            case "akka-http" => AkkaHttp
-          }, {
-            _.parse[Importer].toEither.bimap(err => UnparseableArgument("import", err.toString), importer => Import(List(importer)))
-          }))
+          .foldMap(
+            CoreTermInterp[ScalaLanguage](
+              "akka-http", {
+                case "akka-http" => AkkaHttp
+              }, {
+                _.parse[Importer].toEither.bimap(err => UnparseableArgument("import", err.toString), importer => Import(List(importer)))
+              }
+            )
+          )
       )
       .toList
       .flatMap(x => Target.unsafeExtract(injectSwagger(swagger, x)))

--- a/modules/sample/src/main/resources/issues/issue148.yaml
+++ b/modules/sample/src/main/resources/issues/issue148.yaml
@@ -1,0 +1,69 @@
+swagger: '2.0'
+info:
+  title: https://github.com/twilio/guardrail/issues/148
+  version: 1.0.0
+paths:
+  /test:
+    post:
+      operationId: createFoo
+      consumes:
+        - application/json
+      parameters:
+        - in: header
+          name: x-header
+          type: boolean
+          required: true
+        - in: header
+          name: x-optional-header
+          type: boolean
+          required: false
+        - in: body
+          name: body
+          required: true
+          type: object
+          schema:
+            $ref: '#/definitions/Foo'
+      responses:
+        200:
+          schema:
+            $ref: '#/definitions/Foo'
+    put:
+      operationId: updateFoo
+      consumes:
+        - multipart/form-data
+      parameters:
+        - in: formData
+          name: foo
+          type: boolean
+          required: true
+        - in: formData
+          name: bar
+          type: boolean
+      responses:
+        202:
+          schema:
+            $ref: '#/definitions/Foo'
+    get:
+      operationId: getFoo
+      produces:
+        - application/json
+      responses:
+        200:
+          schema:
+            $ref: '#/definitions/Foo'
+definitions:
+  Foo:
+    type: object
+    discriminator: type
+    required:
+    - name
+    properties:
+      name:
+        type: string
+  Bar:
+    allOf:
+    - $ref: '#/definitions/Foo'
+    - type: object
+      properties:
+        bar:
+          type: string

--- a/modules/sample/src/test/scala/core/issues/Issue148.scala
+++ b/modules/sample/src/test/scala/core/issues/Issue148.scala
@@ -1,0 +1,446 @@
+package core.issues
+
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.server._
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.http.scaladsl.unmarshalling.Unmarshaller
+import cats.instances.future._
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.SpanSugar._
+import org.scalatest.{ EitherValues, FunSuite, Matchers }
+import scala.concurrent.Future
+import io.circe._
+import _root_.jawn.IncompleteParseException
+
+/** Changes
+  *
+  * - Server request body validation
+  * - Client responses
+  *   - No content vs Partial content vs Invalid content
+  * - Polymorphic discriminator error messages
+  */
+
+class Issue148Suite extends FunSuite with Matchers with EitherValues with ScalaFutures with ScalatestRouteTest {
+  override implicit val patienceConfig = PatienceConfig(10 seconds, 1 second)
+
+  test("akka-http server request body validation") {
+    import issues.issue148.server.akkaHttp.{ Handler, Resource }
+    import issues.issue148.server.akkaHttp.definitions._
+    val route = Resource.routes(new Handler {
+      override def createFoo(respond: Resource.createFooResponse.type)(body: Foo, xHeader: Boolean, xOptionalHeader: Option[Boolean]): Future[Resource.createFooResponse] =
+        Future.successful(respond.OK(body))
+      override def getFoo(respond: Resource.getFooResponse.type)(): Future[Resource.getFooResponse] =
+        Future.successful(respond.OK(Bar("bar")))
+      override def updateFoo(respond: Resource.updateFooResponse.type)(name: Boolean, bar: Option[Boolean]): Future[Resource.updateFooResponse] =
+        Future.successful(respond.Accepted(Bar("bar")))
+    })
+
+    /* Correct mime type
+     * Missing content
+     */
+    Post("/test").withEntity(ContentTypes.`application/json`, "") ~> route ~> check {
+      rejection match {
+        case RequestEntityExpectedRejection => ()
+      }
+    }
+
+    /* Correct mime type
+     * Invalid JSON
+     */
+    Post("/test").withEntity(ContentTypes.`application/json`, "{") ~> route ~> check {
+      rejection match {
+        case ex: MalformedRequestContentRejection => ex.message shouldBe "exhausted input"
+      }
+    }
+
+    /* Correct mime type
+     * Valid JSON
+     * Missing discriminator
+     */
+    Post("/test").withEntity(ContentTypes.`application/json`, "{}") ~> route ~> check {
+      rejection match {
+        case ex: MalformedRequestContentRejection => ex.message shouldBe "Attempt to decode value on failed cursor: DownField(type)"
+      }
+    }
+
+    /* Correct mime type
+     * Valid JSON
+     * Invalid discriminator
+     */
+    Post("/test").withEntity(ContentTypes.`application/json`, """{"type": "blep"}""") ~> route ~> check {
+      rejection match {
+        case ex: MalformedRequestContentRejection => ex.message shouldBe "Unknown value blep (valid: Bar): DownField(type)"
+      }
+    }
+
+    /* Correct mime type
+     * Valid JSON
+     * Valid discriminator
+     * Missing "name" field
+     */
+    Post("/test").withEntity(ContentTypes.`application/json`, """{"type": "Bar"}""") ~> route ~> check {
+      rejection match {
+        case ex: MalformedRequestContentRejection => ex.message shouldBe "Attempt to decode value on failed cursor: DownField(name)"
+      }
+    }
+
+    val validEntity = """{"type": "Bar", "name": "bar"}"""
+
+    /* Correct mime type
+     * Valid JSON
+     * Valid discriminator
+     * Valid "name" field
+     * Invalid "x-header" value
+     */
+    Post("/test")
+      .withEntity(ContentTypes.`application/json`, validEntity)
+      .withHeaders(RawHeader("x-header", "foo")) ~> route ~> check {
+      rejection match {
+        case MalformedHeaderRejection("x-header", message, _) => message shouldBe "Boolean"
+      }
+    }
+
+    /* Correct mime type
+     * Valid JSON
+     * Valid discriminator
+     * Valid "name" field
+     * Valid "x-header" value
+     * Invalid "x-optional-header" value
+     */
+    Post("/test")
+      .withEntity(ContentTypes.`application/json`, validEntity)
+      .withHeaders(RawHeader("x-header", "false"), RawHeader("x-optional-header", "foo")) ~> route ~> check {
+      rejection match {
+        case MalformedHeaderRejection("x-optional-header", message, _) => message shouldBe "Boolean"
+      }
+    }
+
+    /* Correct entity mime type
+     * Invalid mime type for "foo" body part
+     */
+    Put("/test")
+      .withEntity(Multipart.FormData(
+        Multipart.FormData.BodyPart.Strict("foo", "blep")
+      ).toEntity) ~> route ~> check {
+      rejection match {
+        case MalformedFormFieldRejection("foo", message, _) => message shouldBe "Boolean"
+      }
+    }
+
+    /* Correct entity mime type
+     * Valid mime type for "foo" body part
+     * Invalid content for "foo" body part
+     */
+    Put("/test")
+      .withEntity(Multipart.FormData(
+        Multipart.FormData.BodyPart.Strict("foo", HttpEntity(ContentTypes.`application/json`, "blep"))
+      ).toEntity) ~> route ~> check {
+      rejection match {
+        case MalformedFormFieldRejection("foo", message, _) =>
+          message shouldBe "expected json value got b (line 1, column 1)"
+      }
+    }
+
+    /* Correct entity mime type
+     * Valid mime type for "foo" body part
+     * Valid content for "foo" body part
+     * Invalid mime type for "bar" body part
+     */
+    Put("/test")
+      .withEntity(Multipart.FormData(
+        Multipart.FormData.BodyPart.Strict("foo", HttpEntity(ContentTypes.`application/json`, "false")),
+        Multipart.FormData.BodyPart.Strict("bar", "blep")
+      ).toEntity) ~> route ~> check {
+      rejection match {
+        case MalformedFormFieldRejection("bar", message, _) => message shouldBe "Boolean"
+      }
+    }
+
+    /* Correct entity mime type
+     * Valid mime type for "foo" body part
+     * Valid content for "foo" body part
+     * Valid mime type for "bar" body part
+     * Invalid content for "bar" body part
+     */
+    Put("/test")
+      .withEntity(Multipart.FormData(
+        Multipart.FormData.BodyPart.Strict("foo", HttpEntity(ContentTypes.`application/json`, "false")),
+        Multipart.FormData.BodyPart.Strict("bar", HttpEntity(ContentTypes.`application/json`, "blep"))
+      ).toEntity) ~> route ~> check {
+      rejection match {
+        case MalformedFormFieldRejection("bar", message, _) => message shouldBe "expected json value got b (line 1, column 1)"
+      }
+    }
+  }
+
+  test("akka-http client response body validation") {
+    import issues.issue148.client.akkaHttp.Client
+    import issues.issue148.client.akkaHttp.definitions._
+
+    def jsonResponse(str: String): HttpRequest => Future[HttpResponse] = _ => Future.successful(HttpResponse(200).withEntity(ContentTypes.`application/json`, str))
+
+    /* Correct mime type
+     * Missing content
+     */
+    Client.httpClient(jsonResponse(""), "http://localhost:80").getFoo().value.futureValue match {
+      case Left(Left(Unmarshaller.NoContentException)) => ()
+      case ex => failTest(s"Unknown: ${ex}")
+    }
+
+    /* Correct mime type
+     * Invalid JSON
+     */
+    Client.httpClient(jsonResponse("{"), "http://localhost:80").getFoo().value.futureValue match {
+      case Left(Left(ParsingFailure(msg1, IncompleteParseException(msg2)))) =>
+        msg1 shouldBe "exhausted input"
+        msg2 shouldBe "exhausted input"
+      case ex => failTest(s"Unknown: ${ex}")
+    }
+
+    /* Correct mime type
+     * Valid JSON
+     * Missing discriminator
+     */
+    Client.httpClient(jsonResponse("{}"), "http://localhost:80").getFoo().value.futureValue match {
+      case Left(Left(DecodingFailure(message, history))) =>
+        message shouldBe "Attempt to decode value on failed cursor"
+        history should equal(List(CursorOp.DownField("type")))
+      case ex => failTest(s"Unknown: ${ex}")
+    }
+
+    /* Correct mime type
+     * Valid JSON
+     * Invalid discriminator
+     */
+    Client.httpClient(jsonResponse("""{"type": "blep"}"""), "http://localhost:80").getFoo().value.futureValue match {
+      case Left(Left(DecodingFailure(message, history))) =>
+        message shouldBe "Unknown value blep (valid: Bar)"
+        history should equal(List(CursorOp.DownField("type")))
+      case ex => failTest(s"Unknown: ${ex}")
+    }
+
+    /* Correct mime type
+     * Valid JSON
+     * Valid discriminator
+     * Missing "name" field
+     */
+    Client.httpClient(jsonResponse("""{"type": "Bar"}"""), "http://localhost:80").getFoo().value.futureValue match {
+      case Left(Left(DecodingFailure(message, history))) =>
+        message shouldBe "Attempt to decode value on failed cursor"
+        history should equal(List(CursorOp.DownField("name")))
+      case ex => failTest(s"Unknown: ${ex}")
+    }
+  }
+
+  test("http4s server request body validation") {
+    import cats.effect.IO
+    import issues.issue148.server.http4s.definitions._
+    import issues.issue148.server.http4s.{ Handler, Resource, CreateFooResponse, GetFooResponse, UpdateFooResponse }
+    import org.http4s._
+    import org.http4s.client.Client
+    import org.http4s.client.UnexpectedStatus
+    import org.http4s.client.blaze._
+    import org.http4s.headers._
+    import org.http4s.implicits._
+    import org.http4s.multipart._
+
+    val route = new Resource[IO]().routes(new Handler[IO] {
+      override def createFoo(respond: CreateFooResponse.type)(body: Foo, xHeader: Boolean, xOptionalHeader: Option[Boolean]): IO[CreateFooResponse] =
+        IO.pure(respond.Ok(body))
+      override def getFoo(respond: GetFooResponse.type)(): IO[GetFooResponse] =
+        IO.pure(respond.Ok(Bar("bar")))
+      override def updateFoo(respond: UpdateFooResponse.type)(name: Boolean, bar: Option[Boolean]): IO[UpdateFooResponse] =
+        IO.pure(respond.Accepted(Bar("bar")))
+    })
+
+    val client = Client.fromHttpApp[IO](route.orNotFound)
+    def failedResponseBody(req: Request[IO]): String =
+      client.fetch(req)({
+        case Status.BadRequest(resp) =>
+          resp.as[String]
+        case Status.UnprocessableEntity(resp) =>
+          resp.as[String]
+      }).unsafeRunSync()
+
+    def makeJsonRequest(body: String): Request[IO] = 
+      Request[IO](method = Method.POST, uri = Uri.unsafeFromString("/test"))
+        .withEntity(body)(
+          EntityEncoder[IO, String]
+            .withContentType(`Content-Type`(MediaType.application.json).withCharset(DefaultCharset))
+        )
+
+    def makeFormRequest(body: Multipart[IO]): Request[IO] =
+      Request[IO](method = Method.PUT, uri = Uri.unsafeFromString("/test"))
+        .withEntity(body)
+
+    /* Correct mime type
+     * Missing content
+     */
+    failedResponseBody(makeJsonRequest("")) should equal("The request body was malformed.")
+
+    /* Correct mime type
+     * Invalid JSON
+     */
+    failedResponseBody(makeJsonRequest("{")) should equal("The request body was malformed.")
+
+    /* Correct mime type
+     * Valid JSON
+     * Missing discriminator
+     */
+    failedResponseBody(makeJsonRequest("{}")) should equal("The request body was invalid.")
+
+    /* Correct mime type
+     * Valid JSON
+     * Invalid discriminator
+     */
+    failedResponseBody(makeJsonRequest("""{"type": "blep"}""")) should equal("The request body was invalid.")
+
+    /* Correct mime type
+     * Valid JSON
+     * Valid discriminator
+     * Missing "name" field
+     */
+    failedResponseBody(makeJsonRequest("""{"type": "Bar"}""")) should equal("The request body was invalid.")
+
+    val validEntity = """{"type": "Bar", "name": "bar"}"""
+
+    /* Correct mime type
+     * Valid JSON
+     * Valid discriminator
+     * Valid "name" field
+     * Invalid "x-header" value
+     */
+    failedResponseBody(makeJsonRequest(validEntity).withHeaders(Headers(
+      Header("x-header", "foo")
+    ))) should equal("Invalid data")
+
+    /* Correct mime type
+     * Valid JSON
+     * Valid discriminator
+     * Valid "name" field
+     * Valid "x-header" value
+     * Invalid "x-optional-header" value
+     */
+    // TODO: https://github.com/twilio/guardrail/issues/155
+    // `x-header` is currently never parsed correctly due to #155
+    // Once this is fixed, this test will still fail due to `x-optional-header`,
+    // but this is intentional for this test case.
+    failedResponseBody(makeJsonRequest(validEntity).withHeaders(Headers(
+      Header("x-header", "false"),
+      Header("x-optional-header", "foo")
+    ))) should equal("Invalid data")
+
+    /* Correct entity mime type
+     * Invalid mime type for "foo" body part
+     */
+    // TODO: https://github.com/twilio/guardrail/issues/155
+    failedResponseBody(makeFormRequest(Multipart(Vector(
+      Part.formData[IO]("foo", "blep")
+    )))) should equal("The request body was malformed.")
+
+    /* Correct entity mime type
+     * Valid mime type for "foo" body part
+     * Invalid content for "foo" body part
+     */
+    // TODO: https://github.com/twilio/guardrail/issues/155
+    failedResponseBody(makeFormRequest(Multipart(Vector(
+      Part.formData[IO]("foo", "blep", Header("Content-Type", "application/json"))
+    )))) should equal("The request body was malformed.")
+
+    /* Correct entity mime type
+     * Valid mime type for "foo" body part
+     * Valid content for "foo" body part
+     * Invalid mime type for "bar" body part
+     */
+    // TODO: https://github.com/twilio/guardrail/issues/155
+    failedResponseBody(makeFormRequest(Multipart(Vector(
+      Part.formData[IO]("foo", "false", Header("Content-Type", "application/json")),
+      Part.formData[IO]("bar", "blep")
+    )))) should equal("The request body was malformed.")
+
+    /* Correct entity mime type
+     * Valid mime type for "foo" body part
+     * Valid content for "foo" body part
+     * Valid mime type for "bar" body part
+     * Invalid content for "bar" body part
+     */
+    // TODO: https://github.com/twilio/guardrail/issues/155
+    failedResponseBody(makeFormRequest(Multipart(Vector(
+      Part.formData[IO]("foo", "false", Header("Content-Type", "application/json")),
+      Part.formData[IO]("bar", "blep", Header("Content-Type", "application/json"))
+    )))) should equal("The request body was malformed.")
+  }
+
+  test("http4s client response body validation") {
+    import issues.issue148.client.http4s.{ Client, GetFooResponse }
+    import issues.issue148.client.http4s.definitions._
+    import cats.effect.IO
+    import cats.data.Kleisli
+    import org.http4s._
+    import org.http4s.client.{ Client => Http4sClient }
+    import org.http4s.client.UnexpectedStatus
+    import org.http4s.client.blaze._
+    import org.http4s.headers._
+    import org.http4s.implicits._
+    import org.http4s.multipart._
+
+    def jsonResponse(str: String): Http4sClient[IO] =
+      Http4sClient.fromHttpApp[IO](Kleisli.pure(
+        Response[IO](Status.Ok)
+          .withEntity(str)(
+            EntityEncoder[IO, String]
+              .withContentType(`Content-Type`(MediaType.application.json).withCharset(DefaultCharset))
+          )))
+
+    /* Correct mime type
+     * Missing content
+     */
+    Client.httpClient(jsonResponse(""), "http://localhost:80").getFoo().attempt.unsafeRunSync() match {
+      case Left(MalformedMessageBodyFailure(details, cause)) => details should equal("Invalid JSON: empty body")
+      case ex => failTest(s"Unknown: ${ex}")
+    }
+
+    /* Correct mime type
+     * Invalid JSON
+     */
+    Client.httpClient(jsonResponse("{"), "http://localhost:80").getFoo().attempt.unsafeRunSync() match {
+      case Left(MalformedMessageBodyFailure(details, cause)) => details should equal("Invalid JSON")
+      case ex => failTest(s"Unknown: ${ex}")
+    }
+
+    /* Correct mime type
+     * Valid JSON
+     * Missing discriminator
+     */
+    Client.httpClient(jsonResponse("{}"), "http://localhost:80").getFoo().attempt.unsafeRunSync() match {
+      case Left(InvalidMessageBodyFailure(_, Some(DecodingFailure(message, history)))) =>
+        message shouldBe "Attempt to decode value on failed cursor"
+        history should equal(List(CursorOp.DownField("type")))
+      case ex => failTest(s"Unknown: ${ex}")
+    }
+
+    /* Correct mime type
+     * Valid JSON
+     * Invalid discriminator
+     */
+    Client.httpClient(jsonResponse("""{"type": "blep"}"""), "http://localhost:80").getFoo().attempt.unsafeRunSync() match {
+      case Left(InvalidMessageBodyFailure(_, Some(DecodingFailure(message, history)))) =>
+        message shouldBe "Unknown value blep (valid: Bar)"
+        history should equal(List(CursorOp.DownField("type")))
+      case ex => failTest(s"Unknown: ${ex}")
+    }
+
+    /* Correct mime type
+     * Valid JSON
+     * Valid discriminator
+     * Missing "name" field
+     */
+    Client.httpClient(jsonResponse("""{"type": "Bar"}"""), "http://localhost:80").getFoo().attempt.unsafeRunSync() match {
+      case Left(InvalidMessageBodyFailure(_, Some(DecodingFailure(message, history)))) =>
+        message shouldBe "Attempt to decode value on failed cursor"
+        history should equal(List(CursorOp.DownField("name")))
+      case ex => failTest(s"Unknown: ${ex}")
+    }
+  }
+}


### PR DESCRIPTION
- Added error messages to polymorphic discriminators (previous error: `scala.MatchError: foo (of class java.lang.String)`)
- Exposed underlying circe decoding errors
- Removed incorrect usage of `NoContentException`

Initial work towards #148, actually exposing validation errors in clients and servers. Customization will be more tricky, still need to think about how that will work.