### PR TITLE
Adjusting scalafmt to be less obnoxious during development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target/
 
 modules/sample/target/
 modules/sample/src/main/scala/*
+modules/sample/src/main/scala/generated/*
 !modules/sample/src/main/scala/App.scala
 !modules/sample/src/main/scala/support
 !modules/sample/src/test/resources/

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,13 @@
+project.git = true
+
+project.includeFilters = [
+  ".*\\.sbt$"
+  ".*\\.sc$"
+  "modules/sample[^/]*/src/test/.*\\.scala"
+  "modules/sample[^/]*/src/main/scala/support/.*\\.scala"
+  "modules/codegen/src/.*\\.scala"
+]
+
 style = defaultWithAlign
 
 danglingParentheses        = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: scala
 script:
-- sbt +testSuite
+- sbt checkFormatting +testSuite

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,8 +78,10 @@ Useful commands inside sbt console
 ==================================
 
 - `testSuite`: Compile, test codegen, run sample codegen, compile sample, run tests inside sample
-- `example`: Run guardrail, then run all tests against the generated code
+- `runtimeSuite`: Run guardrail, then run all tests against the generated code
 - `cli`: Useful for scripting: `sbt 'cli --client ...'`
+- `format`: Runs scalafmt against codebase
+- `checkFormatting`: Verifies formatting, run as part of CI against PRs
 
 Resources
 =========

--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,7 @@ val exampleArgs: List[List[String]] = exampleCases
         (
           List(s"--${kind}") ++
             List("--specPath", path.toString()) ++
-            List("--outputPath", "modules/sample/src/main/scala") ++
+            List("--outputPath", s"modules/sample/src/main/scala/generated") ++
             List("--packageName", s"${prefix}.${kind}.${frameworkPackage}") ++
             List("--framework", frameworkName)
         ) ++ tracingFlag ++ extra)

--- a/build.sbt
+++ b/build.sbt
@@ -11,9 +11,6 @@ git.useGitDescribe := true
 crossScalaVersions := Seq("2.11.12", "2.12.3")
 scalaVersion in ThisBuild := crossScalaVersions.value.last
 
-scalafmtOnCompile in ThisBuild := true
-scalafmtFailTest in ThisBuild := false
-
 val akkaVersion       = "10.0.14"
 val catsVersion       = "1.4.0"
 val catsEffectVersion = "1.0.0"
@@ -80,12 +77,6 @@ artifact in (Compile, assembly) := {
 
 addArtifact(artifact in (Compile, assembly), assembly)
 
-addCommandAlias("cli", "runMain com.twilio.guardrail.CLI")
-addCommandAlias(
-  "format",
-  "; codegen/scalafmt ; codegen/test:scalafmt ; scalafmt ; codegen/test:scalafmt ; sample/scalafmt ; sample/test:scalafmt"
-)
-
 val resetSample = TaskKey[Unit]("resetSample", "Reset sample module")
 
 resetSample := {
@@ -93,8 +84,14 @@ resetSample := {
   "git clean -fdx modules/sample/src modules/sample/target" !
 }
 
-addCommandAlias("example", "; resetSample ; runScalaExample ; sample/test")
-addCommandAlias("scalaTestSuite", "; codegen/test ; resetSample; runScalaExample ; sample/test")
+// Deprecated command
+addCommandAlias("example", "runtimeSuite")
+
+addCommandAlias("cli", "runMain com.twilio.guardrail.CLI")
+addCommandAlias("runtimeSuite", "; resetSample ; runScalaExample ; sample/test")
+addCommandAlias("scalaTestSuite", "; codegen/test ; runtimeSuite")
+addCommandAlias("format", "; codegen/test:scalafmt ; sample/test:scalafmt")
+addCommandAlias("checkFormatting", "; codegen/scalafmtCheck ; sample/scalafmtCheck")
 addCommandAlias("testSuite", "; scalaTestSuite")
 
 addCommandAlias(

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
@@ -124,7 +124,8 @@ object CoreTermInterp {
                   (for {
                     defs <- Common.prepareDefinitions[L, CodegenApplication[L, ?]](kind, context, swagger)
                     (proto, codegen) = defs
-                    result <- Common.writePackage[L, CodegenApplication[L, ?]](proto, codegen, context)(Paths.get(outputPath), pkgName, dtoPackage, customImports)
+                    result <- Common
+                      .writePackage[L, CodegenApplication[L, ?]](proto, codegen, context)(Paths.get(outputPath), pkgName, dtoPackage, customImports)
                   } yield result).foldMap(targetInterpreter)
                 } catch {
                   case NonFatal(ex) =>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.4")
 
-addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.15")
+addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
 


### PR DESCRIPTION
- Disabling `scalafmtOnCompile`
- Requiring scalafmt for CI
- Ensuring all source files are tracked (related: https://github.com/scalameta/sbt-scalafmt/issues/11, https://github.com/scalameta/sbt-scalafmt/issues/12)
- Switching from `"com.lucidchart" % "sbt-scalafmt"` to `"com.geirsson" % "sbt-scalafmt"` to get `scalafmtCheck`
