### PR TITLE
don't constrain x-scala-type in params to Type.Name.  fixes #214

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,6 +38,7 @@ val exampleCases: List[(java.io.File, String, Boolean, List[String])] = List(
   (sampleResource("issues/issue143.yaml"), "issues.issue143", false, List.empty),
   (sampleResource("issues/issue148.yaml"), "issues.issue148", false, List.empty),
   (sampleResource("issues/issue164.yaml"), "issues.issue164", false, List.empty),
+  (sampleResource("issues/issue215.yaml"), "issues.issue215", false, List.empty),
   (sampleResource("petstore.json"), "examples", false, List("--import", "support.PositiveLong")),
   (sampleResource("plain.json"), "tests.dtos", false, List.empty),
   (sampleResource("polymorphism.yaml"), "polymorphism", false, List.empty),

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
@@ -510,7 +510,7 @@ object SwaggerUtil {
                   case t"Int"    => Right(q"IntNumber")
                   case t"Long"   => Right(q"LongNumber")
                   case t"BigInt" => Right(q"Segment.map(BigInt.apply _)")
-                  case tpe @ Type.Name(_) =>
+                  case tpe =>
                     Right(q"Segment.flatMap(str => io.circe.Json.fromString(str).as[${tpe}].toOption)")
                 }
               } { segment =>
@@ -519,7 +519,7 @@ object SwaggerUtil {
                   case t"BigDecimal" =>
                     Right(q"${segment}.map(BigDecimal.apply _)")
                   case t"BigInt" => Right(q"${segment}.map(BigInt.apply _)")
-                  case tpe @ Type.Name(_) =>
+                  case tpe =>
                     Right(q"${segment}.flatMap(str => io.circe.Json.fromString(str).as[${tpe}].toOption)")
                 }
               }
@@ -550,7 +550,7 @@ object SwaggerUtil {
                   case t"Int"        => Right(p"IntVar(${Pat.Var(paramName)})")
                   case t"Long"       => Right(p"LongVar(${Pat.Var(paramName)})")
                   case t"BigInt"     => Right(p"BigIntVar(${Pat.Var(paramName)})")
-                  case tpe @ Type.Name(_) =>
+                  case tpe =>
                     Right(p"${Term.Name(s"${tpe}Var")}(${Pat.Var(paramName)})")
                 }
               } { _ =>

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
@@ -550,8 +550,13 @@ object SwaggerUtil {
                   case t"Int"        => Right(p"IntVar(${Pat.Var(paramName)})")
                   case t"Long"       => Right(p"LongVar(${Pat.Var(paramName)})")
                   case t"BigInt"     => Right(p"BigIntVar(${Pat.Var(paramName)})")
-                  case tpe =>
+                  case Type.Name(tpe) =>
                     Right(p"${Term.Name(s"${tpe}Var")}(${Pat.Var(paramName)})")
+                  case Type.Select(_, Type.Name(tpe)) =>
+                    Right(p"${Term.Name(s"${tpe}Var")}(${Pat.Var(paramName)})")
+                  case tpe =>
+                    println(s"Error: Unsure how to map ${tpe} into an extractor")
+                    Left(s"Unsure how to map ${tpe} into an extractor")
                 }
               } { _ =>
                 //todo add support for regex segment

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
@@ -549,9 +549,14 @@ object Http4sServerGenerator {
 
     def generatePathParamExtractors(pathArgs: List[ScalaParameter[ScalaLanguage]]): List[Defn] =
       pathArgs
-        .map(_.argType.toString)
+        .map(_.argType)
+        .filterNot(x => List("Int", "Long", "String").contains(x.toString))
+        .flatMap({
+          case Type.Name(tpe)                 => Some(tpe)
+          case Type.Select(_, Type.Name(tpe)) => Some(tpe)
+          case tpe                            => None
+        })
         .distinct
-        .filter(!List("Int", "Long", "String").contains(_))
         .map(tpe => q"""
           object ${Term.Name(s"${tpe}Var")} {
             def unapply(str: String): Option[${Type.Name(tpe)}] = {

--- a/modules/sample/src/main/resources/issues/issue215.yaml
+++ b/modules/sample/src/main/resources/issues/issue215.yaml
@@ -1,0 +1,28 @@
+swagger: '2.0'
+info:
+  title: https://github.com/twilio/guardrail/issues/215
+host: localhost:1234
+schemes:
+- http
+paths:
+  /entity/{bar}:
+    delete:
+      operationId: deleteFoo
+      parameters:
+      - name: bar
+        in: path
+        type: string
+        x-scala-type: _root_.java.lang.String
+      responses:
+        '204':
+          description: No content
+definitions:
+  Foo:
+    type: object
+    discriminator: type
+    required:
+    - name
+    properties:
+      name:
+        type: string
+        x-scala-type: _root_.java.lang.String


### PR DESCRIPTION
<!-- Describe your Pull Request -->

We can use x-scala-type: SomeType in both parameters and definitions. We can also use x-scala-type: some.qualified.Type in definitions -- but not in parameters. Using that in parameters crashes guardrail.

This change relaxes the match that was crashing.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowlege that all my contributions will be made under the project's license.
