### PR TITLE
Generate @TRACE and @PATCH annotations for Dropwizard

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
@@ -238,7 +238,6 @@ object DropwizardServerGenerator {
           "javax.ws.rs.GET",
           "javax.ws.rs.HEAD",
           "javax.ws.rs.HeaderParam",
-          "javax.ws.rs.HttpMethod",
           "javax.ws.rs.OPTIONS",
           "javax.ws.rs.POST",
           "javax.ws.rs.PUT",
@@ -278,17 +277,7 @@ object DropwizardServerGenerator {
                 parameters.parameters.foreach(p => p.param.setType(p.param.getType.unbox))
 
                 val method = new MethodDeclaration(util.EnumSet.of(PUBLIC), new VoidType, operationId)
-                val httpMethodAnnotation = httpMethod match {
-                  case HttpMethod.DELETE  => new MarkerAnnotationExpr("DELETE")
-                  case HttpMethod.GET     => new MarkerAnnotationExpr("GET")
-                  case HttpMethod.HEAD    => new MarkerAnnotationExpr("HEAD")
-                  case HttpMethod.OPTIONS => new MarkerAnnotationExpr("OPTIONS")
-                  case HttpMethod.PATCH   => new SingleMemberAnnotationExpr(new Name("HttpMethod"), new StringLiteralExpr("PATCH"))
-                  case HttpMethod.POST    => new MarkerAnnotationExpr("POST")
-                  case HttpMethod.PUT     => new MarkerAnnotationExpr("PUT")
-                  case HttpMethod.TRACE   => new SingleMemberAnnotationExpr(new Name("HttpMethod"), new StringLiteralExpr("TRACE"))
-                }
-                method.addAnnotation(httpMethodAnnotation)
+                  .addAnnotation(new MarkerAnnotationExpr(httpMethod.toString))
 
                 val pathSuffix = splitPathComponents(path).drop(commonPathPrefix.length).mkString("/", "/", "")
                 if (pathSuffix.nonEmpty && pathSuffix != "/") {
@@ -532,12 +521,34 @@ object DropwizardServerGenerator {
         }
 
       case GenerateSupportDefinitions(tracing) =>
-        val showerClass = SHOWER_CLASS_DEF
-        Target.pure(
+        for {
+          annotationImports <- List(
+            "java.lang.annotation.ElementType",
+            "java.lang.annotation.Retention",
+            "java.lang.annotation.RetentionPolicy",
+            "java.lang.annotation.Target",
+            "javax.ws.rs.HttpMethod"
+          ).traverse(safeParseRawImport)
+        } yield {
+          def httpMethodAnnotation(name: String): SupportDefinition[JavaLanguage] = {
+            val annotationDecl = new AnnotationDeclaration(util.EnumSet.of(PUBLIC), name)
+              .addAnnotation(
+                new SingleMemberAnnotationExpr(new Name("Target"),
+                                               new ArrayInitializerExpr(new NodeList(new FieldAccessExpr(new NameExpr("ElementType"), "METHOD"))))
+              )
+              .addAnnotation(new SingleMemberAnnotationExpr(new Name("Retention"), new FieldAccessExpr(new NameExpr("RetentionPolicy"), "RUNTIME")))
+              .addAnnotation(new SingleMemberAnnotationExpr(new Name("HttpMethod"), new StringLiteralExpr(name)))
+            SupportDefinition[JavaLanguage](new Name(name), annotationImports, annotationDecl)
+          }
+
+          val showerClass = SHOWER_CLASS_DEF
+
           List(
-            SupportDefinition[JavaLanguage](new Name(showerClass.getNameAsString), List.empty, showerClass)
+            SupportDefinition[JavaLanguage](new Name(showerClass.getNameAsString), List.empty, showerClass),
+            httpMethodAnnotation("PATCH"),
+            httpMethodAnnotation("TRACE")
           )
-        )
+        }
 
       case RenderClass(className, handlerName, classAnnotations, combinedRouteTerms, extraRouteParams, responseDefinitions, supportDefinitions) =>
         def doRender: Target[List[BodyDeclaration[_]]] = {


### PR DESCRIPTION
Turns out you're not supposed to use `@HttpMethod` on resource methods directly, but instead create your own annotations that are themselves annotated with `@HttpMethod`.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowlege that all my contributions will be made under the project's license.
