### PR TITLE
Abstract companion objects

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -18,6 +18,8 @@ import scala.io.AnsiColor
 import scala.meta._
 
 object Common {
+  val resolveFile: Path => List[String] => Path = root => _.foldLeft(root)(_.resolve(_))
+
   def writePackage[L <: LA, F[_]](kind: CodegenTarget,
                                   context: Context,
                                   swagger: Swagger,
@@ -39,7 +41,6 @@ object Common {
     import Sc._
     import Sw._
 
-    val resolveFile: Path => List[String] => Path       = root => _.foldLeft(root)(_.resolve(_))
     val splitComponents: String => Option[List[String]] = x => Some(x.split('.').toList).filterNot(_.isEmpty)
 
     val pkgPath        = resolveFile(outputPath)(pkgName)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
@@ -96,9 +96,9 @@ object SwaggerUtil {
             .flatMap {
               case RandomType(name, tpe) =>
                 Free.pure(Resolved[L](tpe, None, None))
-              case ClassDefinition(name, tpe, cls, companion, _) =>
+              case ClassDefinition(name, tpe, cls, _, _) =>
                 widenTypeName(tpe).map(Resolved[L](_, None, None))
-              case EnumDefinition(name, tpe, elems, cls, companion) =>
+              case EnumDefinition(name, tpe, elems, cls, _) =>
                 widenTypeName(tpe).map(Resolved[L](_, None, None))
               case ADT(_, tpe, _, _) =>
                 widenTypeName(tpe).map(Resolved[L](_, None, None))
@@ -108,9 +108,9 @@ object SwaggerUtil {
             .flatMap {
               case RandomType(name, tpe) =>
                 liftVectorType(tpe).map(Resolved[L](_, None, None))
-              case ClassDefinition(name, tpe, cls, companion, _) =>
+              case ClassDefinition(name, tpe, cls, _, _) =>
                 widenTypeName(tpe).flatMap(liftVectorType).map(Resolved[L](_, None, None))
-              case EnumDefinition(name, tpe, elems, cls, companion) =>
+              case EnumDefinition(name, tpe, elems, cls, _) =>
                 widenTypeName(tpe).flatMap(liftVectorType).map(Resolved[L](_, None, None))
               case ADT(_, tpe, _, _) =>
                 widenTypeName(tpe).flatMap(liftVectorType).map(Resolved[L](_, None, None))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpClientGenerator.scala
@@ -309,7 +309,7 @@ object AkkaHttpClientGenerator {
 
       case GenerateResponseDefinitions(operationId, operation, protocolElems) => Target.pure(List.empty)
 
-      case BuildCompanion(clientName, tracingName, schemes, host, ctorArgs, tracing) =>
+      case BuildStaticDefns(clientName, tracingName, schemes, host, ctorArgs, tracing) =>
         def extraConstructors(tracingName: Option[String],
                               schemes: List[String],
                               host: Option[String],
@@ -346,14 +346,18 @@ object AkkaHttpClientGenerator {
           """
         }
 
-        val companion: Defn.Object =
-          q"""
-            object ${Term.Name(clientName)} {
-              def apply(...$ctorArgs): ${Type.Name(clientName)} = $ctorCall
-              ..${extraConstructors(tracingName, schemes, host, Type.Name(clientName), ctorCall, tracing)}
-            }
-          """
-        Target.pure(companion)
+        val decls: List[Defn] =
+          q"""def apply(...$ctorArgs): ${Type.Name(clientName)} = $ctorCall""" +:
+            extraConstructors(tracingName, schemes, host, Type.Name(clientName), ctorCall, tracing)
+        Target.pure(
+          StaticDefns[ScalaLanguage](
+            className = clientName,
+            extraImports = List.empty,
+            members = List.empty,
+            definitions = decls,
+            values = List.empty
+          )
+        )
 
       case BuildClient(clientName, tracingName, schemes, host, basePath, ctorArgs, clientCalls, supportDefinitions, tracing) =>
         val client =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpClientGenerator.scala
@@ -7,7 +7,7 @@ import _root_.io.swagger.models._
 import cats.arrow.FunctionK
 import cats.data.NonEmptyList
 import cats.syntax.flatMap._
-import com.twilio.guardrail.generators.syntax.scala._
+import com.twilio.guardrail.generators.syntax.Scala._
 import com.twilio.guardrail.protocol.terms.client._
 import com.twilio.guardrail.terms.RouteMeta
 import com.twilio.guardrail.languages.ScalaLanguage

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
@@ -11,7 +11,7 @@ import cats.syntax.functor._
 import cats.syntax.traverse._
 import com.twilio.guardrail.SwaggerUtil
 import com.twilio.guardrail.extract.{ ScalaPackage, ScalaTracingLabel, ServerRawResponse }
-import com.twilio.guardrail.generators.syntax.scala._
+import com.twilio.guardrail.generators.syntax.Scala._
 import com.twilio.guardrail.languages.ScalaLanguage
 import com.twilio.guardrail.protocol.terms.server._
 import com.twilio.guardrail.terms.RouteMeta

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sClientGenerator.scala
@@ -9,7 +9,7 @@ import cats.syntax.flatMap._
 import cats.syntax.functor._
 import cats.syntax.traverse._
 import com.twilio.guardrail.extract.ScalaPackage
-import com.twilio.guardrail.generators.syntax.scala._
+import com.twilio.guardrail.generators.syntax.Scala._
 import com.twilio.guardrail.languages.ScalaLanguage
 import com.twilio.guardrail.protocol.terms.client._
 import com.twilio.guardrail.terms.RouteMeta

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
@@ -9,7 +9,7 @@ import cats.syntax.flatMap._
 import cats.syntax.functor._
 import cats.syntax.traverse._
 import com.twilio.guardrail.extract.{ ScalaPackage, ScalaTracingLabel, ServerRawResponse }
-import com.twilio.guardrail.generators.syntax.scala._
+import com.twilio.guardrail.generators.syntax.Scala._
 import com.twilio.guardrail.languages.ScalaLanguage
 import com.twilio.guardrail.protocol.terms.server._
 import com.twilio.guardrail.terms.RouteMeta

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
@@ -3,10 +3,10 @@ package generators
 
 import cats.syntax.either._
 import cats.~>
+import com.twilio.guardrail.generators.syntax.Scala._
 import com.twilio.guardrail.languages.ScalaLanguage
 import com.twilio.guardrail.terms._
 import scala.meta._
-import java.nio.file.{ Path, Paths }
 
 object ScalaGenerator {
   object ScalaInterp extends (ScalaTerm[ScalaLanguage, ?] ~> Target) {
@@ -17,8 +17,6 @@ object ScalaGenerator {
     }
     val partitionImplicits: PartialFunction[Stat, Boolean] = matchImplicit.andThen(_ => true).orElse({ case _ => false })
 
-    val utf8                                      = java.nio.charset.Charset.availableCharsets.get("UTF-8")
-    val resolveFile: Path => List[String] => Path = root => _.foldLeft(root)(_.resolve(_))
     val buildPkgTerm: List[String] => Term.Ref =
       _.map(Term.Name.apply _).reduceLeft(Term.Select.apply _)
     def apply[T](term: ScalaTerm[ScalaLanguage, T]): Target[T] = term match {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
@@ -1,11 +1,13 @@
-package com.twilio.guardrail
-package generators
+package com.twilio.guardrail.generators
 
 import cats.syntax.either._
 import cats.~>
+import com.twilio.guardrail._
+import com.twilio.guardrail.Common.resolveFile
 import com.twilio.guardrail.generators.syntax.Scala._
 import com.twilio.guardrail.languages.ScalaLanguage
 import com.twilio.guardrail.terms._
+import java.nio.charset.StandardCharsets
 import scala.meta._
 
 object ScalaGenerator {
@@ -191,7 +193,7 @@ object ScalaGenerator {
               }
             }
           """
-        Target.pure(WriteTree(pkgPath.resolve("Implicits.scala"), implicits.syntax.getBytes(utf8)))
+        Target.pure(WriteTree(pkgPath.resolve("Implicits.scala"), implicits.syntax.getBytes(StandardCharsets.UTF_8)))
 
       case RenderFrameworkImplicits(pkgPath, pkgName, frameworkImports, jsonImports, frameworkImplicits, frameworkImplicitName) =>
         val pkg: Term.Ref =
@@ -212,7 +214,7 @@ object ScalaGenerator {
 
             ${frameworkImplicits}
           """
-        Target.pure(WriteTree(pkgPath.resolve(s"${frameworkImplicitName.value}.scala"), frameworkImplicitsFile.syntax.getBytes(utf8)))
+        Target.pure(WriteTree(pkgPath.resolve(s"${frameworkImplicitName.value}.scala"), frameworkImplicitsFile.syntax.getBytes(StandardCharsets.UTF_8)))
 
       case WritePackageObject(dtoPackagePath, dtoComponents, customImports, packageObjectImports, protocolImports, packageObjectContents, extraTypes) =>
         val dtoHead :: dtoRest = dtoComponents
@@ -247,7 +249,7 @@ object ScalaGenerator {
             package object ${Term.Name(dtoComponents.last)} {
               ..${(mirroredImplicits ++ statements ++ extraTypes).to[List]}
             }
-            """.syntax.getBytes(utf8)
+            """.syntax.getBytes(StandardCharsets.UTF_8)
           )
         )
       case WriteProtocolDefinition(outputPath, pkgName, definitions, dtoComponents, imports, elem) =>
@@ -263,7 +265,7 @@ object ScalaGenerator {
 
                 $cls
                 ${companionForStaticDefns(staticDefns)}
-              """.syntax.getBytes(utf8)
+              """.syntax.getBytes(StandardCharsets.UTF_8)
                )
              ),
              List.empty[Stat])
@@ -277,7 +279,7 @@ object ScalaGenerator {
                 ..${imports}
                 $cls
                 ${companionForStaticDefns(staticDefns)}
-              """.syntax.getBytes(utf8)
+              """.syntax.getBytes(StandardCharsets.UTF_8)
                )
              ),
              List.empty[Stat])
@@ -296,7 +298,7 @@ object ScalaGenerator {
                     $polyImports
                     $trt
                     ${companionForStaticDefns(staticDefns)}
-                  """.syntax.getBytes(utf8)
+                  """.syntax.getBytes(StandardCharsets.UTF_8)
                 )
               ),
               List.empty[Stat]
@@ -324,7 +326,7 @@ object ScalaGenerator {
             ${companionForStaticDefns(staticDefns)};
             ${client};
             ..${responseDefinitions}
-            """.syntax.getBytes(utf8)
+            """.syntax.getBytes(StandardCharsets.UTF_8)
           )
         )
       case WriteServer(pkgPath, pkgName, customImports, frameworkImplicitName, dtoComponents, Server(pkg, extraImports, src)) =>
@@ -339,7 +341,7 @@ object ScalaGenerator {
               import ${buildPkgTerm(List("_root_") ++ dtoComponents)}._
               ..${customImports}
               ..$src
-              """.syntax.getBytes(utf8)
+              """.syntax.getBytes(StandardCharsets.UTF_8)
           )
         )
     }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/package.scala
@@ -1,5 +1,5 @@
 package com.twilio.guardrail
-import java.nio.charset.{Charset, StandardCharsets}
+import java.nio.charset.{ Charset, StandardCharsets }
 import java.nio.file.Path
 
 package object generators {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/package.scala
@@ -1,8 +1,0 @@
-package com.twilio.guardrail
-import java.nio.charset.{ Charset, StandardCharsets }
-import java.nio.file.Path
-
-package object generators {
-  val utf8: Charset                             = StandardCharsets.UTF_8
-  val resolveFile: Path => List[String] => Path = root => _.foldLeft(root)(_.resolve(_))
-}

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/package.scala
@@ -1,37 +1,8 @@
-package com.twilio.guardrail.generators.syntax
-import com.twilio.guardrail.generators._
-import cats.data.NonEmptyList
+package com.twilio.guardrail
+import java.nio.charset.{Charset, StandardCharsets}
+import java.nio.file.Path
 
-object scala {
-  implicit class RichRawParameterName(parameter: RawParameterName) {
-    import _root_.scala.meta._
-    def toLit: Lit.String = Lit.String(parameter.value)
-  }
-
-  implicit class RichScalaParameter(value: ScalaParameter.type) {
-    import _root_.scala.meta._
-    import com.twilio.guardrail.languages.ScalaLanguage
-    def fromParam(param: Term.Param): ScalaParameter[ScalaLanguage] = param match {
-      case param @ Term.Param(_, name, decltype, _) =>
-        val tpe: Type = decltype
-          .flatMap({
-            case tpe @ t"Option[$_]" => Some(tpe)
-            case Type.ByName(tpe)    => Some(tpe)
-            case tpe @ Type.Name(_)  => Some(tpe)
-            case _                   => None
-          })
-          .getOrElse(t"Nothing")
-        new ScalaParameter[ScalaLanguage](None, param, Term.Name(name.value), RawParameterName(name.value), tpe, true, None, false)
-    }
-  }
-
-  implicit class ExtendedUnzip[T1, T2, T3, T4, T5, T6, T7](xs: NonEmptyList[(T1, T2, T3, T4, T5, T6, T7)]) {
-    def unzip7: (List[T1], List[T2], List[T3], List[T4], List[T5], List[T6], List[T7]) =
-      xs.foldLeft(
-        (List.empty[T1], List.empty[T2], List.empty[T3], List.empty[T4], List.empty[T5], List.empty[T6], List.empty[T7])
-      ) {
-        case ((v1a, v2a, v3a, v4a, v5a, v6a, v7a), (v1, v2, v3, v4, v5, v6, v7)) =>
-          (v1a :+ v1, v2a :+ v2, v3a :+ v3, v4a :+ v4, v5a :+ v5, v6a :+ v6, v7a :+ v7)
-      }
-  }
+package object generators {
+  val utf8: Charset                             = StandardCharsets.UTF_8
+  val resolveFile: Path => List[String] => Path = root => _.foldLeft(root)(_.resolve(_))
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/Scala.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/Scala.scala
@@ -1,7 +1,10 @@
 package com.twilio.guardrail.generators.syntax
 
 import cats.data.NonEmptyList
+import com.twilio.guardrail.StaticDefns
 import com.twilio.guardrail.generators._
+import com.twilio.guardrail.languages.ScalaLanguage
+import scala.meta._
 
 object Scala {
   implicit class RichRawParameterName(parameter: RawParameterName) {
@@ -35,4 +38,14 @@ object Scala {
           (v1a :+ v1, v2a :+ v2, v3a :+ v3, v4a :+ v4, v5a :+ v5, v6a :+ v6, v7a :+ v7)
       }
   }
+
+  def companionForStaticDefns(staticDefns: StaticDefns[ScalaLanguage]): Defn.Object =
+    q"""
+    object ${Term.Name(staticDefns.className)} {
+      ..${staticDefns.extraImports}
+      ..${staticDefns.members}
+      ..${staticDefns.values}
+      ..${staticDefns.definitions}
+    }
+    """
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/Scala.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/Scala.scala
@@ -1,0 +1,38 @@
+package com.twilio.guardrail.generators.syntax
+
+import cats.data.NonEmptyList
+import com.twilio.guardrail.generators._
+
+object Scala {
+  implicit class RichRawParameterName(parameter: RawParameterName) {
+    import _root_.scala.meta._
+    def toLit: Lit.String = Lit.String(parameter.value)
+  }
+
+  implicit class RichScalaParameter(value: ScalaParameter.type) {
+    import _root_.scala.meta._
+    import com.twilio.guardrail.languages.ScalaLanguage
+    def fromParam(param: Term.Param): ScalaParameter[ScalaLanguage] = param match {
+      case param @ Term.Param(_, name, decltype, _) =>
+        val tpe: Type = decltype
+          .flatMap({
+            case tpe @ t"Option[$_]" => Some(tpe)
+            case Type.ByName(tpe)    => Some(tpe)
+            case tpe @ Type.Name(_)  => Some(tpe)
+            case _                   => None
+          })
+          .getOrElse(t"Nothing")
+        new ScalaParameter[ScalaLanguage](None, param, Term.Name(name.value), RawParameterName(name.value), tpe, true, None, false)
+    }
+  }
+
+  implicit class ExtendedUnzip[T1, T2, T3, T4, T5, T6, T7](xs: NonEmptyList[(T1, T2, T3, T4, T5, T6, T7)]) {
+    def unzip7: (List[T1], List[T2], List[T3], List[T4], List[T5], List[T6], List[T7]) =
+      xs.foldLeft(
+        (List.empty[T1], List.empty[T2], List.empty[T3], List.empty[T4], List.empty[T5], List.empty[T6], List.empty[T7])
+      ) {
+        case ((v1a, v2a, v3a, v4a, v5a, v6a, v7a), (v1, v2, v3, v4, v5, v6, v7)) =>
+          (v1a :+ v1, v2a :+ v2, v3a :+ v3, v4a :+ v4, v5a :+ v5, v6a :+ v6, v7a :+ v7)
+      }
+  }
+}

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientTerm.scala
@@ -1,11 +1,9 @@
 package com.twilio.guardrail.protocol.terms.client
 
-import com.twilio.guardrail.{ RenderedClientOperation, StrictProtocolElems }
 import com.twilio.guardrail.generators.{ Responses, ScalaParameters }
-import com.twilio.guardrail.terms.RouteMeta
 import com.twilio.guardrail.languages.LA
-
-import _root_.io.swagger.models.Operation
+import com.twilio.guardrail.terms.RouteMeta
+import com.twilio.guardrail.{ RenderedClientOperation, StaticDefns, StrictProtocolElems }
 
 sealed trait ClientTerm[L <: LA, T]
 case class GenerateClientOperation[L <: LA](className: List[String],
@@ -21,13 +19,13 @@ case class ClientClsArgs[L <: LA](tracingName: Option[String], schemes: List[Str
     extends ClientTerm[L, List[List[L#MethodParameter]]]
 case class GenerateResponseDefinitions[L <: LA](operationId: String, responses: Responses[L], protocolElems: List[StrictProtocolElems[L]])
     extends ClientTerm[L, List[L#Definition]]
-case class BuildCompanion[L <: LA](clientName: String,
-                                   tracingName: Option[String],
-                                   schemes: List[String],
-                                   host: Option[String],
-                                   ctorArgs: List[List[L#MethodParameter]],
-                                   tracing: Boolean)
-    extends ClientTerm[L, L#ObjectDefinition]
+case class BuildStaticDefns[L <: LA](clientName: String,
+                                     tracingName: Option[String],
+                                     schemes: List[String],
+                                     host: Option[String],
+                                     ctorArgs: List[List[L#MethodParameter]],
+                                     tracing: Boolean)
+    extends ClientTerm[L, StaticDefns[L]]
 case class BuildClient[L <: LA](clientName: String,
                                 tracingName: Option[String],
                                 schemes: List[String],

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientTerms.scala
@@ -2,12 +2,10 @@ package com.twilio.guardrail.protocol.terms.client
 
 import cats.InjectK
 import cats.free.Free
-import com.twilio.guardrail.{ RenderedClientOperation, StrictProtocolElems }
+import com.twilio.guardrail.generators.{ Responses, ScalaParameters }
 import com.twilio.guardrail.languages.LA
 import com.twilio.guardrail.terms.RouteMeta
-import com.twilio.guardrail.generators.{ Responses, ScalaParameters }
-
-import _root_.io.swagger.models.Operation
+import com.twilio.guardrail.{ RenderedClientOperation, StaticDefns, StrictProtocolElems }
 
 class ClientTerms[L <: LA, F[_]](implicit I: InjectK[ClientTerm[L, ?], F]) {
   def generateClientOperation(className: List[String], tracing: Boolean, parameters: ScalaParameters[L])(
@@ -24,13 +22,13 @@ class ClientTerms[L <: LA, F[_]](implicit I: InjectK[ClientTerm[L, ?], F]) {
     Free.inject[ClientTerm[L, ?], F](ClientClsArgs[L](tracingName, schemes, host, tracing))
   def generateResponseDefinitions(operationId: String, responses: Responses[L], protocolElems: List[StrictProtocolElems[L]]): Free[F, List[L#Definition]] =
     Free.inject[ClientTerm[L, ?], F](GenerateResponseDefinitions[L](operationId, responses, protocolElems))
-  def buildCompanion(clientName: String,
-                     tracingName: Option[String],
-                     schemes: List[String],
-                     host: Option[String],
-                     ctorArgs: List[List[L#MethodParameter]],
-                     tracing: Boolean): Free[F, L#ObjectDefinition] =
-    Free.inject[ClientTerm[L, ?], F](BuildCompanion[L](clientName, tracingName, schemes, host, ctorArgs, tracing))
+  def buildStaticDefns(clientName: String,
+                       tracingName: Option[String],
+                       schemes: List[String],
+                       host: Option[String],
+                       ctorArgs: List[List[L#MethodParameter]],
+                       tracing: Boolean): Free[F, StaticDefns[L]] =
+    Free.inject[ClientTerm[L, ?], F](BuildStaticDefns[L](clientName, tracingName, schemes, host, ctorArgs, tracing))
   def buildClient(clientName: String,
                   tracingName: Option[String],
                   schemes: List[String],

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/EnumProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/EnumProtocolTerm.scala
@@ -1,6 +1,7 @@
 package com.twilio.guardrail.protocol.terms.protocol
 
 import _root_.io.swagger.models.ModelImpl
+import com.twilio.guardrail.StaticDefns
 import com.twilio.guardrail.languages.LA
 
 sealed trait EnumProtocolTerm[L <: LA, T]
@@ -9,10 +10,10 @@ case class RenderMembers[L <: LA](clsName: String, elems: List[(String, L#TermNa
 case class EncodeEnum[L <: LA](clsName: String)                                                     extends EnumProtocolTerm[L, L#ValueDefinition]
 case class DecodeEnum[L <: LA](clsName: String)                                                     extends EnumProtocolTerm[L, L#ValueDefinition]
 case class RenderClass[L <: LA](clsName: String, tpe: L#Type)                                       extends EnumProtocolTerm[L, L#ClassDefinition]
-case class RenderCompanion[L <: LA](clsName: String,
-                                    members: L#ObjectDefinition,
-                                    accessors: List[L#TermName],
-                                    encoder: L#ValueDefinition,
-                                    decoder: L#ValueDefinition)
-    extends EnumProtocolTerm[L, L#ObjectDefinition]
+case class RenderStaticDefns[L <: LA](clsName: String,
+                                      members: L#ObjectDefinition,
+                                      accessors: List[L#TermName],
+                                      encoder: L#ValueDefinition,
+                                      decoder: L#ValueDefinition)
+    extends EnumProtocolTerm[L, StaticDefns[L]]
 case class BuildAccessor[L <: LA](clsName: String, termName: String) extends EnumProtocolTerm[L, L#TermSelect]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/EnumProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/EnumProtocolTerms.scala
@@ -3,6 +3,7 @@ package com.twilio.guardrail.protocol.terms.protocol
 import _root_.io.swagger.models.ModelImpl
 import cats.InjectK
 import cats.free.Free
+import com.twilio.guardrail.StaticDefns
 import com.twilio.guardrail.languages.LA
 
 class EnumProtocolTerms[L <: LA, F[_]](implicit I: InjectK[EnumProtocolTerm[L, ?], F]) {
@@ -16,12 +17,12 @@ class EnumProtocolTerms[L <: LA, F[_]](implicit I: InjectK[EnumProtocolTerm[L, ?
     Free.inject[EnumProtocolTerm[L, ?], F](DecodeEnum[L](clsName))
   def renderClass(clsName: String, tpe: L#Type): Free[F, L#ClassDefinition] =
     Free.inject[EnumProtocolTerm[L, ?], F](RenderClass[L](clsName, tpe))
-  def renderCompanion(clsName: String,
-                      members: L#ObjectDefinition,
-                      accessors: List[L#TermName],
-                      encoder: L#ValueDefinition,
-                      decoder: L#ValueDefinition): Free[F, L#ObjectDefinition] =
-    Free.inject[EnumProtocolTerm[L, ?], F](RenderCompanion[L](clsName, members, accessors, encoder, decoder))
+  def renderStaticDefns(clsName: String,
+                        members: L#ObjectDefinition,
+                        accessors: List[L#TermName],
+                        encoder: L#ValueDefinition,
+                        decoder: L#ValueDefinition): Free[F, StaticDefns[L]] =
+    Free.inject[EnumProtocolTerm[L, ?], F](RenderStaticDefns[L](clsName, members, accessors, encoder, decoder))
   def buildAccessor(clsName: String, termName: String): Free[F, L#TermSelect] =
     Free.inject[EnumProtocolTerm[L, ?], F](BuildAccessor[L](clsName, termName))
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerm.scala
@@ -1,10 +1,10 @@
 package com.twilio.guardrail.protocol.terms.protocol
 
-import _root_.io.swagger.models.{ ComposedModel, Model, ModelImpl }
+import _root_.io.swagger.models.Model
 import _root_.io.swagger.models.properties.Property
-import com.twilio.guardrail.{ ProtocolParameter, SuperClass }
-import com.twilio.guardrail.languages.LA
 import com.twilio.guardrail.SwaggerUtil.ResolvedType
+import com.twilio.guardrail.languages.LA
+import com.twilio.guardrail.{ ProtocolParameter, StaticDefns, SuperClass }
 
 sealed trait ModelProtocolTerm[L <: LA, T]
 case class ExtractProperties[L <: LA](swagger: Model) extends ModelProtocolTerm[L, List[(String, Property)]]
@@ -18,8 +18,8 @@ case class TransformProperty[L <: LA](clsName: String,
 case class RenderDTOClass[L <: LA](clsName: String, terms: List[L#MethodParameter], parents: List[SuperClass[L]] = Nil)
     extends ModelProtocolTerm[L, L#ClassDefinition]
 case class EncodeModel[L <: LA](clsName: String, needCamelSnakeConversion: Boolean, params: List[ProtocolParameter[L]], parents: List[SuperClass[L]] = Nil)
-    extends ModelProtocolTerm[L, L#Statement]
+    extends ModelProtocolTerm[L, L#ValueDefinition]
 case class DecodeModel[L <: LA](clsName: String, needCamelSnakeConversion: Boolean, params: List[ProtocolParameter[L]], parents: List[SuperClass[L]] = Nil)
-    extends ModelProtocolTerm[L, L#Statement]
-case class RenderDTOCompanion[L <: LA](clsName: String, deps: List[L#TermName], encoder: L#Statement, decoder: L#Statement)
-    extends ModelProtocolTerm[L, L#ObjectDefinition]
+    extends ModelProtocolTerm[L, L#ValueDefinition]
+case class RenderDTOStaticDefns[L <: LA](clsName: String, deps: List[L#TermName], encoder: L#ValueDefinition, decoder: L#ValueDefinition)
+    extends ModelProtocolTerm[L, StaticDefns[L]]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerms.scala
@@ -4,7 +4,7 @@ import _root_.io.swagger.models.Model
 import _root_.io.swagger.models.properties.Property
 import cats.InjectK
 import cats.free.Free
-import com.twilio.guardrail.{ ProtocolParameter, SuperClass }
+import com.twilio.guardrail.{ ProtocolParameter, StaticDefns, SuperClass }
 import com.twilio.guardrail.languages.LA
 import com.twilio.guardrail.SwaggerUtil.ResolvedType
 
@@ -22,15 +22,15 @@ class ModelProtocolTerms[L <: LA, F[_]](implicit I: InjectK[ModelProtocolTerm[L,
   def encodeModel(clsName: String,
                   needCamelSnakeConversion: Boolean,
                   params: List[ProtocolParameter[L]],
-                  parents: List[SuperClass[L]] = Nil): Free[F, L#Statement] =
+                  parents: List[SuperClass[L]] = Nil): Free[F, L#ValueDefinition] =
     Free.inject[ModelProtocolTerm[L, ?], F](EncodeModel[L](clsName, needCamelSnakeConversion, params, parents))
   def decodeModel(clsName: String,
                   needCamelSnakeConversion: Boolean,
                   params: List[ProtocolParameter[L]],
-                  parents: List[SuperClass[L]] = Nil): Free[F, L#Statement] =
+                  parents: List[SuperClass[L]] = Nil): Free[F, L#ValueDefinition] =
     Free.inject[ModelProtocolTerm[L, ?], F](DecodeModel[L](clsName, needCamelSnakeConversion, params, parents))
-  def renderDTOCompanion(clsName: String, deps: List[L#TermName], encoder: L#Statement, decoder: L#Statement): Free[F, L#ObjectDefinition] =
-    Free.inject[ModelProtocolTerm[L, ?], F](RenderDTOCompanion[L](clsName, deps, encoder, decoder))
+  def renderDTOStaticDefns(clsName: String, deps: List[L#TermName], encoder: L#ValueDefinition, decoder: L#ValueDefinition): Free[F, StaticDefns[L]] =
+    Free.inject[ModelProtocolTerm[L, ?], F](RenderDTOStaticDefns[L](clsName, deps, encoder, decoder))
 }
 object ModelProtocolTerms {
   implicit def modelProtocolTerm[L <: LA, F[_]](implicit I: InjectK[ModelProtocolTerm[L, ?], F]): ModelProtocolTerms[L, F] =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/PolyProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/PolyProtocolTerm.scala
@@ -2,7 +2,7 @@ package com.twilio.guardrail.protocol.terms.protocol
 
 import cats.InjectK
 import cats.free.Free
-import com.twilio.guardrail.SuperClass
+import com.twilio.guardrail.{ StaticDefns, SuperClass }
 import com.twilio.guardrail.languages.LA
 import io.swagger.models.{ Model, RefModel }
 
@@ -16,12 +16,12 @@ case class ExtractSuperClass[L <: LA](swagger: Model, definitions: List[(String,
 case class RenderSealedTrait[L <: LA](className: String, terms: List[L#MethodParameter], discriminator: String, parents: List[SuperClass[L]] = Nil)
     extends PolyProtocolTerm[L, L#Trait]
 
-case class EncodeADT[L <: LA](clsName: String, children: List[String] = Nil) extends PolyProtocolTerm[L, L#Statement]
+case class EncodeADT[L <: LA](clsName: String, children: List[String] = Nil) extends PolyProtocolTerm[L, L#ValueDefinition]
 
-case class DecodeADT[L <: LA](clsName: String, children: List[String] = Nil) extends PolyProtocolTerm[L, L#Statement]
+case class DecodeADT[L <: LA](clsName: String, children: List[String] = Nil) extends PolyProtocolTerm[L, L#ValueDefinition]
 
-case class RenderADTCompanion[L <: LA](clsName: String, discriminator: String, encoder: L#Statement, decoder: L#Statement)
-    extends PolyProtocolTerm[L, L#ObjectDefinition]
+case class RenderADTStaticDefns[L <: LA](clsName: String, discriminator: String, encoder: L#ValueDefinition, decoder: L#ValueDefinition)
+    extends PolyProtocolTerm[L, StaticDefns[L]]
 
 class PolyProtocolTerms[L <: LA, F[_]](implicit I: InjectK[PolyProtocolTerm[L, ?], F]) {
   def extractSuperClass(swagger: Model, definitions: List[(String, Model)]): Free[F, List[(String, Model, List[RefModel])]] =
@@ -34,19 +34,19 @@ class PolyProtocolTerms[L <: LA, F[_]](implicit I: InjectK[PolyProtocolTerm[L, ?
   ): Free[F, L#Trait] =
     Free.inject[PolyProtocolTerm[L, ?], F](RenderSealedTrait(className, terms, discriminator, parents))
 
-  def encodeADT(clsName: String, children: List[String] = Nil): Free[F, L#Statement] =
+  def encodeADT(clsName: String, children: List[String] = Nil): Free[F, L#ValueDefinition] =
     Free.inject[PolyProtocolTerm[L, ?], F](EncodeADT(clsName, children))
 
-  def decodeADT(clsName: String, children: List[String] = Nil): Free[F, L#Statement] =
+  def decodeADT(clsName: String, children: List[String] = Nil): Free[F, L#ValueDefinition] =
     Free.inject[PolyProtocolTerm[L, ?], F](DecodeADT(clsName, children))
 
-  def renderADTCompanion(
+  def renderADTStaticDefns(
       clsName: String,
       discriminator: String,
-      encoder: L#Statement,
-      decoder: L#Statement
-  ): Free[F, L#ObjectDefinition] =
-    Free.inject[PolyProtocolTerm[L, ?], F](RenderADTCompanion(clsName, discriminator, encoder, decoder))
+      encoder: L#ValueDefinition,
+      decoder: L#ValueDefinition
+  ): Free[F, StaticDefns[L]] =
+    Free.inject[PolyProtocolTerm[L, ?], F](RenderADTStaticDefns(clsName, discriminator, encoder, decoder))
 
 }
 

--- a/modules/codegen/src/test/scala/core/issues/Issue105.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue105.scala
@@ -1,25 +1,11 @@
 package tests.core.issues
 
-import _root_.io.swagger.parser.SwaggerParser
-import cats.instances.all._
-import com.twilio.swagger._
 import com.twilio.guardrail.generators.AkkaHttp
-import com.twilio.guardrail.{
-  ClassDefinition,
-  Client,
-  ClientGenerator,
-  Clients,
-  CodegenApplication,
-  Context,
-  ProtocolDefinitions,
-  ProtocolGenerator,
-  RandomType,
-  Target
-}
+import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
+import com.twilio.guardrail.{ ClassDefinition, Context, ProtocolDefinitions }
 import org.scalatest.{ FunSuite, Matchers }
-import support.SwaggerSpecRunner
-
 import scala.meta._
+import support.SwaggerSpecRunner
 
 class Issue105 extends FunSuite with Matchers with SwaggerSpecRunner {
   val swagger: String = s"""
@@ -46,10 +32,11 @@ class Issue105 extends FunSuite with Matchers with SwaggerSpecRunner {
 
   test("Generate plain array alias definition") {
     val (
-      ProtocolDefinitions(ClassDefinition(_, _, cls, cmp, _) :: Nil, _, _, _),
+      ProtocolDefinitions(ClassDefinition(_, _, cls, staticDefns, _) :: Nil, _, _, _),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    )       = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    val cmp = companionForStaticDefns(staticDefns)
 
     val definition = q"""
       case class Foo(nonEmptyString: Option[String Refined NonEmpty] = None, positiveLong: Option[Long Refined Positive] = None)

--- a/modules/codegen/src/test/scala/core/issues/Issue122.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue122.scala
@@ -1,25 +1,11 @@
 package tests.core.issues
 
-import _root_.io.swagger.parser.SwaggerParser
-import cats.instances.all._
-import com.twilio.swagger._
 import com.twilio.guardrail.generators.AkkaHttp
-import com.twilio.guardrail.{
-  ClassDefinition,
-  Client,
-  ClientGenerator,
-  Clients,
-  CodegenApplication,
-  Context,
-  ProtocolDefinitions,
-  ProtocolGenerator,
-  RandomType,
-  Target
-}
+import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
+import com.twilio.guardrail.{ Client, Clients, Context }
 import org.scalatest.{ FunSuite, Matchers }
-import support.SwaggerSpecRunner
-
 import scala.meta._
+import support.SwaggerSpecRunner
 
 class Issue122 extends FunSuite with Matchers with SwaggerSpecRunner {
   val swagger: String = s"""
@@ -60,9 +46,10 @@ class Issue122 extends FunSuite with Matchers with SwaggerSpecRunner {
   test("Ensure clients are able to pass sequences of values for array form parameters") {
     val (
       _,
-      Clients(Client(tags, className, imports, cmp, cls, _) :: _),
+      Clients(Client(tags, className, imports, staticDefns, cls, _) :: _),
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    )       = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    val cmp = companionForStaticDefns(staticDefns)
 
     val client = q"""
       class UsersClient(host: String = "http://localhost:1234")(implicit httpClient: HttpRequest => Future[HttpResponse], ec: ExecutionContext, mat: Materializer) {

--- a/modules/codegen/src/test/scala/core/issues/Issue145.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue145.scala
@@ -2,6 +2,7 @@ package core.issues
 
 import com.twilio.guardrail._
 import com.twilio.guardrail.generators.AkkaHttp
+import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
 import org.scalatest.{ FunSpec, Matchers }
 import support.SwaggerSpecRunner
 
@@ -36,7 +37,7 @@ class Issue145 extends FunSpec with Matchers with SwaggerSpecRunner {
 
     val (
       ProtocolDefinitions(
-        ClassDefinition(namePet, tpePet, clsPet, companionPet, catParents) :: Nil,
+        ClassDefinition(namePet, tpePet, clsPet, staticDefnsPet, catParents) :: Nil,
         _,
         _,
         _
@@ -46,6 +47,7 @@ class Issue145 extends FunSpec with Matchers with SwaggerSpecRunner {
     ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
 
     it("should generate right companion object") {
+      val companionPet = companionForStaticDefns(staticDefnsPet)
       companionPet.toString() shouldBe q"""
         object Pet {
           implicit val encodePet = {

--- a/modules/codegen/src/test/scala/core/issues/Issue43.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue43.scala
@@ -2,6 +2,7 @@ package core.issues
 
 import com.twilio.guardrail._
 import com.twilio.guardrail.generators.AkkaHttp
+import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
 import org.scalatest.{ FunSpec, Matchers }
 import support.SwaggerSpecRunner
 
@@ -80,11 +81,11 @@ class Issue43 extends FunSpec with Matchers with SwaggerSpecRunner {
 
     val (
       ProtocolDefinitions(
-        ClassDefinition(nameCat, tpeCat, clsCat, companionCat, catParents) :: ClassDefinition(nameDog, tpeDog, _, _, _) :: ADT(
+        ClassDefinition(nameCat, tpeCat, clsCat, staticDefnsCat, catParents) :: ClassDefinition(nameDog, tpeDog, _, _, _) :: ADT(
           namePet,
           tpePet,
           trtPet,
-          companion
+          staticDefns
         ) :: Nil,
         _,
         _,
@@ -92,7 +93,9 @@ class Issue43 extends FunSpec with Matchers with SwaggerSpecRunner {
       ),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    )                = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    val companion    = companionForStaticDefns(staticDefns)
+    val companionCat = companionForStaticDefns(staticDefnsCat)
 
     it("should generate right name of pets") {
       nameCat shouldBe "Cat"
@@ -241,16 +244,20 @@ class Issue43 extends FunSpec with Matchers with SwaggerSpecRunner {
 
     val (
       ProtocolDefinitions(
-        ClassDefinition(namePersianCat, tpePersianCat, clsPersianCat, companionPersianCat, persianCatParents)
-          :: ClassDefinition(nameDog, tpeDog, clsDog, companionDog, dogParents)
-          :: ADT(namePet, tpePet, trtPet, companionPet) :: ADT(nameCat, tpeCat, trtCat, companionCat) :: Nil,
+        ClassDefinition(namePersianCat, tpePersianCat, clsPersianCat, staticDefnsPersianCat, persianCatParents)
+          :: ClassDefinition(nameDog, tpeDog, clsDog, staticDefnsDog, dogParents)
+          :: ADT(namePet, tpePet, trtPet, staticDefnsPet) :: ADT(nameCat, tpeCat, trtCat, staticDefnsCat) :: Nil,
         _,
         _,
         _
       ),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    )                       = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    val companionPersianCat = companionForStaticDefns(staticDefnsPersianCat)
+    val companionDog        = companionForStaticDefns(staticDefnsDog)
+    val companionPet        = companionForStaticDefns(staticDefnsPet)
+    val companionCat        = companionForStaticDefns(staticDefnsCat)
 
     it("should generate right name of pets") {
       namePet shouldBe "Pet"
@@ -430,16 +437,18 @@ class Issue43 extends FunSpec with Matchers with SwaggerSpecRunner {
 
     val (
       ProtocolDefinitions(
-        ClassDefinition(nameDog, tpeDog, clsDog, companionDog, dogParents)
-          :: ClassDefinition(namePersianCat, tpePersianCat, clsPersianCat, companionPersianCat, persianCatParents)
-          :: ADT(namePet, tpePet, trtPet, companionPet) :: ADT(nameCat, tpeCat, trtCat, companionCat) :: Nil,
+        ClassDefinition(nameDog, tpeDog, clsDog, staticDefnsDog, dogParents)
+          :: ClassDefinition(namePersianCat, tpePersianCat, clsPersianCat, staticDefnsPersianCat, persianCatParents)
+          :: ADT(namePet, tpePet, trtPet, staticDefnsPet) :: ADT(nameCat, tpeCat, trtCat, staticDefnsCat) :: Nil,
         _,
         _,
         _
       ),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    )                       = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    val companionPersianCat = companionForStaticDefns(staticDefnsPersianCat)
+    val companionCat        = companionForStaticDefns(staticDefnsCat)
 
     it("should generate right case class") {
       clsPersianCat.structure shouldBe q"""case class PersianCat(catBreed: String) extends Cat""".structure
@@ -528,15 +537,18 @@ class Issue43 extends FunSpec with Matchers with SwaggerSpecRunner {
 
     val (
       ProtocolDefinitions(
-        ClassDefinition(nameCat, tpeCat, clsCat, companionCat, catParents)
-          :: ADT(namePet, tpePet, trtPet, companionPet) :: ADT(nameMammal, tpeMammal, trtMammal, companionMammal) :: Nil,
+        ClassDefinition(nameCat, tpeCat, clsCat, staticDefnsCat, catParents)
+          :: ADT(namePet, tpePet, trtPet, staticDefnsPet) :: ADT(nameMammal, tpeMammal, trtMammal, staticDefnsMammal) :: Nil,
         _,
         _,
         _
       ),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    )                   = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    val companionCat    = companionForStaticDefns(staticDefnsCat)
+    val companionPet    = companionForStaticDefns(staticDefnsPet)
+    val companionMammal = companionForStaticDefns(staticDefnsMammal)
 
     it("should generate right case class") {
       clsCat.structure shouldBe q"""case class Cat(wool: Boolean, catBreed: String) extends Pet with Mammal""".structure

--- a/modules/codegen/src/test/scala/swagger/protocols/BigObjectSpec.scala
+++ b/modules/codegen/src/test/scala/swagger/protocols/BigObjectSpec.scala
@@ -2,6 +2,7 @@ package swagger
 package protocols
 
 import com.twilio.guardrail.generators.AkkaHttp
+import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
 import com.twilio.guardrail.{ ClassDefinition, Context, ProtocolDefinitions }
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
@@ -115,8 +116,9 @@ class BigObjectSpec extends FunSuite with Matchers with SwaggerSpecRunner {
     |""".stripMargin
 
   test("Big objects can be generated") {
-    val (ProtocolDefinitions(ClassDefinition(_, _, cls, cmp, _) :: Nil, _, _, _), _, _) =
+    val (ProtocolDefinitions(ClassDefinition(_, _, cls, staticDefns, _) :: Nil, _, _, _), _, _) =
       runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    val cmp = companionForStaticDefns(staticDefns)
 
     val definition = q"""
       case class BigObject(v1: Option[Int] = None, v2: Option[Int] = None, v3: Option[Int] = None, v4: Option[Int] = None, v5: Option[Int] = None, v6: Option[Int] = None, v7: Option[Int] = None, v8: Option[Int] = None, v9: Option[Int] = None, v10: Option[Int] = None, v11: Option[Int] = None, v12: Option[Int] = None, v13: Option[Int] = None, v14: Option[Int] = None, v15: Option[Int] = None, v16: Option[Int] = None, v17: Option[Int] = None, v18: Option[Int] = None, v19: Option[Int] = None, v20: Option[Int] = None, v21: Option[Int] = None, v22: Option[Int] = None, v23: Option[Int] = None, v24: Option[Int] = None, v25: Option[Int] = None, v26: Option[Int] = None, v27: Option[Int] = None, v28: Option[Int] = None, v29: Option[Int] = None, v30: Option[Int] = None)

--- a/modules/codegen/src/test/scala/tests/core/BacktickTest.scala
+++ b/modules/codegen/src/test/scala/tests/core/BacktickTest.scala
@@ -2,6 +2,7 @@ package tests.core
 
 import com.twilio.guardrail._
 import com.twilio.guardrail.generators.AkkaHttp
+import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
@@ -67,9 +68,10 @@ class BacktickTest extends FunSuite with Matchers with SwaggerSpecRunner {
   test("Ensure paths are generated with escapes") {
     val (
       _,
-      Clients(Client(tags, className, imports, cmp, cls, _) :: _),
+      Clients(Client(tags, className, imports, staticDefns, cls, _) :: _),
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    )       = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    val cmp = companionForStaticDefns(staticDefns)
 
     tags should equal(Seq("dashy-package"))
 
@@ -125,10 +127,11 @@ class BacktickTest extends FunSuite with Matchers with SwaggerSpecRunner {
 
   test("Ensure dtos are generated with escapes") {
     val (
-      ProtocolDefinitions(ClassDefinition(_, _, cls, cmp, _) :: _, _, _, _),
+      ProtocolDefinitions(ClassDefinition(_, _, cls, staticDefns, _) :: _, _, _, _),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    )       = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    val cmp = companionForStaticDefns(staticDefns)
 
     val definition = q"""
     case class `dashy-class`(`dashy-param`: Option[Long] = None)
@@ -160,10 +163,11 @@ class BacktickTest extends FunSuite with Matchers with SwaggerSpecRunner {
 
   test("Ensure enums are generated with escapes") {
     val (
-      ProtocolDefinitions(_ :: EnumDefinition(_, _, _, cls, cmp) :: _, _, _, _),
+      ProtocolDefinitions(_ :: EnumDefinition(_, _, _, cls, staticDefns) :: _, _, _, _),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    )       = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    val cmp = companionForStaticDefns(staticDefns)
 
     val definition = q"""
     sealed abstract class `dashy-enum`(val value: String) {
@@ -181,11 +185,11 @@ class BacktickTest extends FunSuite with Matchers with SwaggerSpecRunner {
       val DashyValueB: `dashy-enum` = members.DashyValueB
       val DashyValueC: `dashy-enum` = members.DashyValueC
       val values = Vector(DashyValueA, DashyValueB, DashyValueC)
-      def parse(value: String): Option[`dashy-enum`] = values.find(_.value == value)
       implicit val `encodedashy-enum`: Encoder[`dashy-enum`] = Encoder[String].contramap(_.value)
       implicit val `decodedashy-enum`: Decoder[`dashy-enum`] = Decoder[String].emap(value => parse(value).toRight(s"$$value not a member of dashy-enum"))
       implicit val `addPathdashy-enum`: AddPath[`dashy-enum`] = AddPath.build(_.value)
       implicit val `showdashy-enum`: Show[`dashy-enum`] = Show.build(_.value)
+      def parse(value: String): Option[`dashy-enum`] = values.find(_.value == value)
     }
     """
 

--- a/modules/codegen/src/test/scala/tests/core/DereferencingAliasesSpec.scala
+++ b/modules/codegen/src/test/scala/tests/core/DereferencingAliasesSpec.scala
@@ -2,10 +2,10 @@ package tests.core
 
 import com.twilio.guardrail._
 import com.twilio.guardrail.generators.AkkaHttp
+import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
 import org.scalatest.{ FunSuite, Matchers }
-import support.SwaggerSpecRunner
-
 import scala.meta._
+import support.SwaggerSpecRunner
 
 class DereferencingAliasesSpec extends FunSuite with Matchers with SwaggerSpecRunner {
 
@@ -62,10 +62,12 @@ class DereferencingAliasesSpec extends FunSuite with Matchers with SwaggerSpecRu
 
   test("All types should be dereferenced") {
     val (
-      ProtocolDefinitions(_ :: _ :: _ :: ClassDefinition(_, _, cls, cmp, _) :: _, _, _, _),
-      Clients(Client(_, _, _, clientCmp, clientCls, _) :: _),
+      ProtocolDefinitions(_ :: _ :: _ :: ClassDefinition(_, _, cls, staticDefns, _) :: _, _, _, _),
+      Clients(Client(_, clientName, _, clientStaticDefns, clientCls, _) :: _),
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    )             = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    val cmp       = companionForStaticDefns(staticDefns)
+    val clientCmp = companionForStaticDefns(clientStaticDefns)
 
     val definition = q"""
       case class propRef(param: Option[Long] = None, array: Option[IndexedSeq[Long]] = None, arrayArray: Option[IndexedSeq[IndexedSeq[Long]]] = None)

--- a/modules/codegen/src/test/scala/tests/core/PathParserSpec.scala
+++ b/modules/codegen/src/test/scala/tests/core/PathParserSpec.scala
@@ -1,7 +1,7 @@
 package tests.core
 
 import com.twilio.guardrail.generators.ScalaParameter
-import com.twilio.guardrail.generators.syntax.scala._
+import com.twilio.guardrail.generators.syntax.Scala._
 import com.twilio.guardrail.{ SwaggerUtil, Target }
 import org.scalatest.{ EitherValues, FunSuite, Matchers, OptionValues }
 import support.ScalaMetaMatchers._

--- a/modules/codegen/src/test/scala/tests/core/ScalaTypesTest.scala
+++ b/modules/codegen/src/test/scala/tests/core/ScalaTypesTest.scala
@@ -1,6 +1,7 @@
 package tests.core
 
 import com.twilio.guardrail.generators.AkkaHttp
+import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
 import com.twilio.guardrail.{ ClassDefinition, Context, ProtocolDefinitions }
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
@@ -26,10 +27,11 @@ class ScalaTypesTest extends FunSuite with Matchers with SwaggerSpecRunner {
 
   test("Generate no definitions") {
     val (
-      ProtocolDefinitions(ClassDefinition(_, _, cls, cmp, _) :: Nil, _, _, _),
+      ProtocolDefinitions(ClassDefinition(_, _, cls, staticDefns, _) :: Nil, _, _, _),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    )       = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    val cmp = companionForStaticDefns(staticDefns)
 
     val definition = q"""
       case class Baz(foo: Option[com.twilio.foo.bar.Baz] = None)

--- a/modules/codegen/src/test/scala/tests/core/TypesTest.scala
+++ b/modules/codegen/src/test/scala/tests/core/TypesTest.scala
@@ -1,11 +1,11 @@
 package tests.core
 
 import com.twilio.guardrail.generators.AkkaHttp
+import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
 import com.twilio.guardrail.{ ClassDefinition, Context, ProtocolDefinitions }
 import org.scalatest.{ FunSuite, Matchers }
-import support.SwaggerSpecRunner
-
 import scala.meta._
+import support.SwaggerSpecRunner
 
 class TypesTest extends FunSuite with Matchers with SwaggerSpecRunner {
 
@@ -67,10 +67,11 @@ class TypesTest extends FunSuite with Matchers with SwaggerSpecRunner {
 
   test("Generate no definitions") {
     val (
-      ProtocolDefinitions(ClassDefinition(_, _, cls, cmp, _) :: Nil, _, _, _),
+      ProtocolDefinitions(ClassDefinition(_, _, cls, staticDefns, _) :: Nil, _, _, _),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    )       = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    val cmp = companionForStaticDefns(staticDefns)
 
     val definition = q"""
       case class Types(

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/AkkaHttpClientGeneratorTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/AkkaHttpClientGeneratorTest.scala
@@ -1,6 +1,7 @@
 package tests.generators.akkaHttp
 
 import com.twilio.guardrail.generators.AkkaHttp
+import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
 import com.twilio.guardrail.{ Client, Clients, Context }
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
@@ -111,9 +112,10 @@ class AkkaHttpClientGeneratorTest extends FunSuite with Matchers with SwaggerSpe
   test("Ensure responses are generated") {
     val (
       _,
-      Clients(Client(tags, className, _, cmp, cls, _) :: Nil),
+      Clients(Client(tags, className, _, staticDefns, cls, _) :: Nil),
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    )       = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    val cmp = companionForStaticDefns(staticDefns)
 
     tags should equal(Seq("store"))
 
@@ -165,9 +167,10 @@ class AkkaHttpClientGeneratorTest extends FunSuite with Matchers with SwaggerSpe
   test("Ensure traced responses are generated") {
     val (
       _,
-      Clients(List(Client(tags, className, _, cmp, cls, _))),
+      Clients(List(Client(tags, className, _, staticDefns, cls, _))),
       _
-    ) = runSwaggerSpec(swagger)(Context.empty.copy(framework = Some("akka-http"), tracing = true), AkkaHttp)
+    )       = runSwaggerSpec(swagger)(Context.empty.copy(framework = Some("akka-http"), tracing = true), AkkaHttp)
+    val cmp = companionForStaticDefns(staticDefns)
 
     tags should equal(Seq("store"))
 

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/DefinitionSpec.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/DefinitionSpec.scala
@@ -1,6 +1,7 @@
 package tests.generators.akkaHttp
 
 import com.twilio.guardrail.generators.AkkaHttp
+import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
 import com.twilio.guardrail.{ ClassDefinition, Context, EnumDefinition, ProtocolDefinitions }
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
@@ -68,10 +69,11 @@ class DefinitionSpec extends FunSuite with Matchers with SwaggerSpecRunner {
 
   test("Plain objects should be generated") {
     val (
-      ProtocolDefinitions(ClassDefinition(_, _, cls, cmp, _) :: _, _, _, _),
+      ProtocolDefinitions(ClassDefinition(_, _, cls, staticDefns, _) :: _, _, _, _),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    )       = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    val cmp = companionForStaticDefns(staticDefns)
 
     val definition = q"""
       case class First(a: Option[Int] = None)
@@ -92,10 +94,11 @@ class DefinitionSpec extends FunSuite with Matchers with SwaggerSpecRunner {
 
   test("Enumerations should be generated") {
     val (
-      ProtocolDefinitions(_ :: _ :: EnumDefinition(_, _, _, cls, cmp) :: _, _, _, _),
+      ProtocolDefinitions(_ :: _ :: EnumDefinition(_, _, _, cls, staticDefns) :: _, _, _, _),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    )       = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    val cmp = companionForStaticDefns(staticDefns)
 
     val definition = q"""
     sealed abstract class Third(val value: String) {
@@ -113,12 +116,13 @@ class DefinitionSpec extends FunSuite with Matchers with SwaggerSpecRunner {
       val V2: Third = members.V2
       val ILikeSpaces: Third = members.ILikeSpaces
       val values = Vector(V1, V2, ILikeSpaces)
-      def parse(value: String): Option[Third] = values.find(_.value == value)
 
       implicit val encodeThird: Encoder[Third] = Encoder[String].contramap(_.value)
       implicit val decodeThird: Decoder[Third] = Decoder[String].emap(value => parse(value).toRight(s"$${value} not a member of Third"))
       implicit val addPathThird: AddPath[Third] = AddPath.build(_.value)
       implicit val showThird: Show[Third] = Show.build(_.value)
+
+      def parse(value: String): Option[Third] = values.find(_.value == value)
     }
     """
 
@@ -128,10 +132,11 @@ class DefinitionSpec extends FunSuite with Matchers with SwaggerSpecRunner {
 
   test("Camel case conversion should happen") {
     val (
-      ProtocolDefinitions(_ :: _ :: _ :: _ :: ClassDefinition(_, _, cls, cmp, _) :: _, _, _, _),
+      ProtocolDefinitions(_ :: _ :: _ :: _ :: ClassDefinition(_, _, cls, staticDefns, _) :: _, _, _, _),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    )       = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    val cmp = companionForStaticDefns(staticDefns)
 
     val definition = q"""
       case class Fifth(aBCD: Option[Int] = None, bCDE: Option[Int] = None)
@@ -152,10 +157,11 @@ class DefinitionSpec extends FunSuite with Matchers with SwaggerSpecRunner {
 
   test("Defaults should work") {
     val (
-      ProtocolDefinitions(_ :: _ :: _ :: _ :: _ :: ClassDefinition(_, _, cls, cmp, _) :: _, _, _, _),
+      ProtocolDefinitions(_ :: _ :: _ :: _ :: _ :: ClassDefinition(_, _, cls, staticDefns, _) :: _, _, _, _),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    )       = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    val cmp = companionForStaticDefns(staticDefns)
 
     val definition = q"""
       case class Sixth(defval: Int = 1, defvalOpt: Option[Long] = Option(2L))

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/PropertyExtractors.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/PropertyExtractors.scala
@@ -1,6 +1,7 @@
 package tests.generators.akkaHttp
 
 import com.twilio.guardrail.generators.AkkaHttp
+import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
 import com.twilio.guardrail.{ ClassDefinition, Context, ProtocolDefinitions }
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
@@ -63,10 +64,11 @@ class PropertyExtractors extends FunSuite with Matchers with SwaggerSpecRunner {
 
   test("Render all primitive types correctly") {
     val (
-      ProtocolDefinitions(ClassDefinition(_, _, cls, cmp, _) :: _, _, _, _),
+      ProtocolDefinitions(ClassDefinition(_, _, cls, staticDefns, _) :: _, _, _, _),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    )       = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    val cmp = companionForStaticDefns(staticDefns)
 
     val definition = q"""
       case class Something(

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/AkkaHttpClientTracingTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/AkkaHttpClientTracingTest.scala
@@ -89,7 +89,7 @@ class AkkaHttpClientTracingTest extends FunSuite with Matchers with SwaggerSpecR
 
     val (
       _,
-      Clients(Client(tags, className, _, cmp, cls, _) :: _),
+      Clients(Client(tags, className, _, _, cls, _) :: _),
       _
     ) = runSwaggerSpec(swagger)(Context.empty.copy(tracing = true), AkkaHttp)
 

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/BasicTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/BasicTest.scala
@@ -1,10 +1,11 @@
 package tests.generators.akkaHttp.client
 
-import com.twilio.guardrail.generators.AkkaHttp
 import com.twilio.guardrail._
+import com.twilio.guardrail.generators.AkkaHttp
+import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
 import org.scalatest.{ FunSuite, Matchers }
-import support.SwaggerSpecRunner
 import scala.meta._
+import support.SwaggerSpecRunner
 
 class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
   val swagger: String = s"""
@@ -79,10 +80,11 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
 
   test("Handle json subvalues") {
     val (
-      ProtocolDefinitions(_ :: ClassDefinition(_, _, cls, cmp, _) :: _, _, _, _),
+      ProtocolDefinitions(_ :: ClassDefinition(_, _, cls, staticDefns, _) :: _, _, _, _),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    )       = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    val cmp = companionForStaticDefns(staticDefns)
 
     val definition = q"""
       case class Blix(map: io.circe.Json)
@@ -105,7 +107,7 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
   test("Properly handle all methods") {
     val (
       _,
-      Clients(Client(tags, className, _, cmp, cls, _) :: _),
+      Clients(Client(tags, className, _, _, cls, _) :: _),
       _
     ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
 

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/DefaultParametersTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/DefaultParametersTest.scala
@@ -1,6 +1,7 @@
 package tests.generators.akkaHttp.client
 
 import com.twilio.guardrail.generators.AkkaHttp
+import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
 import com.twilio.guardrail.{ Client, Clients, Context }
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
@@ -122,9 +123,10 @@ class DefaultParametersTest extends FunSuite with Matchers with SwaggerSpecRunne
   test("Ensure responses are generated") {
     val (
       _,
-      Clients(Client(tags, className, _, cmp, cls, _) :: _),
+      Clients(Client(tags, className, _, staticDefns, cls, _) :: _),
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    )       = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    val cmp = companionForStaticDefns(staticDefns)
 
     tags should equal(Seq("store"))
 

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/FormFieldsTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/FormFieldsTest.scala
@@ -43,7 +43,7 @@ class FormFieldsTest extends FunSuite with Matchers with SwaggerSpecRunner {
   test("Properly handle all methods") {
     val (
       _,
-      Clients(Client(tags, className, _, cmp, cls, _) :: _),
+      Clients(Client(tags, className, _, _, cls, _) :: _),
       _
     ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
 

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/HardcodedQSSpec.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/HardcodedQSSpec.scala
@@ -47,7 +47,7 @@ class HardcodedQSSpec extends FunSuite with Matchers with SwaggerSpecRunner {
   test("Test all cases") {
     val (
       _,
-      Clients(Client(tags, className, _, cmp, cls, _) :: _),
+      Clients(Client(tags, className, _, _, cls, _) :: _),
       _
     ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
 

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/HttpBodiesTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/HttpBodiesTest.scala
@@ -85,7 +85,7 @@ class HttpBodiesTest extends FunSuite with Matchers with SwaggerSpecRunner {
   test("Properly handle all methods") {
     val (
       _,
-      Clients(Client(tags, className, _, cmp, cls, _) :: _),
+      Clients(Client(tags, className, _, _, cls, _) :: _),
       _
     ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
 

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/ParamConflictsTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/ParamConflictsTest.scala
@@ -2,6 +2,7 @@ package tests.generators.akkaHttp.client
 
 import com.twilio.guardrail._
 import com.twilio.guardrail.generators.AkkaHttp
+import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 import scala.meta._
@@ -43,7 +44,7 @@ class ParamConflictsTest extends FunSuite with Matchers with SwaggerSpecRunner {
   test("Generate non-conflicting names in clients") {
     val (
       _,
-      Clients(Client(tags, className, _, cmp, cls, _) :: _),
+      Clients(Client(tags, className, _, _, cls, _) :: _),
       _
     ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
 
@@ -80,10 +81,11 @@ class ParamConflictsTest extends FunSuite with Matchers with SwaggerSpecRunner {
 
   test("Generate non-conflicting names in definitions") {
     val (
-      ProtocolDefinitions(ClassDefinition(_, _, cls, cmp, _) :: _, _, _, _),
+      ProtocolDefinitions(ClassDefinition(_, _, cls, staticDefns, _) :: _, _, _, _),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    )       = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    val cmp = companionForStaticDefns(staticDefns)
 
     val definition = q"""
       case class Foo(conflicting_name: Option[String] = None, ConflictingName: Option[String] = None)

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/SchemeTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/SchemeTest.scala
@@ -1,6 +1,7 @@
 package tests.generators.akkaHttp.client
 
 import com.twilio.guardrail.generators.AkkaHttp
+import com.twilio.guardrail.generators.syntax.Scala._
 import com.twilio.guardrail.{ Client, Clients, Context }
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
@@ -34,8 +35,9 @@ class SchemeTest extends FunSuite with Matchers with SwaggerSpecRunner {
     |""".stripMargin
 
   test("Use first scheme") {
-    val (_, Clients(Client(_, _, _, cmp, cls, _) :: _), _) =
+    val (_, Clients(Client(_, clientName, _, staticDefns, cls, _) :: _), _) =
       runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    val cmp = companionForStaticDefns(staticDefns)
 
     val companion = q"""
     object Client {

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/contentType/TextPlainTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/contentType/TextPlainTest.scala
@@ -1,6 +1,7 @@
 package tests.generators.akkaHttp.client.contentType
 
 import com.twilio.guardrail.generators.AkkaHttp
+import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
 import com.twilio.guardrail.{ Client, Clients, Context }
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
@@ -35,9 +36,10 @@ class TextPlainTest extends FunSuite with Matchers with SwaggerSpecRunner {
   test("Properly handle all methods") {
     val (
       _,
-      Clients(Client(tags, className, _, cmp, cls, _) :: _),
+      Clients(Client(tags, className, _, staticDefns, cls, _) :: _),
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    )       = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    val cmp = companionForStaticDefns(staticDefns)
 
     val companion = q"""
       object Client {

--- a/modules/codegen/src/test/scala/tests/generators/http4s/BasicTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/http4s/BasicTest.scala
@@ -2,6 +2,7 @@ package tests.generators.http4s
 
 import com.twilio.guardrail._
 import com.twilio.guardrail.generators.Http4s
+import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 import scala.meta._
@@ -79,10 +80,11 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
 
   test("Handle json subvalues") {
     val (
-      ProtocolDefinitions(_ :: ClassDefinition(_, _, cls, cmp, _) :: _, _, _, _),
+      ProtocolDefinitions(_ :: ClassDefinition(_, _, cls, staticDefns, _) :: _, _, _, _),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, Http4s)
+    )       = runSwaggerSpec(swagger)(Context.empty, Http4s)
+    val cmp = companionForStaticDefns(staticDefns)
 
     val definition = q"""
       case class Blix(map: io.circe.Json)
@@ -105,10 +107,11 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
   test("Properly handle all methods") {
     val (
       _,
-      Clients(Client(tags, className, _, cls, cmp, statements) :: _),
+      Clients(Client(tags, className, _, staticDefns, cls, statements) :: _),
       _
     )          = runSwaggerSpec(swagger)(Context.empty, Http4s)
-    val actual = cls +: cmp +: statements
+    val cmp    = companionForStaticDefns(staticDefns)
+    val actual = cmp +: cls +: statements
 
     val expected = List(
       q"""object Client {

--- a/modules/codegen/src/test/scala/tests/generators/http4s/client/DefaultParametersTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/http4s/client/DefaultParametersTest.scala
@@ -1,6 +1,7 @@
 package tests.generators.http4s.client
 
 import com.twilio.guardrail.generators.Http4s
+import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
 import com.twilio.guardrail.{ Client, Clients, Context }
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
@@ -122,13 +123,13 @@ class DefaultParametersTest extends FunSuite with Matchers with SwaggerSpecRunne
   test("Ensure responses are generated") {
     val (
       _,
-      Clients(Client(tags, className, _, cls, cmp, statements) :: _),
+      Clients(Client(tags, className, _, staticDefns, cls, statements) :: _),
       _
     ) = runSwaggerSpec(swagger)(Context.empty, Http4s)
 
     tags should equal(Seq("store"))
-
-    val actual = cls +: cmp +: statements
+    val cmp    = companionForStaticDefns(staticDefns)
+    val actual = cmp +: cls +: statements
 
     val expected = List(
       q"""object StoreClient {


### PR DESCRIPTION
Companion objects are a feature somewhat unique to Scala, so we need to abstract them out.  The per-language generators can do what they need to do from there.  For example, the Java generator will turn them into `static` declarations on the associated class (if any).