### PR TITLE
Restructuring compatibility matrix

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,9 +1,33 @@
-Library compatibility matrix
+# Library compatibility matrix
 
-Language | Library   | Guardrail range  | Version range   | Notes
--------- | --------- | ---------------- | --------------- | -----
-Scala    | akka-http | 0.26.0 -> latest | 10.0.5          |
-Scala    | http4s    | 0.34.0 -> 0.41.0 | 0.18.5          | Unfortunately a backwards<br />incompatbile http4s change<br />was released as<br />a bugfix version
-Scala    | http4s    | 0.41.1 -> latest | 0.19.0          |
-Scala    | circe     | 0.26.0 -> latest | 0.7.0 -> 0.10.1 |
-Scala    | cats      | 0.26.0 -> latest | 0.9.0 -> 1.4.0  |
+The following tables are intended to be rough guidelines on which library
+versions are generally expected to have a fair degree of support for
+different guardrail features.
+
+Only direct dependencies are listed.
+
+## Scala
+
+### akka-http
+
+akka-http has no direct dependencies on circe or cats, which is why the versions are unrelated.
+
+Guardrail version | akka-http | akka-stream | circe  | cats  | Notes
+----------------- | --------- | ----------- | ------ | ----- | -----
+0.34.0 ⚠          | 10.0.2    |             | 0.6.0  | 0.8.1 | Some syntax incompatibilities
+ "                |  "        |             | 0.7.0  | 0.9.0 |
+ "                |  "        |             | 0.8.0  | 0.9.0 |
+ "                |  "        |             | 0.9.0  | 1.0.1 |
+ "                |  "        |             | 0.10.0 | 1.4.0 |
+ "                |  "        |             | 0.11.0 | 1.5.0 |
+ "                | 10.0.15   |             |  "     |  "    |
+ "                | 10.1.0    | 2.3.5       |  "     |  "    |
+ "                | 10.1.7    | 2.5.19      |  "     |  "    |
+
+### http4s
+
+Guardrail version | http4s | circe-core | cats  | Notes
+----------------- | ------ | ---------- | ----- | -----
+0.34.0 ⚠          | 0.18.0 | 0.9.0      | 1.0.1 | Only clients are supported
+0.39.0            | 0.18.0 |  "         |  "    | First server release
+0.41.1            | 0.19.0 | 0.10.0     | 1.4.0 |

--- a/docs/book.md
+++ b/docs/book.md
@@ -69,6 +69,12 @@ If compiling with Scala < 2.13.x, you'll need to enable `-Ypartial-unification`:
 scalacOptions += "-Ypartial-unification"
 ```
 
+If compiling with Scala < 2.12.x, you'll additionally need the `-Xexperimental` flag:
+
+```scala
+scalacOptions += "-Xexperimental"
+```
+
 Sample API specification
 ========================
 


### PR DESCRIPTION
Related to #161 

I've created [a new repo](https://github.com/blast-hardcheese/guardrail-version-isolation) to permit easily trying out different combinations of library versions and guardrail versions. With that, I was able to better narrow down versions that are generally compatible.