### PR TITLE
Unify build tool codepaths

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ val exampleCases: List[(java.io.File, String, Boolean, List[String])] = List(
   (sampleResource("issues/issue127.yaml"), "issues.issue127", false, List.empty),
   (sampleResource("issues/issue143.yaml"), "issues.issue143", false, List.empty),
   (sampleResource("issues/issue148.yaml"), "issues.issue148", false, List.empty),
-  (sampleResource("issues/issue164.yaml"), "issues.issue148", false, List.empty),
+  (sampleResource("issues/issue164.yaml"), "issues.issue164", false, List.empty),
   (sampleResource("petstore.json"), "examples", false, List("--import", "support.PositiveLong")),
   (sampleResource("plain.json"), "tests.dtos", false, List.empty),
   (sampleResource("polymorphism.yaml"), "polymorphism", false, List.empty),

--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,7 @@ def exampleArgs(language: String): List[List[String]] = exampleCases
         frameworkSuite <- exampleFrameworkSuites(language)
         (frameworkName, frameworkPackage, kinds) = frameworkSuite
         kind <- kinds
-        tracingFlag = if (tracing) Option("--tracing") else Option.empty[String]
+        tracingFlag = if (tracing && language != "java") Option("--tracing") else Option.empty[String]
       } yield
         (
           List(s"--${kind}") ++

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/CLI.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/CLI.scala
@@ -22,10 +22,7 @@ object CLICommon {
       args.span(arg => LogLevels(arg.stripPrefix("--")).isDefined)
     val level: Option[String] = levels.lastOption.map(_.stripPrefix("--"))
 
-    val coreArgs = for {
-      defaultFramework <- C.getDefaultFramework
-      args             <- C.parseArgs(newArgs, defaultFramework)
-    } yield NonEmptyList.fromList(args)
+    val coreArgs = C.parseArgs(newArgs).map(NonEmptyList.fromList(_))
 
     val result = coreArgs
       .foldMap(interpreter)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/CLI.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/CLI.scala
@@ -22,6 +22,10 @@ object CLICommon {
       args.span(arg => LogLevels(arg.stripPrefix("--")).isDefined)
     val level: Option[String] = levels.lastOption.map(_.stripPrefix("--"))
 
+    // FIXME: The only reason we need the interpreter at all is to call parseArgs on it
+    // This likely means the CLI should _not_ be part of CoreTerms. There's no reason
+    // for it to be in there, as CLI is effectively a bespoke build tool whose unused
+    // code is included into all other build tools.
     val coreArgs = C.parseArgs(newArgs).map(NonEmptyList.fromList(_))
 
     val result = coreArgs

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -161,12 +161,12 @@ object Common {
   }
 
   def runM[L <: LA, F[_]](
-      args: List[Args]
+      args: NonEmptyList[Args]
   )(implicit C: CoreTerms[L, F]): Free[F, NonEmptyList[ReadSwagger[Target[List[WriteTree]]]]] = {
     import C._
 
     for {
-      validated  <- validateArgs(args)
+      validated  <- validateArgs(args.toList)
       writeTrees <- processArgs(validated)
     } yield writeTrees
   }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -161,15 +161,13 @@ object Common {
   }
 
   def runM[L <: LA, F[_]](
-      args: Array[String]
+      args: List[Args]
   )(implicit C: CoreTerms[L, F]): Free[F, NonEmptyList[ReadSwagger[Target[List[WriteTree]]]]] = {
     import C._
 
     for {
-      defaultFramework <- getDefaultFramework
-      parsed           <- parseArgs(args, defaultFramework)
-      args             <- validateArgs(parsed)
-      writeTrees       <- processArgs(args)
+      validated  <- validateArgs(args)
+      writeTrees <- processArgs(validated)
     } yield writeTrees
   }
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -154,7 +154,8 @@ object Common {
     args.traverse(
       arg =>
         for {
-          targetInterpreter <- extractGenerator(arg.context)
+          defaultFramework  <- getDefaultFramework
+          targetInterpreter <- extractGenerator(arg.context, defaultFramework)
           writeFile         <- processArgSet(targetInterpreter)(arg)
         } yield writeFile
     )

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Error.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Error.scala
@@ -8,6 +8,8 @@ case class UnparseableArgument(name: String, message: String) extends Error
 case object NoArgsSpecified                                   extends Error
 case object NoFramework                                       extends Error
 case object PrintHelp                                         extends Error
+case class RuntimeFailure(message: String)                    extends Error
+case class UserError(message: String)                         extends Error
 object Error {
   case class ArgName(value: String) extends AnyVal
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ReadSwagger.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ReadSwagger.scala
@@ -4,6 +4,7 @@ import java.nio.file.Path
 import java.util
 
 import cats._
+import cats.implicits._
 import io.swagger.parser.OpenAPIParser
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.parser.core.models.ParseOptions
@@ -12,22 +13,17 @@ import scala.io.AnsiColor
 
 case class ReadSwagger[T](path: Path, next: OpenAPI => T)
 object ReadSwagger {
-  @deprecated("0.37.1", "Hiding the error result prevents build tools from failing on file read")
-  def unsafeReadSwagger[T: Monoid](rs: ReadSwagger[T]): T =
-    readSwagger(rs)
-      .fold({ err =>
-        println(s"${AnsiColor.RED}${err}${AnsiColor.RESET}")
-        Monoid.empty[T]
-      }, identity)
-
-  def readSwagger[T](rs: ReadSwagger[T]): Either[String, T] =
+  def readSwagger[T](rs: ReadSwagger[Target[T]]): Target[T] =
     if (rs.path.toFile.exists()) {
       val opts = new ParseOptions()
       opts.setResolve(true)
-      Option(new OpenAPIParser().readLocation(rs.path.toAbsolutePath.toString, new util.LinkedList(), opts).getOpenAPI)
-        .map(rs.next)
-        .toRight(s"Spec file ${rs.path} is incorrectly formatted.")
+      CoreTarget
+        .fromOption(
+          Option(new OpenAPIParser().readLocation(rs.path.toAbsolutePath.toString, new util.LinkedList(), opts).getOpenAPI),
+          UserError(s"Spec file ${rs.path} is incorrectly formatted.")
+        )
+        .flatMap(rs.next)
     } else {
-      Left(s"Spec file ${rs.path} does not exist.")
+      CoreTarget.raiseError(UserError(s"Spec file ${rs.path} does not exist."))
     }
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
@@ -219,7 +219,9 @@ object SwaggerUtil {
 
       def log(fmt: Option[String], t: L#Type): L#Type = {
         fmt.foreach { fmt =>
-          println(s"Warning: Deprecated behavior: Unsupported type '$fmt', falling back to $t. Please switch definitions to x-scala-type for custom types")
+          println(
+            s"Warning: Deprecated behavior: Unsupported format '$fmt' for type '${typeName}', falling back to $t. Please switch definitions to x-scala-type for custom types"
+          )
         }
 
         t

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
@@ -15,10 +15,6 @@ import com.twilio.swagger.core.StructuredLogger
 package guardrail {
   case class CodegenDefinitions[L <: LA](clients: List[Client[L]], servers: List[Server[L]], supportDefinitions: List[SupportDefinition[L]])
 
-  sealed trait ErrorKind
-  case object UserError     extends ErrorKind
-  case object InternalError extends ErrorKind
-
   sealed trait LogAbstraction {
     type F[_]
     implicit def A: Applicative[F]
@@ -55,10 +51,10 @@ package guardrail {
     def pure[T](x: T): Target[T]                          = A.pure(x)
     @deprecated("Use raiseError instead", "v0.41.2")
     def error[T](x: String): Target[T]          = raiseError(x)
-    def raiseError[T](x: String): Target[T]     = EitherT.fromEither(Left((x, UserError)))
-    def raiseException[T](x: String): Target[T] = EitherT.fromEither(Left((x, InternalError)))
+    def raiseError[T](x: String): Target[T]     = EitherT.fromEither(Left(UserError(x)))
+    def raiseException[T](x: String): Target[T] = EitherT.fromEither(Left(RuntimeFailure(x)))
     def fromOption[T](x: Option[T], default: => String): Target[T] =
-      EitherT.fromOption(x, (default, UserError))
+      EitherT.fromOption(x, UserError(default))
     def unsafeExtract[T](x: Target[T]): T =
       x.valueOr({ err =>
           throw new Exception(err.toString)
@@ -103,7 +99,7 @@ package object guardrail {
   type CodegenApplication[L <: LA, T] = EitherK[ScalaTerm[L, ?], Parser[L, ?], T]
 
   type Logger[T]     = IndexedStateT[Id, StructuredLogger, StructuredLogger, T]
-  type Target[A]     = EitherT[Logger, (String, ErrorKind), A]
+  type Target[A]     = EitherT[Logger, Error, A]
   type CoreTarget[A] = EitherT[Logger, Error, A]
 
   // Likely can be removed in future versions of scala or cats? -Ypartial-unification seems to get confused here -- possibly higher arity issues?

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/CoreTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/CoreTerm.scala
@@ -7,8 +7,8 @@ import cats.data.NonEmptyList
 import com.twilio.guardrail.languages.LA
 
 sealed trait CoreTerm[L <: LA, T]
-case class GetDefaultFramework[L <: LA]()                                                           extends CoreTerm[L, String]
-case class ExtractGenerator[L <: LA](context: Context)                                              extends CoreTerm[L, CodegenApplication[L, ?] ~> Target]
-case class ParseArgs[L <: LA](args: Array[String], defaultFramework: String)                        extends CoreTerm[L, List[Args]]
+case class GetDefaultFramework[L <: LA]()                                                           extends CoreTerm[L, Option[String]]
+case class ExtractGenerator[L <: LA](context: Context, defaultFramework: Option[String])            extends CoreTerm[L, CodegenApplication[L, ?] ~> Target]
+case class ParseArgs[L <: LA](args: Array[String])                                                  extends CoreTerm[L, List[Args]]
 case class ValidateArgs[L <: LA](parsed: List[Args])                                                extends CoreTerm[L, NonEmptyList[Args]]
 case class ProcessArgSet[L <: LA](targetInterpreter: CodegenApplication[L, ?] ~> Target, arg: Args) extends CoreTerm[L, ReadSwagger[Target[List[WriteTree]]]]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/CoreTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/CoreTerms.scala
@@ -8,12 +8,12 @@ import cats.free.Free
 import com.twilio.guardrail.languages.LA
 
 class CoreTerms[L <: LA, F[_]](implicit I: InjectK[CoreTerm[L, ?], F]) {
-  def getDefaultFramework: Free[F, String] =
+  def getDefaultFramework: Free[F, Option[String]] =
     Free.inject[CoreTerm[L, ?], F](GetDefaultFramework())
-  def extractGenerator(context: Context): Free[F, CodegenApplication[L, ?] ~> Target] =
-    Free.inject[CoreTerm[L, ?], F](ExtractGenerator(context))
-  def parseArgs(args: Array[String], defaultFramework: String): Free[F, List[Args]] =
-    Free.inject[CoreTerm[L, ?], F](ParseArgs(args, defaultFramework))
+  def extractGenerator(context: Context, defaultFramework: Option[String]): Free[F, CodegenApplication[L, ?] ~> Target] =
+    Free.inject[CoreTerm[L, ?], F](ExtractGenerator(context, defaultFramework))
+  def parseArgs(args: Array[String]): Free[F, List[Args]] =
+    Free.inject[CoreTerm[L, ?], F](ParseArgs(args))
   def validateArgs(parsed: List[Args]): Free[F, NonEmptyList[Args]] =
     Free.inject[CoreTerm[L, ?], F](ValidateArgs(parsed))
   def processArgSet(targetInterpreter: CodegenApplication[L, ?] ~> Target)(args: Args): Free[F, ReadSwagger[Target[List[WriteTree]]]] =

--- a/modules/sample/src/main/resources/petstore.json
+++ b/modules/sample/src/main/resources/petstore.json
@@ -514,7 +514,7 @@
           {
             "name": "custom-optional-value",
             "in": "formData",
-            "type": "number",
+            "type": "integer",
             "format": "int64",
             "x-scala-type": "PositiveLong"
           }


### PR DESCRIPTION
- Combine `Target` and `CoreTarget`, at least in structure initially
- Unify the three different kinds of log handling
- Consolidate common build idioms from different build tooling into a set of reusable functions
- Using `NonEmptyList` to represent argument lists for different languages

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowlege that all my contributions will be made under the project's license.
