### PR TITLE
Fix compilation of AkkaHttpImplicits for Scala 2.11

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpGenerator.scala
@@ -148,7 +148,7 @@ object AkkaHttpGenerator {
 
             def AccumulatingUnmarshaller[T, U, V](accumulator: AtomicReference[List[V]], ev: Unmarshaller[T, U])(acc: U => V)(implicit mat: Materializer): Unmarshaller[T, U] = {
               ev.map { value =>
-                accumulator.updateAndGet(acc(value) :: _)
+                accumulator.updateAndGet(x => (acc(value) :: x))
                 value
               }
             }


### PR DESCRIPTION
The code generated for AkkaHttp is not compiling for Scala 2.11 The error is like following:
```
target/scala-2.11/src_managed/main/com/codacy/worker/api/specification/AkkaHttpImplicits.scala:92:46: missing parameter type for expanded function ((x$8) => {
[error]   <synthetic> <artifact> val x$9 = acc(value);
[error]   x$8.$colon$colon(x$9)
[error] })
[error]       accumulator.updateAndGet(acc(value) :: _)
[error]                                              ^
[error] one error found
```
Here you have the trivial fix.