### PR TITLE
DW responses back in handler

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
@@ -66,7 +66,7 @@ object ServerGenerator {
             }
             (responseDefinitions, serverOperations) = responseServerPair.unzip
             renderedRoutes   <- generateRoutes(context.tracing, resourceName, basePath, serverOperations, protocolElems)
-            handlerSrc       <- renderHandler(handlerName, renderedRoutes.methodSigs, renderedRoutes.handlerDefinitions)
+            handlerSrc       <- renderHandler(handlerName, renderedRoutes.methodSigs, renderedRoutes.handlerDefinitions, responseDefinitions.flatten)
             extraRouteParams <- getExtraRouteParams(context.tracing)
             classSrc <- renderClass(
               resourceName,

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
@@ -140,7 +140,7 @@ object AkkaHttpServerGenerator {
           )
         }
 
-      case RenderHandler(handlerName, methodSigs, handlerDefinitions) =>
+      case RenderHandler(handlerName, methodSigs, handlerDefinitions, responseDefinitions) =>
         for {
           _ <- Target.log.debug("AkkaHttpServerGenerator", "server")(s"renderHandler(${handlerName}, ${methodSigs}")
         } yield q"""

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/EndpointsServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/EndpointsServerGenerator.scala
@@ -11,7 +11,7 @@ object EndpointsServerGenerator {
       case GenerateResponseDefinitions(operationId, responses, protocolElems)                                                                 => ???
       case BuildTracingFields(operation, resourceName, tracing)                                                                               => ???
       case GenerateRoutes(tracing, resourceName, basePath, routes, protocolElems)                                                             => ???
-      case RenderHandler(handlerName, methodSigs, handlerDefinitions)                                                                         => ???
+      case RenderHandler(handlerName, methodSigs, handlerDefinitions, responseDefinitions)                                                    => ???
       case GetExtraRouteParams(tracing)                                                                                                       => ???
       case GenerateSupportDefinitions(tracing)                                                                                                => ???
       case RenderClass(resourceName, handlerName, annotations, combinedRouteTerms, extraRouteParams, responseDefinitions, supportDefinitions) => ???

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
@@ -68,7 +68,7 @@ object Http4sServerGenerator {
           )
         }
 
-      case RenderHandler(handlerName, methodSigs, handlerDefinitions) =>
+      case RenderHandler(handlerName, methodSigs, handlerDefinitions, responseDefinitions) =>
         for {
           _ <- Target.log.debug("Http4sServerGenerator", "server")(s"renderHandler(${handlerName}, ${methodSigs}")
         } yield q"""

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
@@ -545,7 +545,7 @@ object DropwizardServerGenerator {
           safeParseSimpleName(handlerName) >>
           Target.pure(doRenderClass(className, classAnnotations, supportDefinitions, combinedRouteTerms) +: responseDefinitions)
 
-      case RenderHandler(handlerName, methodSigs, handlerDefinitions) =>
+      case RenderHandler(handlerName, methodSigs, handlerDefinitions, responseDefinitions) =>
         val handlerClass = new ClassOrInterfaceDeclaration(util.EnumSet.of(PUBLIC), true, handlerName)
         methodSigs.foreach(handlerClass.addMember)
         Target.pure(handlerClass)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
@@ -350,7 +350,7 @@ object DropwizardServerGenerator {
                   new Parameter(util.EnumSet.of(FINAL), ASYNC_RESPONSE_TYPE, new SimpleName("asyncResponse")).addMarkerAnnotation("Suspended")
                 )
 
-                val responseName = s"${operationId.capitalize}Response"
+                val responseName = s"${handlerName}.${operationId.capitalize}Response"
                 val responseType = JavaParser.parseClassOrInterfaceType(responseName)
 
                 val whenCompleteLambda = new LambdaExpr(
@@ -543,11 +543,11 @@ object DropwizardServerGenerator {
       case RenderClass(className, handlerName, classAnnotations, combinedRouteTerms, extraRouteParams, responseDefinitions, supportDefinitions) =>
         safeParseSimpleName(className) >>
           safeParseSimpleName(handlerName) >>
-          Target.pure(doRenderClass(className, classAnnotations, supportDefinitions, combinedRouteTerms) +: responseDefinitions)
+          Target.pure(doRenderClass(className, classAnnotations, supportDefinitions, combinedRouteTerms) :: Nil)
 
       case RenderHandler(handlerName, methodSigs, handlerDefinitions, responseDefinitions) =>
         val handlerClass = new ClassOrInterfaceDeclaration(util.EnumSet.of(PUBLIC), true, handlerName)
-        methodSigs.foreach(handlerClass.addMember)
+        sortDefinitions(methodSigs ++ responseDefinitions).foreach(handlerClass.addMember)
         Target.pure(handlerClass)
     }
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerm.scala
@@ -27,6 +27,9 @@ case class RenderClass[L <: LA](className: String,
                                 responseDefinitions: List[L#Definition],
                                 supportDefinitions: List[L#Definition])
     extends ServerTerm[L, List[L#Definition]]
-case class RenderHandler[L <: LA](handlerName: String, methodSigs: List[L#MethodDeclaration], handlerDefinitions: List[L#Statement])
+case class RenderHandler[L <: LA](handlerName: String,
+                                  methodSigs: List[L#MethodDeclaration],
+                                  handlerDefinitions: List[L#Statement],
+                                  responseDefinitions: List[L#Definition])
     extends ServerTerm[L, L#Definition]
 case class GetExtraImports[L <: LA](tracing: Boolean) extends ServerTerm[L, List[L#Import]]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerms.scala
@@ -34,8 +34,11 @@ class ServerTerms[L <: LA, F[_]](implicit I: InjectK[ServerTerm[L, ?], F]) {
     Free.inject[ServerTerm[L, ?], F](
       RenderClass(resourceName, handlerName, annotations, combinedRouteTerms, extraRouteParams, responseDefinitions, supportDefinitions)
     )
-  def renderHandler(handlerName: String, methodSigs: List[L#MethodDeclaration], handlerDefinitions: List[L#Statement]): Free[F, L#Definition] =
-    Free.inject[ServerTerm[L, ?], F](RenderHandler(handlerName, methodSigs, handlerDefinitions))
+  def renderHandler(handlerName: String,
+                    methodSigs: List[L#MethodDeclaration],
+                    handlerDefinitions: List[L#Statement],
+                    responseDefinitions: List[L#Definition]): Free[F, L#Definition] =
+    Free.inject[ServerTerm[L, ?], F](RenderHandler(handlerName, methodSigs, handlerDefinitions, responseDefinitions))
   def getExtraImports(tracing: Boolean): Free[F, List[L#Import]] =
     Free.inject[ServerTerm[L, ?], F](GetExtraImports(tracing))
 }

--- a/modules/sample-dropwizard/src/test/java/core/Dropwizard/DropwizardResourceTest.java
+++ b/modules/sample-dropwizard/src/test/java/core/Dropwizard/DropwizardResourceTest.java
@@ -1,10 +1,10 @@
 package core.Dropwizard;
 
 import examples.server.dropwizard.definitions.User;
-import examples.server.dropwizard.user.CreateUserResponse;
-import examples.server.dropwizard.user.GetUserByNameResponse;
-import examples.server.dropwizard.user.LoginUserResponse;
 import examples.server.dropwizard.user.UserHandler;
+import examples.server.dropwizard.user.UserHandler.CreateUserResponse;
+import examples.server.dropwizard.user.UserHandler.GetUserByNameResponse;
+import examples.server.dropwizard.user.UserHandler.LoginUserResponse;
 import examples.server.dropwizard.user.UserResource;
 import io.dropwizard.testing.junit.ResourceTestRule;
 import org.glassfish.jersey.test.grizzly.GrizzlyTestContainerFactory;

--- a/modules/sample-dropwizard/src/test/scala/core/Dropwizard/DropwizardRoundTripTest.scala
+++ b/modules/sample-dropwizard/src/test/scala/core/Dropwizard/DropwizardRoundTripTest.scala
@@ -3,6 +3,7 @@ package core.Dropwizard
 import com.fasterxml.jackson.databind.ObjectMapper
 import examples.client.dropwizard.user.{UserClient, GetUserByNameResponse => GetUserByNameClientResponse}
 import examples.server.dropwizard.definitions.User
+import examples.server.dropwizard.user.UserHandler._
 import examples.server.dropwizard.user._
 import helpers.MockHelpers._
 import java.util


### PR DESCRIPTION
Moves DW response definitions back into the handler interface, as inner classes.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowlege that all my contributions will be made under the project's license.
