### PR TITLE
Move generated samples under target/ and refactor build.sbt a bit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,4 @@
 .DS_Store
 target/
 
-modules/sample*/target/
-modules/sample*/src/main/scala/*
-modules/sample*/src/main/scala/generated/*
-modules/sample*/src/main/java/*
-modules/sample*/src/main/java/generated/*
-!modules/sample*/src/main/scala/App.scala
-!modules/sample*/src/main/scala/support
-!modules/sample*/src/main/java/support
-!modules/sample*/src/test/resources/
-
 .idea


### PR DESCRIPTION
This avoids a weird situation where a source root is a subdirectory of another source root, and makes it so the sample code generation gets cleaned up with `sbt clean`.  The gitignore rules become simpler, and IDEs don't get confused about where the generated code lives.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowlege that all my contributions will be made under the project's license.
