### PR TITLE
fix double trailing slash for http4s server

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
@@ -442,10 +442,10 @@ object SwaggerUtil {
       ) | opt(char('?')).map { _ =>
         None
       })
-      val emptyPath: Parser[(List[(Option[TN], T)], (Boolean, Option[T]))]   = endOfInput ~> ok((List.empty[(Option[TN], T)], (false, None)))
+      val emptyPath: Parser[(List[(Option[TN], T)], (Boolean, Option[T]))]   = ok((List.empty[(Option[TN], T)], (false, None)))
       val emptyPathQS: Parser[(List[(Option[TN], T)], (Boolean, Option[T]))] = ok(List.empty[(Option[TN], T)]) ~ (ok(false) ~ staticQS)
       def pattern(implicit pathArgs: List[ScalaParameter[ScalaLanguage]]): Parser[(List[(Option[TN], T)], (Boolean, Option[T]))] =
-        opt(leadingSlash) ~> ((segments ~ (trailingSlash ~ staticQS) <~ endOfInput) | emptyPathQS | emptyPath)
+        opt(leadingSlash) ~> ((segments ~ (trailingSlash ~ staticQS)) | emptyPathQS | emptyPath) <~ endOfInput
     }
 
     object akkaExtractor

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
@@ -434,7 +434,8 @@ object SwaggerUtil {
         .map(_.fold("")(_.mkString))
       val staticQSTerm: Parser[T] =
         choice(staticQSArg, qsValueOnly).map(buildParamConstraint)
-      val trailingSlash: Parser[Boolean] = opt(char('/')).map(_.nonEmpty)
+      val leadingSlash: Parser[Option[Char]] = opt(char('/'))
+      val trailingSlash: Parser[Boolean]     = opt(char('/')).map(_.nonEmpty)
       val staticQS: Parser[Option[T]] = (opt(
         char('?') ~> sepBy1(staticQSTerm, char('&'))
           .map(_.reduceLeft(joinParams))
@@ -444,7 +445,7 @@ object SwaggerUtil {
       val emptyPath: Parser[(List[(Option[TN], T)], (Boolean, Option[T]))]   = endOfInput ~> ok((List.empty[(Option[TN], T)], (false, None)))
       val emptyPathQS: Parser[(List[(Option[TN], T)], (Boolean, Option[T]))] = ok(List.empty[(Option[TN], T)]) ~ (ok(false) ~ staticQS)
       def pattern(implicit pathArgs: List[ScalaParameter[ScalaLanguage]]): Parser[(List[(Option[TN], T)], (Boolean, Option[T]))] =
-        (segments ~ (trailingSlash ~ staticQS) <~ endOfInput) | emptyPathQS | emptyPath
+        opt(leadingSlash) ~> ((segments ~ (trailingSlash ~ staticQS) <~ endOfInput) | emptyPathQS | emptyPath)
     }
 
     object akkaExtractor

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
@@ -117,7 +117,7 @@ object Http4sServerGenerator {
 
     def pathStrToHttp4s(basePath: Option[String], path: String, pathArgs: List[ScalaParameter[ScalaLanguage]]): Target[(Pat, Option[Pat])] =
       (basePath.getOrElse("") + path).stripPrefix("/") match {
-        case "" => Target.pure((p"${Term.Name("Root")} / ${Lit.String("")}", None))
+        case "" => Target.pure((p"${Term.Name("Root")}", None))
         case path =>
           for {
             pathDirective <- SwaggerUtil.paths

--- a/modules/codegen/src/test/scala/core/issues/Issue122.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue122.scala
@@ -24,6 +24,9 @@ class Issue122 extends FunSuite with Matchers with SwaggerSpecRunner {
     |      produces:
     |        - application/json
     |      parameters:
+    |      - name: id
+    |        in: path
+    |        type: string
     |      - name: optionalIterable
     |        in: formData
     |        description: Media Urls
@@ -62,9 +65,9 @@ class Issue122 extends FunSuite with Matchers with SwaggerSpecRunner {
               Left(Left(t))
           }))
         }
-        def getUser(optionalIterable: Option[Iterable[String]] = None, requiredIterable: Iterable[String], headers: List[HttpHeader] = Nil): EitherT[Future, Either[Throwable, HttpResponse], GetUserResponse] = {
+        def getUser(id: String, optionalIterable: Option[Iterable[String]] = None, requiredIterable: Iterable[String], headers: List[HttpHeader] = Nil): EitherT[Future, Either[Throwable, HttpResponse], GetUserResponse] = {
           val allHeaders = headers ++ scala.collection.immutable.Seq[Option[HttpHeader]]().flatten
-          makeRequest(HttpMethods.GET, host + basePath + "/user/", allHeaders, FormData(List(optionalIterable.toList.flatMap {
+          makeRequest(HttpMethods.GET, host + basePath + "/user/" + Formatter.addPath(id), allHeaders, FormData(List(optionalIterable.toList.flatMap {
             x => x.toList.map(("optionalIterable", _))
           }, List(("requiredIterable", Formatter.show(requiredIterable)))).flatten: _*), HttpProtocols.`HTTP/1.1`).flatMap(req => EitherT(httpClient(req).flatMap(resp => resp.status match {
             case StatusCodes.OK =>

--- a/modules/codegen/src/test/scala/core/issues/Issue165.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue165.scala
@@ -1,11 +1,11 @@
-package tests.generators.http4s
+package tests.core.issues
 
 import com.twilio.guardrail.generators.Http4s
 import com.twilio.guardrail.{ Context, Server, Servers }
 import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
-class Http4sServerTest extends FunSuite with Matchers with SwaggerSpecRunner {
+class Issue165 extends FunSuite with Matchers with SwaggerSpecRunner {
 
   import scala.meta._
 

--- a/modules/codegen/src/test/scala/tests/generators/http4s/Http4sServerTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/http4s/Http4sServerTest.scala
@@ -21,10 +21,17 @@ class Http4sServerTest extends FunSuite with Matchers with SwaggerSpecRunner {
        |      responses:
        |        200:
        |         description: description
-       |  "/foo/":
+       |  "/foo":
        |    get:
        |      x-scala-package: store
        |      operationId: getFoo
+       |      responses:
+       |        200:
+       |         description: description
+       |  "/foo/":
+       |    get:
+       |      x-scala-package: store
+       |      operationId: getFooDir
        |      responses:
        |        200:
        |         description: description
@@ -37,6 +44,7 @@ class Http4sServerTest extends FunSuite with Matchers with SwaggerSpecRunner {
       trait StoreHandler[F[_]] {
         def getRoot(respond: GetRootResponse.type)(): F[GetRootResponse]
         def getFoo(respond: GetFooResponse.type)(): F[GetFooResponse]
+        def getFooDir(respond: GetFooDirResponse.type)(): F[GetFooDirResponse]
       }
     """
     val resource = q"""
@@ -48,9 +56,14 @@ class Http4sServerTest extends FunSuite with Matchers with SwaggerSpecRunner {
                 case GetRootResponse.Ok =>
                   Ok()
               }
-            case req @ GET -> Root / "foo" / "" =>
+            case req @ GET -> Root / "foo" =>
               handler.getFoo(GetFooResponse)() flatMap {
                 case GetFooResponse.Ok =>
+                  Ok()
+              }
+            case req @ GET -> Root / "foo" / "" =>
+              handler.getFooDir(GetFooDirResponse)() flatMap {
+                case GetFooDirResponse.Ok =>
                   Ok()
               }
           }

--- a/modules/codegen/src/test/scala/tests/generators/http4s/Http4sServerTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/http4s/Http4sServerTest.scala
@@ -1,0 +1,148 @@
+package tests.generators.http4s
+
+import com.twilio.guardrail.generators.Http4s
+import com.twilio.guardrail.{Context, Server, Servers}
+import org.scalatest.{FunSuite, Matchers}
+import support.SwaggerSpecRunner
+
+class Http4sServerTest extends FunSuite with Matchers with SwaggerSpecRunner {
+
+  import scala.meta._
+
+  val swagger: String =
+    s"""
+       |swagger: '2.0'
+       |host: petstore.swagger.io
+       |paths:
+       |  "/":
+       |    post:
+       |      x-scala-package: store
+       |      operationId: addOrder
+       |      responses:
+       |        200:
+       |         description: description
+       |      consumes:
+       |        - application/json
+       |      produces:
+       |        - application/json
+       |      parameters:
+       |        - in: body
+       |          name: body
+       |          required: true
+       |          schema:
+       |            $$ref: '#/definitions/Order'
+       |  "/store/order/{order_id}":
+       |    get:
+       |      tags:
+       |       - store
+       |      x-scala-package: store
+       |      operationId: getOrderById
+       |      produces:
+       |      - application/xml
+       |      - application/json
+       |      parameters:
+       |       - name: order_id
+       |         in: path
+       |         required: true
+       |         type: integer
+       |         format: int64
+       |       - name: status
+       |         in: query
+       |         required: true
+       |         type: string
+       |         x-scala-type: OrderStatus
+       |         default: placed
+       |      responses:
+       |        '200':
+       |          description: successful operation
+       |          schema:
+       |            $$ref: "#/definitions/Order"
+       |        '400':
+       |          description: Invalid ID supplied
+       |        '404':
+       |          description: Order not found
+       |definitions:
+       |  Order:
+       |    type: object
+       |    properties:
+       |      id:
+       |        type: integer
+       |        format: int64
+       |      petId:
+       |        type: integer
+       |        format: int64
+       |      quantity:
+       |        type: integer
+       |        format: int32
+       |      shipDate:
+       |        type: string
+       |        format: date-time
+       |      status:
+       |        type: string
+       |        description: Order Status
+       |        enum:
+       |        - placed
+       |        - approved
+       |        - delivered
+       |      complete:
+       |        type: boolean
+       |        default: false
+       |    xml:
+       |      name: Order
+       |  OrderStatus:
+       |    type: string
+       |    enum:
+       |    - placed
+       |    - approved
+       |    - delivered
+       |""".stripMargin
+
+  test("Ensure routes are generated") {
+    val (_, _, Servers(Server(_, _, genHandler :: genResource :: _) :: Nil)) = runSwaggerSpec(swagger)(Context.empty, Http4s)
+
+    val handler = q"""
+      trait StoreHandler[F[_]] {
+        def addOrder(respond: AddOrderResponse.type)(body: Order): F[AddOrderResponse]
+        def getOrderById(respond: GetOrderByIdResponse.type)(orderId: Long, status: OrderStatus = OrderStatus.Placed): F[GetOrderByIdResponse]
+      }
+    """
+    val resource = q"""
+      class StoreResource[F[_]]()(implicit E: Effect[F]) extends Http4sDsl[F] {
+
+        val addOrderDecoder: EntityDecoder[F, Order] = jsonOf[F, Order]
+
+        object GetOrderByIdStatusMatcher extends QueryParamDecoderMatcher[OrderStatus]("status")
+
+        implicit val statusQueryParamDecoder: QueryParamDecoder[OrderStatus] = (value: QueryParameterValue) => Json.fromString(value.value).as[OrderStatus].leftMap(t => ParseFailure("Query decoding failed", t.getMessage)).toValidatedNel
+
+        val getOrderByIdOkEncoder = jsonEncoderOf[F, Order]
+
+        def routes(handler: StoreHandler[F]): HttpRoutes[F] = HttpRoutes.of {
+          {
+            case req @ POST -> Root =>
+              req.decodeWith(addOrderDecoder, strict = false) { body =>
+                handler.addOrder(AddOrderResponse)(body) flatMap {
+                  case AddOrderResponse.Ok =>
+                    Ok()
+                }
+              }
+            case req @ GET -> Root / "store" / "order" / LongVar(orderId) :? GetOrderByIdStatusMatcher(status) =>
+              handler.getOrderById(GetOrderByIdResponse)(orderId, status) flatMap {
+                case GetOrderByIdResponse.Ok(value) =>
+                  Ok(value)(E, getOrderByIdOkEncoder)
+                case GetOrderByIdResponse.BadRequest =>
+                  BadRequest()
+                case GetOrderByIdResponse.NotFound =>
+                  NotFound()
+              }
+          }
+        }
+      }
+    """
+
+    genHandler.structure shouldEqual handler.structure
+
+    // Cause structure is slightly different but source code is the same the value converted to string and then parsed
+    genResource.toString().parse[Stat].get.structure shouldEqual resource.structure
+  }
+}

--- a/modules/codegen/src/test/scala/tests/generators/http4s/Http4sServerTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/http4s/Http4sServerTest.scala
@@ -1,8 +1,8 @@
 package tests.generators.http4s
 
 import com.twilio.guardrail.generators.Http4s
-import com.twilio.guardrail.{Context, Server, Servers}
-import org.scalatest.{FunSuite, Matchers}
+import com.twilio.guardrail.{ Context, Server, Servers }
+import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 class Http4sServerTest extends FunSuite with Matchers with SwaggerSpecRunner {
@@ -15,125 +15,43 @@ class Http4sServerTest extends FunSuite with Matchers with SwaggerSpecRunner {
        |host: petstore.swagger.io
        |paths:
        |  "/":
-       |    post:
+       |    get:
        |      x-scala-package: store
-       |      operationId: addOrder
+       |      operationId: getRoot
        |      responses:
        |        200:
        |         description: description
-       |      consumes:
-       |        - application/json
-       |      produces:
-       |        - application/json
-       |      parameters:
-       |        - in: body
-       |          name: body
-       |          required: true
-       |          schema:
-       |            $$ref: '#/definitions/Order'
-       |  "/store/order/{order_id}":
+       |  "/foo/":
        |    get:
-       |      tags:
-       |       - store
        |      x-scala-package: store
-       |      operationId: getOrderById
-       |      produces:
-       |      - application/xml
-       |      - application/json
-       |      parameters:
-       |       - name: order_id
-       |         in: path
-       |         required: true
-       |         type: integer
-       |         format: int64
-       |       - name: status
-       |         in: query
-       |         required: true
-       |         type: string
-       |         x-scala-type: OrderStatus
-       |         default: placed
+       |      operationId: getFoo
        |      responses:
-       |        '200':
-       |          description: successful operation
-       |          schema:
-       |            $$ref: "#/definitions/Order"
-       |        '400':
-       |          description: Invalid ID supplied
-       |        '404':
-       |          description: Order not found
-       |definitions:
-       |  Order:
-       |    type: object
-       |    properties:
-       |      id:
-       |        type: integer
-       |        format: int64
-       |      petId:
-       |        type: integer
-       |        format: int64
-       |      quantity:
-       |        type: integer
-       |        format: int32
-       |      shipDate:
-       |        type: string
-       |        format: date-time
-       |      status:
-       |        type: string
-       |        description: Order Status
-       |        enum:
-       |        - placed
-       |        - approved
-       |        - delivered
-       |      complete:
-       |        type: boolean
-       |        default: false
-       |    xml:
-       |      name: Order
-       |  OrderStatus:
-       |    type: string
-       |    enum:
-       |    - placed
-       |    - approved
-       |    - delivered
+       |        200:
+       |         description: description
        |""".stripMargin
 
   test("Ensure routes are generated") {
     val (_, _, Servers(Server(_, _, genHandler :: genResource :: _) :: Nil)) = runSwaggerSpec(swagger)(Context.empty, Http4s)
 
-    val handler = q"""
+    val handler  = q"""
       trait StoreHandler[F[_]] {
-        def addOrder(respond: AddOrderResponse.type)(body: Order): F[AddOrderResponse]
-        def getOrderById(respond: GetOrderByIdResponse.type)(orderId: Long, status: OrderStatus = OrderStatus.Placed): F[GetOrderByIdResponse]
+        def getRoot(respond: GetRootResponse.type)(): F[GetRootResponse]
+        def getFoo(respond: GetFooResponse.type)(): F[GetFooResponse]
       }
     """
     val resource = q"""
       class StoreResource[F[_]]()(implicit E: Effect[F]) extends Http4sDsl[F] {
-
-        val addOrderDecoder: EntityDecoder[F, Order] = jsonOf[F, Order]
-
-        object GetOrderByIdStatusMatcher extends QueryParamDecoderMatcher[OrderStatus]("status")
-
-        implicit val statusQueryParamDecoder: QueryParamDecoder[OrderStatus] = (value: QueryParameterValue) => Json.fromString(value.value).as[OrderStatus].leftMap(t => ParseFailure("Query decoding failed", t.getMessage)).toValidatedNel
-
-        val getOrderByIdOkEncoder = jsonEncoderOf[F, Order]
-
         def routes(handler: StoreHandler[F]): HttpRoutes[F] = HttpRoutes.of {
           {
-            case req @ POST -> Root =>
-              req.decodeWith(addOrderDecoder, strict = false) { body =>
-                handler.addOrder(AddOrderResponse)(body) flatMap {
-                  case AddOrderResponse.Ok =>
-                    Ok()
-                }
+            case req @ GET -> Root =>
+              handler.getRoot(GetRootResponse)() flatMap {
+                case GetRootResponse.Ok =>
+                  Ok()
               }
-            case req @ GET -> Root / "store" / "order" / LongVar(orderId) :? GetOrderByIdStatusMatcher(status) =>
-              handler.getOrderById(GetOrderByIdResponse)(orderId, status) flatMap {
-                case GetOrderByIdResponse.Ok(value) =>
-                  Ok(value)(E, getOrderByIdOkEncoder)
-                case GetOrderByIdResponse.BadRequest =>
-                  BadRequest()
-                case GetOrderByIdResponse.NotFound =>
-                  NotFound()
+            case req @ GET -> Root / "foo" / "" =>
+              handler.getFoo(GetFooResponse)() flatMap {
+                case GetFooResponse.Ok =>
+                  Ok()
               }
           }
         }


### PR DESCRIPTION
Fix double trailing slash for http4s server generator.

The issue:
When we have empty path for method like in swagger file below:
```yaml
swagger: 2.0
info:
  description: Some description
schemes:
  - http
paths:
  /:
    post:
      x-scala-package: somePackage
      operationId: someOperationId
      consumes:
        - application/json
      produces:
        - application/json
      responses:
        200:
```
generated server consumes only requests for this path with double slash like so:
http://localhost//