### PR TITLE
Issue 218

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,6 +39,7 @@ val exampleCases: List[(java.io.File, String, Boolean, List[String])] = List(
   (sampleResource("issues/issue148.yaml"), "issues.issue148", false, List.empty),
   (sampleResource("issues/issue164.yaml"), "issues.issue164", false, List.empty),
   (sampleResource("issues/issue215.yaml"), "issues.issue215", false, List.empty),
+  (sampleResource("issues/issue218.yaml"), "issues.issue218", false, List.empty),
   (sampleResource("petstore.json"), "examples", false, List("--import", "support.PositiveLong")),
   (sampleResource("plain.json"), "tests.dtos", false, List.empty),
   (sampleResource("polymorphism.yaml"), "polymorphism", false, List.empty),

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -49,8 +49,9 @@ object Common {
         .map(_.flatMap({ x =>
           Option(x.getUrl())
             .map({ x =>
-              val uri = new URI(x.iterateWhileM[Id](_.stripSuffix("/"))(_.endsWith("/")))
-              new URI(uri.getScheme, uri.getUserInfo, uri.getHost, uri.getPort, "", uri.getQuery, uri.getFragment)
+              val uri    = new URI(x.iterateWhileM[Id](_.stripSuffix("/"))(_.endsWith("/")))
+              val scheme = Option(uri.getScheme).orElse(Option(uri.getHost).filterNot(_.isEmpty).map(_ => "http")).getOrElse(null) // Only force a scheme if we have a host, falling back to null as required by URI
+              new URI(scheme, uri.getUserInfo, uri.getHost, uri.getPort, "", uri.getQuery, uri.getFragment)
             })
             .filterNot(_.toString().isEmpty)
         }))

--- a/modules/sample/src/main/resources/issues/issue218.yaml
+++ b/modules/sample/src/main/resources/issues/issue218.yaml
@@ -1,0 +1,11 @@
+swagger: "2.0"
+info:
+  version: "1.0.1"
+basePath: "/v1"
+paths:
+  /foo:
+    get:
+      operationId: "getFoo"
+      responses:
+        200:
+          description: "successful operation"


### PR DESCRIPTION
Resolving #218 

- It seems as though the OpenAPI 3.x to OpenAPI 2.x shim incorrectly handled specification with empty `host` values. Adding a better attempt to backport this functionality.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
