### PR TITLE
Move Response/Responses out of Http4sHelper and into common code

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ClientGenerator.scala
@@ -3,12 +3,15 @@ package com.twilio.guardrail
 import cats.data.NonEmptyList
 import cats.free.Free
 import cats.implicits._
-import com.twilio.guardrail.generators.Http4sHelper
 import com.twilio.guardrail.languages.LA
 import com.twilio.guardrail.protocol.terms.client.ClientTerms
+import com.twilio.guardrail.protocol.terms.{ Response, Responses }
 import com.twilio.guardrail.terms.framework.FrameworkTerms
 import com.twilio.guardrail.terms.{ RouteMeta, ScalaTerms, SwaggerTerms }
+import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.media.Schema
 import java.net.URI
+import scala.collection.JavaConverters._
 
 case class Clients[L <: LA](clients: List[Client[L]], supportDefinitions: List[SupportDefinition[L]])
 case class Client[L <: LA](pkg: List[String],
@@ -50,7 +53,7 @@ object ClientGenerator {
               case route @ RouteMeta(path, method, operation) =>
                 for {
                   operationId         <- getOperationId(operation)
-                  responses           <- Http4sHelper.getResponses[L, F](operationId, operation, protocolElems)
+                  responses           <- Responses.getResponses[L, F](operationId, operation, protocolElems)
                   responseDefinitions <- generateResponseDefinitions(operationId, responses, protocolElems)
                   parameters          <- route.getParameters[L, F](protocolElems)
                   clientOp            <- generateClientOperation(className, context.tracing, parameters)(route, operationId, responses)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
@@ -4,8 +4,9 @@ import _root_.io.swagger.v3.oas.models._
 import cats.free.Free
 import cats.instances.all._
 import cats.syntax.all._
-import com.twilio.guardrail.generators.{ Http4sHelper, ScalaParameter }
+import com.twilio.guardrail.generators.ScalaParameter
 import com.twilio.guardrail.languages.LA
+import com.twilio.guardrail.protocol.terms.Responses
 import com.twilio.guardrail.protocol.terms.server.ServerTerms
 import com.twilio.guardrail.shims._
 import com.twilio.guardrail.terms.framework.FrameworkTerms
@@ -57,7 +58,7 @@ object ServerGenerator {
               case route @ RouteMeta(path, method, operation) =>
                 for {
                   operationId         <- getOperationId(operation)
-                  responses           <- Http4sHelper.getResponses(operationId, operation, protocolElems)
+                  responses           <- Responses.getResponses(operationId, operation, protocolElems)
                   responseDefinitions <- generateResponseDefinitions(operationId, responses, protocolElems)
                   parameters          <- route.getParameters[L, F](protocolElems)
                   tracingField        <- buildTracingFields(operation, className, context.tracing)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
@@ -15,8 +15,9 @@ import com.twilio.guardrail.terms.{ ScalaTerms, SwaggerTerms }
 import com.twilio.guardrail.terms.framework.FrameworkTerms
 import com.twilio.guardrail.extract.{ Default, VendorExtension, extractFromNames }
 import com.twilio.guardrail.extract.VendorExtension.VendorExtensible._
-import com.twilio.guardrail.generators.{ Responses, ScalaParameter }
+import com.twilio.guardrail.generators.ScalaParameter
 import com.twilio.guardrail.languages.{ JavaLanguage, LA, ScalaLanguage }
+import com.twilio.guardrail.protocol.terms.Responses
 import com.twilio.guardrail.shims._
 import java.util.{ Map => JMap }
 import scala.language.reflectiveCalls

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpClientGenerator.scala
@@ -2,18 +2,17 @@ package com.twilio.guardrail
 package generators
 
 import java.util.Locale
-
 import _root_.io.swagger.v3.oas.models._
 import cats.arrow.FunctionK
 import cats.data.NonEmptyList
 import cats.syntax.flatMap._
 import com.twilio.guardrail.generators.syntax.Scala._
 import com.twilio.guardrail.generators.syntax._
+import com.twilio.guardrail.protocol.terms.Responses
 import com.twilio.guardrail.protocol.terms.client._
 import com.twilio.guardrail.shims._
 import com.twilio.guardrail.terms.RouteMeta
 import com.twilio.guardrail.languages.ScalaLanguage
-
 import scala.collection.JavaConverters._
 import scala.meta._
 import _root_.io.swagger.v3.oas.models.PathItem.HttpMethod

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
@@ -12,10 +12,10 @@ import com.twilio.guardrail.SwaggerUtil
 import com.twilio.guardrail.extract.{ ScalaPackage, ScalaTracingLabel, ServerRawResponse }
 import com.twilio.guardrail.generators.syntax.Scala._
 import com.twilio.guardrail.languages.ScalaLanguage
+import com.twilio.guardrail.protocol.terms.Responses
 import com.twilio.guardrail.protocol.terms.server._
 import com.twilio.guardrail.terms.RouteMeta
 import com.twilio.guardrail.shims._
-
 import scala.collection.JavaConverters._
 import scala.meta._
 import _root_.io.swagger.v3.oas.models.PathItem.HttpMethod

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/EndpointsClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/EndpointsClientGenerator.scala
@@ -2,19 +2,18 @@ package com.twilio.guardrail
 package generators
 
 import java.util.Locale
-
 import _root_.io.swagger.v3.oas.models.PathItem.HttpMethod
 import cats.arrow.FunctionK
 import cats.data.{ Ior, NonEmptyList }
 import cats.implicits._
 import com.twilio.guardrail.generators.syntax.Scala._
 import com.twilio.guardrail.generators.syntax._
+import com.twilio.guardrail.languages.ScalaLanguage
+import com.twilio.guardrail.protocol.terms.Responses
 import com.twilio.guardrail.protocol.terms.client._
 import com.twilio.guardrail.terms.RouteMeta
-import com.twilio.guardrail.languages.ScalaLanguage
 import com.twilio.guardrail.shims._
 import java.net.URI
-
 import scala.collection.JavaConverters._
 import scala.meta._
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sClientGenerator.scala
@@ -12,6 +12,7 @@ import com.twilio.guardrail.extract.ScalaPackage
 import com.twilio.guardrail.generators.syntax.Scala._
 import com.twilio.guardrail.generators.syntax._
 import com.twilio.guardrail.languages.ScalaLanguage
+import com.twilio.guardrail.protocol.terms.Responses
 import com.twilio.guardrail.protocol.terms.client._
 import com.twilio.guardrail.shims._
 import com.twilio.guardrail.terms.RouteMeta

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
@@ -10,6 +10,7 @@ import cats.syntax.traverse._
 import com.twilio.guardrail.extract.{ ScalaPackage, ScalaTracingLabel, ServerRawResponse }
 import com.twilio.guardrail.generators.syntax.Scala._
 import com.twilio.guardrail.languages.ScalaLanguage
+import com.twilio.guardrail.protocol.terms.{ Response, Responses }
 import com.twilio.guardrail.protocol.terms.server._
 import com.twilio.guardrail.shims._
 import com.twilio.guardrail.terms.RouteMeta

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
@@ -11,9 +11,10 @@ import com.github.javaparser.ast.`type`.{ ClassOrInterfaceType, Type, VoidType }
 import com.github.javaparser.ast.body._
 import com.github.javaparser.ast.expr.{ MethodCallExpr, NameExpr, _ }
 import com.github.javaparser.ast.stmt._
-import com.twilio.guardrail.generators.{ Response, ScalaParameter }
+import com.twilio.guardrail.generators.ScalaParameter
 import com.twilio.guardrail.generators.syntax.Java._
 import com.twilio.guardrail.languages.JavaLanguage
+import com.twilio.guardrail.protocol.terms.Response
 import com.twilio.guardrail.protocol.terms.client._
 import com.twilio.guardrail.terms.RouteMeta
 import com.twilio.guardrail.{ RenderedClientOperation, StaticDefns, SupportDefinition, SwaggerUtil, Target }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
@@ -12,10 +12,11 @@ import com.github.javaparser.ast.`type`.{ ClassOrInterfaceType, PrimitiveType, T
 import com.github.javaparser.ast.body._
 import com.github.javaparser.ast.expr._
 import com.github.javaparser.ast.stmt._
-import com.twilio.guardrail.generators.{ Response, ScalaParameters }
+import com.twilio.guardrail.generators.ScalaParameters
 import com.twilio.guardrail.{ ADT, ClassDefinition, EnumDefinition, RandomType, RenderedRoutes, StrictProtocolElems, SupportDefinition, Target }
 import com.twilio.guardrail.generators.syntax.Java._
 import com.twilio.guardrail.languages.JavaLanguage
+import com.twilio.guardrail.protocol.terms.Response
 import com.twilio.guardrail.protocol.terms.server._
 import com.twilio.guardrail.shims.OperationExt
 import com.twilio.guardrail.terms.RouteMeta

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/Responses.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/Responses.scala
@@ -1,0 +1,57 @@
+package com.twilio.guardrail.protocol.terms
+
+import cats.free.Free
+import cats.instances.list._
+import cats.syntax.traverse._
+import com.twilio.guardrail.{ StrictProtocolElems, SwaggerUtil }
+import com.twilio.guardrail.languages.LA
+import com.twilio.guardrail.terms.{ ScalaTerms, SwaggerTerms }
+import com.twilio.guardrail.terms.framework.FrameworkTerms
+import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.media.Schema
+import scala.collection.JavaConverters._
+
+class Response[L <: LA](val statusCodeName: L#TermName, val statusCode: Int, val value: Option[(L#Type, Option[L#Term])]) {
+  override def toString: String = s"Response($statusCodeName, $statusCode, $value)"
+}
+object Response {
+  def unapply[L <: LA](value: Response[L]): Option[(L#TermName, Option[L#Type])] = Some((value.statusCodeName, value.value.map(_._1)))
+}
+
+class Responses[L <: LA](val value: List[Response[L]]) {
+  override def toString: String = s"Responses($value)"
+}
+object Responses {
+  def getResponses[L <: LA, F[_]](operationId: String, operation: Operation, protocolElems: List[StrictProtocolElems[L]])(
+      implicit Fw: FrameworkTerms[L, F],
+      Sc: ScalaTerms[L, F],
+      Sw: SwaggerTerms[L, F]
+  ): Free[F, Responses[L]] = Sw.log.function("getResponses") {
+    import Fw._
+    for {
+      responses <- Sw.getResponses(operationId, operation)
+
+      instances <- responses
+        .foldLeft[List[Free[F, Response[L]]]](List.empty)({
+          case (acc, (key, resp)) =>
+            acc :+ (for {
+              httpCode <- lookupStatusCode(key)
+              (statusCode, statusCodeName) = httpCode
+              valueTypes <- (for {
+                content       <- Option(resp.getContent).toList
+                contentValues <- Option(content.values()).toList.flatMap(_.asScala) // FIXME: values() ignores Content-Types in the keys
+                schema        <- Option[Schema[_]](contentValues.getSchema).toList
+              } yield schema).traverse { prop =>
+                for {
+                  meta     <- SwaggerUtil.propMeta[L, F](prop)
+                  resolved <- SwaggerUtil.ResolvedType.resolve[L, F](meta, protocolElems)
+                  SwaggerUtil.Resolved(baseType, _, baseDefaultValue) = resolved
+                } yield (baseType, baseDefaultValue)
+              }
+            } yield new Response[L](statusCodeName, statusCode, valueTypes.headOption)) // FIXME: headOption
+        })
+        .sequence
+    } yield new Responses[L](instances)
+  }
+
+}

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientTerm.scala
@@ -1,8 +1,9 @@
 package com.twilio.guardrail.protocol.terms.client
 
 import cats.data.NonEmptyList
-import com.twilio.guardrail.generators.{ Responses, ScalaParameters }
+import com.twilio.guardrail.generators.ScalaParameters
 import com.twilio.guardrail.languages.LA
+import com.twilio.guardrail.protocol.terms.Responses
 import com.twilio.guardrail.terms.RouteMeta
 import com.twilio.guardrail.{ RenderedClientOperation, StaticDefns, StrictProtocolElems, SupportDefinition }
 import java.net.URI

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientTerms.scala
@@ -3,8 +3,9 @@ package com.twilio.guardrail.protocol.terms.client
 import cats.InjectK
 import cats.data.NonEmptyList
 import cats.free.Free
-import com.twilio.guardrail.generators.{ Responses, ScalaParameters }
+import com.twilio.guardrail.generators.ScalaParameters
 import com.twilio.guardrail.languages.LA
+import com.twilio.guardrail.protocol.terms.Responses
 import com.twilio.guardrail.terms.RouteMeta
 import com.twilio.guardrail.{ RenderedClientOperation, StaticDefns, StrictProtocolElems, SupportDefinition }
 import java.net.URI

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerm.scala
@@ -1,9 +1,10 @@
 package com.twilio.guardrail.protocol.terms.server
 
+import com.twilio.guardrail.generators.ScalaParameters
 import com.twilio.guardrail.{ RenderedRoutes, StrictProtocolElems, SupportDefinition, TracingField }
 import com.twilio.guardrail.terms.RouteMeta
 import com.twilio.guardrail.languages.LA
-import com.twilio.guardrail.generators.{ Responses, ScalaParameters }
+import com.twilio.guardrail.protocol.terms.{ Response, Responses }
 import io.swagger.v3.oas.models.Operation
 
 sealed trait ServerTerm[L <: LA, T]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerms.scala
@@ -2,10 +2,11 @@ package com.twilio.guardrail.protocol.terms.server
 
 import cats.InjectK
 import cats.free.Free
-import com.twilio.guardrail.{ RenderedRoutes, StrictProtocolElems, SupportDefinition, TracingField }
-import com.twilio.guardrail.generators.{ Responses, ScalaParameters }
-import com.twilio.guardrail.terms.RouteMeta
+import com.twilio.guardrail.generators.ScalaParameters
 import com.twilio.guardrail.languages.LA
+import com.twilio.guardrail.protocol.terms.Responses
+import com.twilio.guardrail.terms.RouteMeta
+import com.twilio.guardrail.{ RenderedRoutes, StrictProtocolElems, SupportDefinition, TracingField }
 import io.swagger.v3.oas.models.Operation
 
 class ServerTerms[L <: LA, F[_]](implicit I: InjectK[ServerTerm[L, ?], F]) {


### PR DESCRIPTION
It's used a bunch of places in the core and in generators and is by no means http4s-specific.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowlege that all my contributions will be made under the project's license.
