### PR TITLE
Make DW server response classes simpler for the resources to use

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/Java.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/Java.scala
@@ -85,6 +85,7 @@ object Java {
   def functionType(in: Type, out: Type): ClassOrInterfaceType = JavaParser.parseClassOrInterfaceType("Function").setTypeArguments(in, out)
   def supplierType(of: Type): ClassOrInterfaceType            = JavaParser.parseClassOrInterfaceType("Supplier").setTypeArguments(of)
 
+  val VOID_TYPE: ClassOrInterfaceType            = JavaParser.parseClassOrInterfaceType("Void")
   val OBJECT_TYPE: ClassOrInterfaceType          = JavaParser.parseClassOrInterfaceType("Object")
   val STRING_TYPE: ClassOrInterfaceType          = JavaParser.parseClassOrInterfaceType("String")
   val THROWABLE_TYPE: ClassOrInterfaceType       = JavaParser.parseClassOrInterfaceType("Throwable")

--- a/modules/sample-dropwizard/src/test/scala/helpers/MockHelpers.scala
+++ b/modules/sample-dropwizard/src/test/scala/helpers/MockHelpers.scala
@@ -15,9 +15,8 @@ import org.scalatest.Assertions
 import scala.reflect.ClassTag
 
 object MockHelpers extends Assertions with MockitoSugar with ArgumentMatchersSugar {
-  def mockAsyncResponse[T](implicit cls: ClassTag[T]): (AsyncResponse, CompletableFuture[T]) = {
+  def mockAsyncResponse[T](future: CompletableFuture[T])(implicit cls: ClassTag[T]): AsyncResponse = {
     val asyncResponse = mock[AsyncResponse]
-    val future = new CompletableFuture[T]
 
     when(asyncResponse.resume(any[T])) thenAnswer[AnyRef] { response => response match {
       case t: Throwable => future.completeExceptionally(t)
@@ -25,7 +24,7 @@ object MockHelpers extends Assertions with MockitoSugar with ArgumentMatchersSug
       case other => fail(s"AsyncResponse.resume expected an object of type ${cls.runtimeClass.getName}, but got ${other.getClass.getName} instead")
     }}
 
-    (asyncResponse, future)
+    asyncResponse
   }
 
   def mockAHCResponse[T](uri: String, status: Int, maybeBody: Option[T] = None)(implicit mapper: ObjectMapper): Response = {


### PR DESCRIPTION
 This is _mostly_ user-invisible.  The base response class now holds the entity body (if any), and is parameterized on the entity body's type.  Now the resource class method doesn't need to do `instanceof` checks for each response type to attempt to extract entity bodies and can instead just pull out an `Optional<T>` from the abstract base class.

Depends on https://github.com/twilio/guardrail/pull/199

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowlege that all my contributions will be made under the project's license.
