### PR TITLE
Java code formatting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -173,14 +173,15 @@ lazy val codegen = (project in file("modules/codegen"))
     (name := "guardrail") +:
       codegenSettings,
     libraryDependencies ++= testDependencies ++ Seq(
-      "org.scalameta"           %% "scalameta"                    % "4.1.0",
-      "com.github.javaparser"   % "javaparser-symbol-solver-core" % javaparserVersion,
-      "io.swagger.parser.v3"    % "swagger-parser"                % "2.0.8",
-      "org.tpolecat"            %% "atto-core"                    % "0.6.3",
-      "org.typelevel"           %% "cats-core"                    % catsVersion,
-      "org.typelevel"           %% "cats-kernel"                  % catsVersion,
-      "org.typelevel"           %% "cats-macros"                  % catsVersion,
-      "org.typelevel"           %% "cats-free"                    % catsVersion
+      "org.scalameta"               %% "scalameta"                    % "4.1.0",
+      "com.github.javaparser"       % "javaparser-symbol-solver-core" % javaparserVersion,
+      "com.google.googlejavaformat" % "google-java-format"            % "1.6",
+      "io.swagger.parser.v3"        % "swagger-parser"                % "2.0.8",
+      "org.tpolecat"                %% "atto-core"                    % "0.6.3",
+      "org.typelevel"               %% "cats-core"                    % catsVersion,
+      "org.typelevel"               %% "cats-kernel"                  % catsVersion,
+      "org.typelevel"               %% "cats-macros"                  % catsVersion,
+      "org.typelevel"               %% "cats-free"                    % catsVersion
     ),
     scalacOptions += "-language:higherKinds",
     bintrayRepository := {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
@@ -9,6 +9,7 @@ import com.github.javaparser.ast.`type`.{ ClassOrInterfaceType, PrimitiveType, T
 import com.github.javaparser.ast.body.{ BodyDeclaration, Parameter, TypeDeclaration }
 import com.github.javaparser.ast.expr._
 import com.github.javaparser.ast.stmt.Statement
+import com.google.googlejavaformat.java.Formatter
 import com.twilio.guardrail._
 import com.twilio.guardrail.Common.resolveFile
 import com.twilio.guardrail.generators.syntax.Java._
@@ -26,6 +27,9 @@ object JavaGenerator {
       case None                   => Target.pure(new MethodCallExpr(name))
       case other                  => Target.raiseError(s"Need expression to call '${name}' but got a ${other.getClass.getName} instead")
     }
+
+    def prettyPrintSource(source: CompilationUnit): Array[Byte] =
+      new Formatter().formatSource(source.toString).getBytes(StandardCharsets.UTF_8)
 
     def apply[T](term: ScalaTerm[JavaLanguage, T]): Target[T] = term match {
       case CustomTypePrefixes() => Target.pure(List("x-java", "x-jvm"))
@@ -158,7 +162,7 @@ object JavaGenerator {
           cu.addType(frameworkDefinitions)
           WriteTree(
             resolveFile(pkgPath)(List(s"${frameworkDefinitionsName.asString}.java")),
-            cu.toString(printer).getBytes(StandardCharsets.UTF_8)
+            prettyPrintSource(cu)
           )
         }
 
@@ -169,7 +173,7 @@ object JavaGenerator {
           Some(
             WriteTree(
               resolveFile(dtoPackagePath)(List.empty).resolve("package-info.java"),
-              pkgDecl.toString(printer).getBytes(StandardCharsets.UTF_8)
+              prettyPrintSource(new CompilationUnit().setPackageDeclaration(pkgDecl))
             )
           )
 
@@ -192,7 +196,7 @@ object JavaGenerator {
                 List(
                   WriteTree(
                     resolveFile(outputPath)(dtoComponents).resolve(s"${cls.getName.getIdentifier}.java"),
-                    cu.toString(printer).getBytes(StandardCharsets.UTF_8)
+                    prettyPrintSource(cu)
                   )
                 ),
                 List.empty[Statement]
@@ -210,7 +214,7 @@ object JavaGenerator {
                 List(
                   WriteTree(
                     resolveFile(outputPath)(dtoComponents).resolve(s"${cls.getName.getIdentifier}.java"),
-                    cu.toString(printer).getBytes(StandardCharsets.UTF_8)
+                    prettyPrintSource(cu)
                   )
                 ),
                 List.empty[Statement]
@@ -228,7 +232,7 @@ object JavaGenerator {
                 List(
                   WriteTree(
                     resolveFile(outputPath)(dtoComponents).resolve(s"${name}.java"),
-                    cu.toString(printer).getBytes(StandardCharsets.UTF_8)
+                    prettyPrintSource(cu)
                   )
                 ),
                 List.empty[Statement]
@@ -262,7 +266,7 @@ object JavaGenerator {
           cu.addType(clientCopy)
           WriteTree(
             resolveFile(pkgPath)(pkg :+ s"${clientName}.java"),
-            cu.toString(printer).getBytes(StandardCharsets.UTF_8)
+            prettyPrintSource(cu)
           )
         }
 
@@ -280,7 +284,7 @@ object JavaGenerator {
           cu.addType(definition)
           WriteTree(
             resolveFile(pkgPath)(pkg :+ s"${definition.getNameAsString}.java"),
-            cu.toString(printer).getBytes(StandardCharsets.UTF_8)
+            prettyPrintSource(cu)
           )
         }
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/Java.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/Java.scala
@@ -5,8 +5,6 @@ import com.github.javaparser.ast.`type`.{ ClassOrInterfaceType, Type }
 import com.github.javaparser.ast.body.{ ClassOrInterfaceDeclaration, Parameter }
 import com.github.javaparser.ast.expr.{ Expression, Name, SimpleName }
 import com.github.javaparser.ast.{ CompilationUnit, ImportDeclaration, Node, NodeList }
-import com.github.javaparser.printer.PrettyPrinterConfiguration
-import com.github.javaparser.printer.PrettyPrinterConfiguration.IndentType
 import com.twilio.guardrail.Target
 import java.nio.charset.StandardCharsets
 import java.util.Optional
@@ -90,16 +88,6 @@ object Java {
   val STRING_TYPE: ClassOrInterfaceType          = JavaParser.parseClassOrInterfaceType("String")
   val THROWABLE_TYPE: ClassOrInterfaceType       = JavaParser.parseClassOrInterfaceType("Throwable")
   val ASSERTION_ERROR_TYPE: ClassOrInterfaceType = JavaParser.parseClassOrInterfaceType("AssertionError")
-
-  val printer: PrettyPrinterConfiguration = new PrettyPrinterConfiguration()
-    .setColumnAlignFirstMethodChain(false)
-    .setColumnAlignParameters(false)
-    .setIndentSize(4)
-    .setIndentType(IndentType.SPACES)
-    .setOrderImports(true)
-    .setPrintComments(true)
-    .setPrintJavadoc(true)
-    .setTabWidth(4)
 
   // from https://en.wikipedia.org/wiki/List_of_Java_keywords
   private val reservedWords = Set(


### PR DESCRIPTION
* Use [google-java-format](https://github.com/google/google-java-format) to format the generated Java code.  I don't love everything about Google's code style guidelines, but this output is _way_ better than javaparser's not-so-pretty printer.
* Sort class body declarations in a sane way so things look nice.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowlege that all my contributions will be made under the project's license.
