### PR TITLE
Java AHC cleanups

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -121,7 +121,7 @@ object Common {
       frameworkImplicitName = frameworkImplicits.map(_._1)
       frameworkDefinitions <- getFrameworkDefinitions()
 
-      files <- (clients.traverse(writeClient(pkgPath, pkgName, customImports, frameworkImplicitName, dtoComponents, _)),
+      files <- (clients.flatTraverse(writeClient(pkgPath, pkgName, customImports, frameworkImplicitName, dtoComponents, _)),
                 servers.flatTraverse(writeServer(pkgPath, pkgName, customImports, frameworkImplicitName, dtoComponents, _))).mapN(_ ++ _)
 
       implicits <- renderImplicits(pkgPath, pkgName, frameworkImports, protocolImports, customImports)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
@@ -752,7 +752,7 @@ object AsyncHttpClientClientGenerator {
             (responseInnerClass, foldMethodParameter, foldMethodBranch)
         })
 
-        val abstractResponseClass = new ClassOrInterfaceDeclaration(util.EnumSet.of(PUBLIC, STATIC, ABSTRACT), false, abstractClassName)
+        val abstractResponseClass = new ClassOrInterfaceDeclaration(util.EnumSet.of(PUBLIC, ABSTRACT), false, abstractClassName)
 
         val (innerClasses, foldMethodParameters, foldMethodIfBranches) = responseData.unzip3
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
@@ -264,9 +264,11 @@ object JavaGenerator {
           staticDefns.definitions.foreach(clientCopy.addMember)
           responseDefinitions.foreach(clientCopy.addMember)
           cu.addType(clientCopy)
-          WriteTree(
-            resolveFile(pkgPath)(pkg :+ s"${clientName}.java"),
-            prettyPrintSource(cu)
+          List(
+            WriteTree(
+              resolveFile(pkgPath)(pkg :+ s"${clientName}.java"),
+              prettyPrintSource(cu)
+            )
           )
         }
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
@@ -6,7 +6,7 @@ import cats.instances.option._
 import cats.syntax.traverse._
 import com.github.javaparser.ast._
 import com.github.javaparser.ast.`type`.{ ClassOrInterfaceType, PrimitiveType, Type, VoidType, ArrayType => AstArrayType }
-import com.github.javaparser.ast.body.{ BodyDeclaration, ClassOrInterfaceDeclaration, Parameter, TypeDeclaration }
+import com.github.javaparser.ast.body.{ BodyDeclaration, Parameter, TypeDeclaration }
 import com.github.javaparser.ast.expr._
 import com.github.javaparser.ast.stmt.Statement
 import com.google.googlejavaformat.java.Formatter
@@ -16,21 +16,64 @@ import com.twilio.guardrail.generators.syntax.Java._
 import com.twilio.guardrail.languages.JavaLanguage
 import com.twilio.guardrail.terms._
 import java.nio.charset.StandardCharsets
+import java.nio.file.Path
 import java.util
 
 object JavaGenerator {
-  object JavaInterp extends (ScalaTerm[JavaLanguage, ?] ~> Target) {
-    def buildPkgDecl(parts: List[String]): Target[PackageDeclaration] = safeParseName(parts.mkString(".")).map(new PackageDeclaration(_))
+  def buildPkgDecl(parts: List[String]): Target[PackageDeclaration] = safeParseName(parts.mkString(".")).map(new PackageDeclaration(_))
 
-    def buildMethodCall(name: String, arg: Option[Node] = None): Target[Node] = arg match {
-      case Some(expr: Expression) => Target.pure(new MethodCallExpr(name, expr))
-      case None                   => Target.pure(new MethodCallExpr(name))
-      case other                  => Target.raiseError(s"Need expression to call '${name}' but got a ${other.getClass.getName} instead")
+  def buildMethodCall(name: String, arg: Option[Node] = None): Target[Node] = arg match {
+    case Some(expr: Expression) => Target.pure(new MethodCallExpr(name, expr))
+    case None                   => Target.pure(new MethodCallExpr(name))
+    case other                  => Target.raiseError(s"Need expression to call '${name}' but got a ${other.getClass.getName} instead")
+  }
+
+  def prettyPrintSource(source: CompilationUnit): Array[Byte] =
+    new Formatter().formatSource(source.toString).getBytes(StandardCharsets.UTF_8)
+
+  def writeClientTree(pkgPath: Path,
+                      pkg: List[String],
+                      pkgDecl: PackageDeclaration,
+                      imports: List[ImportDeclaration],
+                      definition: BodyDeclaration[_]): Target[WriteTree] =
+    definition match {
+      case td: TypeDeclaration[_] =>
+        val cu = new CompilationUnit()
+        cu.setPackageDeclaration(pkgDecl)
+        imports.map(cu.addImport)
+        cu.addType(td)
+        Target.pure(
+          WriteTree(
+            resolveFile(pkgPath)(pkg :+ s"${td.getNameAsString}.java"),
+            prettyPrintSource(cu)
+          )
+        )
+      case other =>
+        Target.raiseError(s"Class definition must be a TypeDeclaration but it is a ${other.getClass.getName}")
     }
 
-    def prettyPrintSource(source: CompilationUnit): Array[Byte] =
-      new Formatter().formatSource(source.toString).getBytes(StandardCharsets.UTF_8)
+  def writeServerTree(pkgPath: Path,
+                      pkg: List[String],
+                      pkgDecl: PackageDeclaration,
+                      imports: List[ImportDeclaration],
+                      definition: BodyDeclaration[_]): Target[WriteTree] =
+    definition match {
+      case td: TypeDeclaration[_] =>
+        val cu = new CompilationUnit()
+        cu.setPackageDeclaration(pkgDecl)
+        imports.map(cu.addImport)
+        cu.addType(td)
+        Target.pure(
+          WriteTree(
+            resolveFile(pkgPath)(pkg :+ s"${td.getNameAsString}.java"),
+            prettyPrintSource(cu)
+          )
+        )
+      case other =>
+        Target.raiseError(s"Class definition must be a TypeDeclaration but it is a ${other.getClass.getName}")
+    }
 
+  object JavaInterp extends (ScalaTerm[JavaLanguage, ?] ~> Target) {
     def apply[T](term: ScalaTerm[JavaLanguage, T]): Target[T] = term match {
       case CustomTypePrefixes() => Target.pure(List("x-java", "x-jvm"))
 
@@ -253,25 +296,10 @@ object JavaGenerator {
           pkgDecl             <- buildPkgDecl(pkgName ++ pkg)
           commonImport        <- safeParseRawImport((pkgName :+ "*").mkString("."))
           dtoComponentsImport <- safeParseRawImport((dtoComponents :+ "*").mkString("."))
-        } yield {
-          def writeTree(typeDecl: TypeDeclaration[_]): WriteTree = {
-            val cu = new CompilationUnit()
-            cu.setPackageDeclaration(pkgDecl)
-            imports.map(cu.addImport)
-            customImports.map(cu.addImport)
-            cu.addImport(commonImport)
-            cu.addImport(dtoComponentsImport)
-            cu.addType(typeDecl)
-            WriteTree(
-              resolveFile(pkgPath)(pkg :+ s"${typeDecl.getNameAsString}.java"),
-              prettyPrintSource(cu)
-            )
-          }
-
-          val clientClasses   = client.map(_.merge).toList
-          val responseClasses = responseDefinitions.collect({ case cd: ClassOrInterfaceDeclaration => cd })
-          (clientClasses ++ responseClasses).map(writeTree)
-        }
+          allImports    = imports ++ customImports :+ commonImport :+ dtoComponentsImport
+          clientClasses = client.map(_.merge).toList
+          trees <- (clientClasses ++ responseDefinitions).traverse(writeClientTree(pkgPath, pkg, pkgDecl, allImports, _))
+        } yield trees
 
       case WriteServer(pkgPath,
                        pkgName,
@@ -279,33 +307,15 @@ object JavaGenerator {
                        frameworkImplicitName,
                        dtoComponents,
                        Server(pkg, extraImports, handlerDefinition, serverDefinitions)) =>
-        def writeClass(pkgDecl: PackageDeclaration, extraImports: List[ImportDeclaration], definition: TypeDeclaration[_]): WriteTree = {
-          val cu = new CompilationUnit()
-          cu.setPackageDeclaration(pkgDecl)
-          extraImports.map(cu.addImport)
-          customImports.map(cu.addImport)
-          cu.addType(definition)
-          WriteTree(
-            resolveFile(pkgPath)(pkg :+ s"${definition.getNameAsString}.java"),
-            prettyPrintSource(cu)
-          )
-        }
-
-        def writeDefinition(pkgDecl: PackageDeclaration, extraImports: List[ImportDeclaration], definition: BodyDeclaration[_]): Target[WriteTree] =
-          definition match {
-            case td: TypeDeclaration[_] => Target.pure(writeClass(pkgDecl, extraImports, td))
-            case other                  => Target.raiseError(s"Class definition must be a TypeDeclaration but it is a ${other.getClass.getName}")
-          }
-
         for {
           pkgDecl <- buildPkgDecl(pkgName ++ pkg)
 
           commonImport        <- safeParseRawImport((pkgName :+ "*").mkString("."))
           dtoComponentsImport <- safeParseRawImport((dtoComponents :+ "*").mkString("."))
-          allExtraImports = extraImports ++ List(commonImport, dtoComponentsImport)
+          allImports = extraImports ++ List(commonImport, dtoComponentsImport) ++ customImports
 
-          handlerTree <- writeDefinition(pkgDecl, allExtraImports, handlerDefinition)
-          serverTrees <- serverDefinitions.traverse(writeDefinition(pkgDecl, allExtraImports, _))
+          handlerTree <- writeServerTree(pkgPath, pkg, pkgDecl, allImports, handlerDefinition)
+          serverTrees <- serverDefinitions.traverse(writeServerTree(pkgPath, pkg, pkgDecl, allImports, _))
         } yield handlerTree +: serverTrees
     }
   }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
@@ -336,19 +336,21 @@ object ScalaGenerator {
                        dtoComponents,
                        Client(pkg, clientName, imports, staticDefns, client, responseDefinitions)) =>
         Target.pure(
-          WriteTree(
-            resolveFile(pkgPath)(pkg :+ s"${clientName}.scala"),
-            source"""
-            package ${buildPkgTerm(pkgName ++ pkg)}
-            import ${buildPkgTerm(List("_root_") ++ pkgName ++ List("Implicits"))}._
-            ..${frameworkImplicitName.map(name => q"import ${buildPkgTerm(List("_root_") ++ pkgName)}.${name}._")}
-            import ${buildPkgTerm(List("_root_") ++ dtoComponents)}._
-            ..${customImports};
-            ..${imports};
-            ${companionForStaticDefns(staticDefns)};
-            ..${client.toList.map(_.merge)};
-            ..${responseDefinitions}
-            """.syntax.getBytes(StandardCharsets.UTF_8)
+          List(
+            WriteTree(
+              resolveFile(pkgPath)(pkg :+ s"${clientName}.scala"),
+              source"""
+              package ${buildPkgTerm(pkgName ++ pkg)}
+              import ${buildPkgTerm(List("_root_") ++ pkgName ++ List("Implicits"))}._
+              ..${frameworkImplicitName.map(name => q"import ${buildPkgTerm(List("_root_") ++ pkgName)}.${name}._")}
+              import ${buildPkgTerm(List("_root_") ++ dtoComponents)}._
+              ..${customImports};
+              ..${imports};
+              ${companionForStaticDefns(staticDefns)};
+              ..${client.toList.map(_.merge)};
+              ..${responseDefinitions}
+              """.syntax.getBytes(StandardCharsets.UTF_8)
+            )
           )
         )
       case WriteServer(pkgPath,

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerm.scala
@@ -96,7 +96,7 @@ case class WriteClient[L <: LA](pkgPath: Path,
                                 frameworkImplicitName: Option[L#TermName],
                                 dtoComponents: List[String],
                                 client: Client[L])
-    extends ScalaTerm[L, WriteTree]
+    extends ScalaTerm[L, List[WriteTree]]
 case class WriteServer[L <: LA](pkgPath: Path,
                                 pkgName: List[String],
                                 customImports: List[L#Import],

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerms.scala
@@ -101,7 +101,7 @@ class ScalaTerms[L <: LA, F[_]](implicit I: InjectK[ScalaTerm[L, ?], F]) {
                   customImports: List[L#Import],
                   frameworkImplicitName: Option[L#TermName],
                   dtoComponents: List[String],
-                  client: Client[L]): Free[F, WriteTree] =
+                  client: Client[L]): Free[F, List[WriteTree]] =
     Free.inject[ScalaTerm[L, ?], F](WriteClient(pkgPath, pkgName, customImports, frameworkImplicitName, dtoComponents, client))
   def writeServer(pkgPath: Path,
                   pkgName: List[String],

--- a/modules/sample-dropwizard/src/test/scala/core/Dropwizard/DropwizardRoundTripTest.scala
+++ b/modules/sample-dropwizard/src/test/scala/core/Dropwizard/DropwizardRoundTripTest.scala
@@ -1,7 +1,7 @@
 package core.Dropwizard
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import examples.client.dropwizard.user.UserClient
+import examples.client.dropwizard.user.{UserClient, GetUserByNameResponse => GetUserByNameClientResponse}
 import examples.server.dropwizard.definitions.User
 import examples.server.dropwizard.user._
 import helpers.MockHelpers._
@@ -73,13 +73,13 @@ class DropwizardRoundTripTest extends FreeSpec with Matchers with Waiters with M
     client.getUserByName(USERNAME).call().whenComplete({ (response, t) =>
       w { t shouldBe null }
       response match {
-        case r: UserClient.GetUserByNameResponse.Ok =>
+        case r: GetUserByNameClientResponse.Ok =>
           w {
             r.getValue.getUsername.get shouldBe USERNAME
             r.getValue.getPassword shouldBe Optional.empty
           }
-        case _: UserClient.GetUserByNameResponse.BadRequest => w { fail("Got BadRequest") }
-        case _: UserClient.GetUserByNameResponse.NotFound => w { fail("Got NotFound") }
+        case _: GetUserByNameClientResponse.BadRequest => w { fail("Got BadRequest") }
+        case _: GetUserByNameClientResponse.NotFound => w { fail("Got NotFound") }
       }
       w.dismiss()
     })


### PR DESCRIPTION
* Allow `WriteClient` to return a `List[WriteTree]` (previously just a single `WriteTree`).
* Emit client response definitions into their own files.
* Sort class members of the client and response definition classes.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowlege that all my contributions will be made under the project's license.
