### PR TITLE
Adding the ability to generate just models with kind of Models

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/CodegenTarget.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/CodegenTarget.scala
@@ -4,4 +4,5 @@ sealed trait CodegenTarget
 object CodegenTarget {
   case object Client extends CodegenTarget
   case object Server extends CodegenTarget
+  case object Models extends CodegenTarget
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -108,6 +108,7 @@ object Common {
               .fromSwagger[L, F](context, swagger, frameworkImports)(protocolElems)
             Servers(servers) = serverMeta
           } yield CodegenDefinitions[L](List.empty, servers)
+        case CodegenTarget.Models => Free.pure[F, CodegenDefinitions[L]](CodegenDefinitions[L](List.empty, List.empty))
       }
 
       CodegenDefinitions(clients, servers) = codegen

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -20,62 +20,25 @@ import scala.meta._
 object Common {
   val resolveFile: Path => List[String] => Path = root => _.foldLeft(root)(_.resolve(_))
 
-  def writePackage[L <: LA, F[_]](kind: CodegenTarget,
-                                  context: Context,
-                                  swagger: Swagger,
-                                  outputPath: Path,
-                                  pkgName: List[String],
-                                  dtoPackage: List[String],
-                                  customImports: List[L#Import])(implicit
-                                                                 C: ClientTerms[L, F],
-                                                                 R: ArrayProtocolTerms[L, F],
-                                                                 E: EnumProtocolTerms[L, F],
-                                                                 F: FrameworkTerms[L, F],
-                                                                 M: ModelProtocolTerms[L, F],
-                                                                 Pol: PolyProtocolTerms[L, F],
-                                                                 S: ProtocolSupportTerms[L, F],
-                                                                 Sc: ScalaTerms[L, F],
-                                                                 Se: ServerTerms[L, F],
-                                                                 Sw: SwaggerTerms[L, F]): Free[F, List[WriteTree]] = {
+  def prepareDefinitions[L <: LA, F[_]](kind: CodegenTarget, context: Context, swagger: Swagger)(
+      implicit
+      C: ClientTerms[L, F],
+      R: ArrayProtocolTerms[L, F],
+      E: EnumProtocolTerms[L, F],
+      F: FrameworkTerms[L, F],
+      M: ModelProtocolTerms[L, F],
+      Pol: PolyProtocolTerms[L, F],
+      S: ProtocolSupportTerms[L, F],
+      Sc: ScalaTerms[L, F],
+      Se: ServerTerms[L, F],
+      Sw: SwaggerTerms[L, F]
+  ): Free[F, (ProtocolDefinitions[L], CodegenDefinitions[L])] = {
     import F._
-    import Sc._
     import Sw._
-
-    val splitComponents: String => Option[List[String]] = x => Some(x.split('.').toList).filterNot(_.isEmpty)
-
-    val pkgPath        = resolveFile(outputPath)(pkgName)
-    val dtoPackagePath = resolveFile(pkgPath.resolve("definitions"))(dtoPackage)
-
-    val definitions: List[String]   = pkgName :+ "definitions"
-    val dtoComponents: List[String] = definitions ++ dtoPackage
-    val buildPkgTerm: List[String] => Term.Ref =
-      _.map(Term.Name.apply _).reduceLeft(Term.Select.apply _)
 
     for {
       proto <- ProtocolGenerator.fromSwagger[L, F](swagger)
       ProtocolDefinitions(protocolElems, protocolImports, packageObjectImports, packageObjectContents) = proto
-      imports                                                                                          = customImports ++ protocolImports
-      utf8                                                                                             = java.nio.charset.Charset.availableCharsets.get("UTF-8")
-
-      protoOut <- protocolElems.traverse(writeProtocolDefinition(outputPath, pkgName, definitions, dtoComponents, imports, _))
-      (protocolDefinitions, extraTypes) = protoOut.foldLeft((List.empty[WriteTree], List.empty[L#Statement]))(_ |+| _)
-
-      dtoHead :: dtoRest = dtoComponents
-      dtoPkg = dtoRest.init
-        .foldLeft[Term.Ref](Term.Name(dtoHead)) {
-          case (acc, next) => Term.Select(acc, Term.Name(next))
-        }
-      companion = Term.Name(s"${dtoComponents.last}$$")
-
-      packageObject <- writePackageObject(
-        dtoPackagePath,
-        dtoComponents,
-        customImports,
-        packageObjectImports,
-        protocolImports,
-        packageObjectContents,
-        extraTypes
-      )
 
       schemes = Option(swagger.getSchemes)
         .fold(List.empty[String])(_.asScala.to[List].map(_.toValue))
@@ -90,9 +53,7 @@ object Common {
         .groupBy(_._1)
         .mapValues(_.map(_._2))
         .toList
-      frameworkImports    <- getFrameworkImports(context.tracing)
-      _frameworkImplicits <- getFrameworkImplicits()
-      (frameworkImplicitName, frameworkImplicits) = _frameworkImplicits
+      frameworkImports <- getFrameworkImports(context.tracing)
 
       codegen <- kind match {
         case CodegenTarget.Client =>
@@ -110,8 +71,43 @@ object Common {
           } yield CodegenDefinitions[L](List.empty, servers)
         case CodegenTarget.Models => Free.pure[F, CodegenDefinitions[L]](CodegenDefinitions[L](List.empty, List.empty))
       }
+    } yield (proto, codegen)
+  }
 
-      CodegenDefinitions(clients, servers) = codegen
+  def writePackage[L <: LA, F[_]](proto: ProtocolDefinitions[L], codegen: CodegenDefinitions[L], context: Context)(
+      outputPath: Path,
+      pkgName: List[String],
+      dtoPackage: List[String],
+      customImports: List[L#Import]
+  )(implicit Sc: ScalaTerms[L, F], F: FrameworkTerms[L, F]): Free[F, List[WriteTree]] = {
+    import F._
+    import Sc._
+
+    val pkgPath        = resolveFile(outputPath)(pkgName)
+    val dtoPackagePath = resolveFile(pkgPath.resolve("definitions"))(dtoPackage)
+
+    val definitions: List[String]   = pkgName :+ "definitions"
+    val dtoComponents: List[String] = definitions ++ dtoPackage
+
+    val ProtocolDefinitions(protocolElems, protocolImports, packageObjectImports, packageObjectContents) = proto
+    val CodegenDefinitions(clients, servers)                                                             = codegen
+
+    for {
+      protoOut <- protocolElems.traverse(writeProtocolDefinition(outputPath, pkgName, definitions, dtoComponents, customImports ++ protocolImports, _))
+      (protocolDefinitions, extraTypes) = protoOut.foldLeft((List.empty[WriteTree], List.empty[L#Statement]))(_ |+| _)
+      packageObject <- writePackageObject(
+        dtoPackagePath,
+        dtoComponents,
+        customImports,
+        packageObjectImports,
+        protocolImports,
+        packageObjectContents,
+        extraTypes
+      )
+
+      frameworkImports    <- getFrameworkImports(context.tracing)
+      _frameworkImplicits <- getFrameworkImplicits()
+      (frameworkImplicitName, frameworkImplicits) = _frameworkImplicits
 
       files <- (clients.traverse(writeClient(pkgPath, pkgName, customImports, frameworkImplicitName, dtoComponents, _)),
                 servers.traverse(writeServer(pkgPath, pkgName, customImports, frameworkImplicitName, dtoComponents, _))).mapN(_ ++ _)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
@@ -122,9 +122,11 @@ object CoreTermInterp {
           } yield {
             ReadSwagger(
               Paths.get(specPath), { swagger =>
-                Common
-                  .writePackage[L, CodegenApplication[L, ?]](kind, context, swagger, Paths.get(outputPath), pkgName, dtoPackage, customImports)
-                  .foldMap(targetInterpreter)
+                (for {
+                  defs <- Common.prepareDefinitions[L, CodegenApplication[L, ?]](kind, context, swagger)
+                  (proto, codegen) = defs
+                  result <- Common.writePackage[L, CodegenApplication[L, ?]](proto, codegen, context)(Paths.get(outputPath), pkgName, dtoPackage, customImports)
+                } yield result).foldMap(targetInterpreter)
               }
             )
           }

--- a/modules/codegen/src/test/scala/core/issues/Issue166.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue166.scala
@@ -1,0 +1,62 @@
+package tests.core.issues
+
+import _root_.io.swagger.parser.SwaggerParser
+import com.twilio.guardrail._
+import com.twilio.guardrail.generators.Http4s
+import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
+import com.twilio.guardrail.languages.ScalaLanguage
+import org.scalatest.{ FunSuite, Matchers }
+import support.SwaggerSpecRunner
+
+import scala.meta._
+
+class Issue166 extends FunSuite with Matchers with SwaggerSpecRunner {
+
+  val swagger = s"""
+                   |swagger: "2.0"
+                   |info:
+                   |  title: Whatever
+                   |  version: 1.0.0
+                   |host: localhost:1234
+                   |schemes:
+                   |  - http
+                   |paths:
+                   |  /blix:
+                   |    get:
+                   |      operationId: getBlix
+                   |      responses:
+                   |        200:
+                   |          schema:
+                   |            $$ref: "#/definitions/Blix"
+                   |definitions:
+                   |  Blix:
+                   |    type: object
+                   |    required:
+                   |      - map
+                   |    properties:
+                   |      map:
+                   |        type: string
+                   |""".stripMargin
+
+  test("Handle generation of models") {
+    val (proto, codegen) = Target.unsafeExtract(
+      Common
+        .prepareDefinitions[ScalaLanguage, CodegenApplication[ScalaLanguage, ?]](
+          CodegenTarget.Models,
+          Context.empty,
+          new SwaggerParser().parse(swagger)
+        )
+        .foldMap(Http4s)
+    )
+
+    val ProtocolDefinitions(ClassDefinition(_, _, cls, _, _) :: Nil, _, _, _) = proto
+    val CodegenDefinitions(Nil, Nil)                                          = codegen
+
+    val definition = q"""
+      case class Blix(map: String)
+    """
+
+    cls.structure should equal(definition.structure)
+  }
+
+}


### PR DESCRIPTION
https://github.com/twilio/guardrail/issues/166

This adds the ability to generate _just_ models from swagger docs. This is my first PR here, so please let me know how this looks!

I know https://github.com/twilio/sbt-guardrail is what i've used in the past to build these, will I need to submit a PR to that project so 
```
guardrailTasks in Compile := List(
  Models(file("petstore.yaml"))
)
```

We can handle something like ^^