### PR TITLE
Making akka-http FormData return 413 instead of 500, delete failed files

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,6 +69,7 @@ fullRunTask(
   --server --specPath modules/sample/src/main/resources/formData.yaml --outputPath modules/sample/src/main/scala --packageName form.server.http4s --framework http4s
   --server --specPath modules/sample/src/main/resources/formData.yaml --outputPath modules/sample/src/main/scala --packageName form.server.akkaHttp --framework akka-http
   --server --specPath modules/sample/src/main/resources/issues/issue127.yaml --outputPath modules/sample/src/main/scala --packageName issues.issue127
+  --server --specPath modules/sample/src/main/resources/issues/issue143.yaml --outputPath modules/sample/src/main/scala --packageName issues.issue143
   --client --specPath modules/sample/src/main/resources/issues/issue148.yaml --outputPath modules/sample/src/main/scala --packageName issues.issue148.client.http4s --framework http4s
   --client --specPath modules/sample/src/main/resources/issues/issue148.yaml --outputPath modules/sample/src/main/scala --packageName issues.issue148.client.akkaHttp --framework akka-http
   --server --specPath modules/sample/src/main/resources/issues/issue148.yaml --outputPath modules/sample/src/main/scala --packageName issues.issue148.server.http4s --framework http4s

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
@@ -443,6 +443,7 @@ object AkkaHttpServerGenerator {
                     val hash = messageDigest.map(md => javax.xml.bind.DatatypeConverter.printHexBinary(md.digest()).toLowerCase(java.util.Locale.US))
                     (dest, part.filename, part.entity.contentType, hash)
                   case IOResult(_, Failure(t)) =>
+                    dest.delete()
                     throw t
                 }, { case t =>
                   dest.delete()

--- a/modules/codegen/src/test/scala/core/issues/Issue127.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue127.scala
@@ -89,11 +89,25 @@ class Issue127 extends FunSuite with Matchers with SwaggerSpecRunner {
             extractExecutionContext.flatMap { implicit executionContext =>
               extractMaterializer.flatMap { implicit mat =>
                 val fileReferences = new AtomicReference(List.empty[File])
-                (handleExceptions(ExceptionHandler({
-                  case e: Throwable =>
-                    fileReferences.get().foreach(_.delete())
-                    throw e
-                })) & handleRejections { (rejections: scala.collection.immutable.Seq[Rejection]) =>
+                (extractSettings.flatMap {
+                  settings => handleExceptions(ExceptionHandler({
+                    case EntityStreamSizeException(limit, contentLength) =>
+                      fileReferences.get().foreach(_.delete())
+                      val summary = contentLength match {
+                        case Some(cl) =>
+                          s"Request Content-Length of $$cl bytes exceeds the configured limit of $$limit bytes"
+                        case None =>
+                          s"Aggregated data length of request entity exceeds the configured limit of $$limit bytes"
+                      }
+                      val info = new ErrorInfo(summary, "Consider increasing the value of akka.http.server.parsing.max-content-length")
+                      val status = StatusCodes.RequestEntityTooLarge
+                      val msg = if (settings.verboseErrorMessages) info.formatPretty else info.summary
+                      complete(HttpResponse(status, entity = msg))
+                    case e: Throwable =>
+                      fileReferences.get().foreach(_.delete())
+                      throw e
+                  }))
+                } & handleRejections { (rejections: scala.collection.immutable.Seq[Rejection]) =>
                   fileReferences.get().foreach(_.delete())
                   None
                 } & mapResponse { resp =>

--- a/modules/codegen/src/test/scala/core/issues/Issue127.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue127.scala
@@ -57,6 +57,7 @@ class Issue127 extends FunSuite with Matchers with SwaggerSpecRunner {
                 val hash = messageDigest.map(md => javax.xml.bind.DatatypeConverter.printHexBinary(md.digest()).toLowerCase(java.util.Locale.US))
                 (dest, part.filename, part.entity.contentType, hash)
               case IOResult(_, Failure(t)) =>
+                dest.delete()
                 throw t
             }, {
               case t =>
@@ -87,8 +88,18 @@ class Issue127 extends FunSuite with Matchers with SwaggerSpecRunner {
             })
             extractExecutionContext.flatMap { implicit executionContext =>
               extractMaterializer.flatMap { implicit mat =>
-                entity(as[Multipart.FormData]).flatMap { formData =>
-                  val fileReferences = new AtomicReference(List.empty[File])
+                val fileReferences = new AtomicReference(List.empty[File])
+                (handleExceptions(ExceptionHandler({
+                  case e: Throwable =>
+                    fileReferences.get().foreach(_.delete())
+                    throw e
+                })) & handleRejections { (rejections: scala.collection.immutable.Seq[Rejection]) =>
+                  fileReferences.get().foreach(_.delete())
+                  None
+                } & mapResponse { resp =>
+                  fileReferences.get().foreach(_.delete())
+                  resp
+                } & entity(as[Multipart.FormData])).flatMap { formData =>
                   val collectedPartsF: Future[Either[Throwable, Tuple1[Option[(File, Option[String], ContentType)]]]] = for (results <- formData.parts.mapConcat {
                     part => if (Set[String]("file").contains(part.name)) part :: Nil else {
                       part.entity.discardBytes()
@@ -112,17 +123,7 @@ class Issue127 extends FunSuite with Matchers with SwaggerSpecRunner {
                       Tuple1(fileO)
                     }
                   }
-                  handleExceptions(ExceptionHandler({
-                    case e: Throwable =>
-                      fileReferences.get().foreach(_.delete())
-                      throw e
-                  })) & handleRejections { (rejections: scala.collection.immutable.Seq[Rejection]) =>
-                    fileReferences.get().foreach(_.delete())
-                    None
-                  } & mapResponse { resp =>
-                    fileReferences.get().foreach(_.delete())
-                    resp
-                  } & onSuccess(collectedPartsF)
+                  onSuccess(collectedPartsF)
                 }
               }
             }.flatMap(_.fold(t => throw t, {

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
@@ -113,11 +113,25 @@ class FormFieldsServerTest extends FunSuite with Matchers with SwaggerSpecRunner
             extractExecutionContext.flatMap { implicit executionContext =>
               extractMaterializer.flatMap { implicit mat =>
                 val fileReferences = new AtomicReference(List.empty[File])
-                (handleExceptions(ExceptionHandler({
-                  case e: Throwable =>
-                    fileReferences.get().foreach(_.delete())
-                    throw e
-                })) & handleRejections { (rejections: scala.collection.immutable.Seq[Rejection]) =>
+                (extractSettings.flatMap {
+                  settings => handleExceptions(ExceptionHandler({
+                    case EntityStreamSizeException(limit, contentLength) =>
+                      fileReferences.get().foreach(_.delete())
+                      val summary = contentLength match {
+                        case Some(cl) =>
+                          s"Request Content-Length of $$cl bytes exceeds the configured limit of $$limit bytes"
+                        case None =>
+                          s"Aggregated data length of request entity exceeds the configured limit of $$limit bytes"
+                      }
+                      val info = new ErrorInfo(summary, "Consider increasing the value of akka.http.server.parsing.max-content-length")
+                      val status = StatusCodes.RequestEntityTooLarge
+                      val msg = if (settings.verboseErrorMessages) info.formatPretty else info.summary
+                      complete(HttpResponse(status, entity = msg))
+                    case e: Throwable =>
+                      fileReferences.get().foreach(_.delete())
+                      throw e
+                  }))
+                } & handleRejections { (rejections: scala.collection.immutable.Seq[Rejection]) =>
                   fileReferences.get().foreach(_.delete())
                   None
                 } & mapResponse { resp =>

--- a/modules/sample/src/main/resources/issues/issue143.yaml
+++ b/modules/sample/src/main/resources/issues/issue143.yaml
@@ -1,0 +1,19 @@
+swagger: '2.0'
+host: localhost:1234
+schemes:
+- http
+paths:
+  /file:
+    post:
+      operationId: uploadFile
+      parameters:
+      - name: file
+        description: File to upload
+        in: formData
+        type: file
+        required: true
+      consumes:
+      - multipart/form-data
+      responses:
+        '201':
+          description: Success

--- a/modules/sample/src/test/scala/core/issues/Issue143.scala
+++ b/modules/sample/src/test/scala/core/issues/Issue143.scala
@@ -1,0 +1,48 @@
+package core.issues
+
+import _root_.issues.issue143.{ Handler, Resource }
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.server._
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.stream.scaladsl.Source
+import cats.implicits._
+import java.io.File
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{ EitherValues, FunSuite, Matchers }
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class Issue143 extends FunSuite with Matchers with EitherValues with ScalaFutures with ScalatestRouteTest {
+  override def testConfigSource =
+    s"""
+      |akka.loglevel = OFF
+    """.stripMargin
+
+  test("Ensure that failed uploads are cleaned up afterwards") {
+    val tempDest = File.createTempFile("guardrail.", ".dat")
+    val route = Resource.routes(new Handler {
+      def uploadFile(respond: Resource.uploadFileResponse.type)(file: (File, Option[String], akka.http.scaladsl.model.ContentType)): Future[Resource.uploadFileResponse] =
+        Future.successful(respond.Created)
+      def uploadFileMapFileField(fieldName: String,fileName: Option[String],contentType: akka.http.scaladsl.model.ContentType): java.io.File =
+        tempDest
+    })
+
+    val chunks = 1000
+    val data = "foo"
+    val contentLength = chunks * data.length
+    val req = Post("/file").withEntity(Multipart.FormData(
+        Multipart.FormData.BodyPart("file",
+          HttpEntity(
+            ContentTypes.`text/plain(UTF-8)`,
+            contentLength,
+            Source.fromIterator(() => List.fill(chunks)(akka.util.ByteString.fromString(data)).toIterator)
+          )
+        )
+      ).toEntity.withSizeLimit(1001))
+
+    req ~> route ~> check {
+      status should equal(StatusCodes.RequestEntityTooLarge)
+      tempDest.exists() should equal(false)
+    }
+  }
+}


### PR DESCRIPTION
Resolves #143 

This moves the exception handler up before the route -- the exception handler was previously not used due to being in the wrong place.

Additionally, calling `dest.delete()` _immediately_ upon any exception, to avoid the condition where an exception happens inside `UnmarshalToFile`, preventing the file handle from being added to the `AtomicReference[List[File]]`s to clean up.