### PR TITLE
Fixes #164  Implict LocalDate for clients

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,6 +78,8 @@ fullRunTask(
   --client --specPath modules/sample/src/main/resources/issues/issue148.yaml --outputPath modules/sample/src/main/scala --packageName issues.issue148.client.akkaHttp --framework akka-http
   --server --specPath modules/sample/src/main/resources/issues/issue148.yaml --outputPath modules/sample/src/main/scala --packageName issues.issue148.server.http4s --framework http4s
   --server --specPath modules/sample/src/main/resources/issues/issue148.yaml --outputPath modules/sample/src/main/scala --packageName issues.issue148.server.akkaHttp --framework akka-http
+  --client --specPath modules/sample/src/main/resources/issues/issue164.yaml --outputPath modules/sample/src/main/scala --packageName issues.issue164.client.http4s --framework http4s
+  --client --specPath modules/sample/src/main/resources/issues/issue164.yaml --outputPath modules/sample/src/main/scala --packageName issues.issue164.client.akkaHttp --framework akka-http
 """.replaceAllLiterally("\n", " ").split(' ').filter(_.nonEmpty): _*
 )
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
@@ -174,6 +174,7 @@ object ScalaGenerator {
                 implicit val showBigInt = build[BigInt](_.toString)
                 implicit val showBigDecimal = build[BigDecimal](_.toString)
                 implicit val showBoolean = build[Boolean](_.toString)
+                implicit val showLocalDate = build[java.time.LocalDate](_.format(java.time.format.DateTimeFormatter.ISO_DATE))
                 implicit val showOffsetDateTime = build[java.time.OffsetDateTime](_.format(java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME))
                 implicit val showJavaURL = build[java.net.URL](_.toString)
               }

--- a/modules/sample/src/main/resources/issues/issue164.yaml
+++ b/modules/sample/src/main/resources/issues/issue164.yaml
@@ -1,0 +1,22 @@
+swagger: '2.0'
+info:
+  title: https://github.com/twilio/guardrail/issues/164
+host: localhost:1234
+schemes:
+- http
+paths:
+  /entity:
+    delete:
+      operationId: deleteFoo
+      parameters:
+      - name: bar
+        in: query
+        description: A local date parameter
+        type: string
+        format: date
+        required: true
+      consumes:
+      - application/x-www-form-urlencoded
+      responses:
+        '204':
+          description: No content


### PR DESCRIPTION
Fixes #164
Allow clients to use LocalDate parameters
With the implict LocalDate provided the generated client test passes
