### PR TITLE
Use cats effect Async instead of Effect

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sGenerator.scala
@@ -20,7 +20,8 @@ object Http4sGenerator {
             q"import cats.data.EitherT",
             q"import cats.implicits._",
             q"import cats.effect.IO",
-            q"import cats.effect.Effect",
+            q"import cats.effect.Async",
+            q"import cats.effect.Sync",
             q"import org.http4s.{Status => _, _}",
             q"import org.http4s.circe._",
             q"import org.http4s.client.{Client => Http4sClient}",
@@ -52,7 +53,7 @@ object Http4sGenerator {
 
             type TraceBuilder[F[_]] = String => org.http4s.client.Client[F] => org.http4s.client.Client[F]
 
-            implicit def emptyEntityEncoder[F[_]: Effect]: EntityEncoder[F, EntityBody[Nothing]] = EntityEncoder.emptyEncoder
+            implicit def emptyEntityEncoder[F[_]: Sync]: EntityEncoder[F, EntityBody[Nothing]] = EntityEncoder.emptyEncoder
 
             object DoubleNumber {
               def unapply(value: String): Option[Double] = Try(value.toDouble).toOption

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
@@ -93,7 +93,7 @@ object Http4sServerGenerator {
           _ <- Target.log.debug("Http4sServerGenerator", "server")(s"renderClass(${resourceName}, ${handlerName}, <combinedRouteTerms>, ${extraRouteParams})")
           routesParams = List(param"handler: ${Type.Name(handlerName)}[F]")
         } yield q"""
-          class ${Type.Name(resourceName)}[F[_]](..$extraRouteParams)(implicit E: Effect[F]) extends Http4sDsl[F] {
+          class ${Type.Name(resourceName)}[F[_]](..$extraRouteParams)(implicit F: Async[F]) extends Http4sDsl[F] {
 
             ..${supportDefinitions};
             def routes(..${routesParams}): HttpRoutes[F] = HttpRoutes.of {
@@ -307,7 +307,7 @@ object Http4sServerGenerator {
                   Target.pure(
                     Param(
                       Some(
-                        enumerator"${Pat.Var(Term.Name(s"${arg.argName.value}Option"))} <- multipart.parts.find(_.name.contains(${arg.argName.toLit})).map(_.body.through(utf8Decode).compile.foldMonoid.flatMap(str => E.fromEither(Json.fromString(str).as[$tpe]))).sequence"
+                        enumerator"${Pat.Var(Term.Name(s"${arg.argName.value}Option"))} <- multipart.parts.find(_.name.contains(${arg.argName.toLit})).map(_.body.through(utf8Decode).compile.foldMonoid.flatMap(str => F.fromEither(Json.fromString(str).as[$tpe]))).sequence"
                       ),
                       Some(
                         (
@@ -339,7 +339,7 @@ object Http4sServerGenerator {
                   Target.pure(
                     Param(
                       Some(
-                        enumerator"${Pat.Var(arg.paramName)} <- multipart.parts.filter(_.name.contains(${arg.argName.toLit})).map(_.body.through(utf8Decode).compile.foldMonoid.flatMap(str => E.fromEither(Json.fromString(str).as[$tpe]))).sequence"
+                        enumerator"${Pat.Var(arg.paramName)} <- multipart.parts.filter(_.name.contains(${arg.argName.toLit})).map(_.body.through(utf8Decode).compile.foldMonoid.flatMap(str => F.fromEither(Json.fromString(str).as[$tpe]))).sequence"
                       ),
                       None,
                       arg.paramName
@@ -366,7 +366,7 @@ object Http4sServerGenerator {
                   Target.pure(
                     Param(
                       Some(
-                        enumerator"${Pat.Var(arg.paramName)} <- multipart.parts.filter(_.name.contains(${arg.argName.toLit})).map(_.body.through(utf8Decode).compile.foldMonoid.flatMap(str => E.fromEither(Json.fromString(str).as[$tpe]))).sequence.map(Option(_).filter(_.nonEmpty))"
+                        enumerator"${Pat.Var(arg.paramName)} <- multipart.parts.filter(_.name.contains(${arg.argName.toLit})).map(_.body.through(utf8Decode).compile.foldMonoid.flatMap(str => F.fromEither(Json.fromString(str).as[$tpe]))).sequence.map(Option(_).filter(_.nonEmpty))"
                       ),
                       None,
                       arg.paramName
@@ -393,7 +393,7 @@ object Http4sServerGenerator {
                   Target.pure(
                     Param(
                       Some(
-                        enumerator"${Pat.Var(arg.paramName)} <- multipart.parts.find(_.name.contains(${arg.argName.toLit})).map(_.body.through(utf8Decode).compile.foldMonoid.flatMap(str => E.fromEither(Json.fromString(str).as[$tpe]))).sequence"
+                        enumerator"${Pat.Var(arg.paramName)} <- multipart.parts.find(_.name.contains(${arg.argName.toLit})).map(_.body.through(utf8Decode).compile.foldMonoid.flatMap(str => F.fromEither(Json.fromString(str).as[$tpe]))).sequence"
                       ),
                       None,
                       arg.paramName
@@ -469,7 +469,7 @@ object Http4sServerGenerator {
                 valueType.fold[Case](
                   p"case $responseCompanionTerm.$responseTerm => ${statusCodeName}()"
                 ) { _ =>
-                  p"case $responseCompanionTerm.$responseTerm(value) => ${statusCodeName}(value)(E, ${Term.Name(s"$operationId${statusCodeName}Encoder")})"
+                  p"case $responseCompanionTerm.$responseTerm(value) => ${statusCodeName}(value)(F, ${Term.Name(s"$operationId${statusCodeName}Encoder")})"
                 }
             }
             q"$handlerCall flatMap ${Term.PartialFunction(marshallers)}"

--- a/modules/codegen/src/test/scala/core/issues/Issue165.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue165.scala
@@ -48,7 +48,7 @@ class Issue165 extends FunSuite with Matchers with SwaggerSpecRunner {
       }
     """
     val resource = q"""
-      class StoreResource[F[_]]()(implicit E: Effect[F]) extends Http4sDsl[F] {
+      class StoreResource[F[_]]()(implicit F: Async[F]) extends Http4sDsl[F] {
         def routes(handler: StoreHandler[F]): HttpRoutes[F] = HttpRoutes.of {
           {
             case req @ GET -> Root =>

--- a/modules/codegen/src/test/scala/tests/generators/http4s/BasicTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/http4s/BasicTest.scala
@@ -113,10 +113,10 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
     val cmp = companionForStaticDefns(staticDefns)
 
     val companion = q"""object Client {
-      def apply[F[_]](host: String = "http://localhost:1234")(implicit effect: Effect[F], httpClient: Http4sClient[F]): Client[F] = new Client[F](host = host)(effect = effect, httpClient = httpClient)
-      def httpClient[F[_]](httpClient: Http4sClient[F], host: String = "http://localhost:1234")(implicit effect: Effect[F]): Client[F] = new Client[F](host = host)(effect = effect, httpClient = httpClient)
+      def apply[F[_]](host: String = "http://localhost:1234")(implicit F: Async[F], httpClient: Http4sClient[F]): Client[F] = new Client[F](host = host)(F = F, httpClient = httpClient)
+      def httpClient[F[_]](httpClient: Http4sClient[F], host: String = "http://localhost:1234")(implicit F: Async[F]): Client[F] = new Client[F](host = host)(F = F, httpClient = httpClient)
     }"""
-    val client    = q"""class Client[F[_]](host: String = "http://localhost:1234")(implicit effect: Effect[F], httpClient: Http4sClient[F]) {
+    val client    = q"""class Client[F[_]](host: String = "http://localhost:1234")(implicit F: Async[F], httpClient: Http4sClient[F]) {
       val basePath: String = ""
       val getBazOkDecoder = EntityDecoder[F, String].flatMapR[io.circe.Json] {
         str => Json.fromString(str).as[io.circe.Json].fold(failure => DecodeResult.failure(InvalidMessageBodyFailure(s"Could not decode response: $$str", Some(failure))), DecodeResult.success(_))
@@ -126,9 +126,9 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
         val req = Request[F](method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/bar"), headers = Headers(allHeaders))
         httpClient.fetch(req)({
           case Ok(_) =>
-            effect.pure(GetBarResponse.Ok)
+            F.pure(GetBarResponse.Ok)
           case resp =>
-            effect.raiseError(UnexpectedStatus(resp.status))
+            F.raiseError(UnexpectedStatus(resp.status))
         })
       }
       def getBaz(headers: List[Header] = List.empty): F[GetBazResponse] = {
@@ -138,7 +138,7 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
           case Ok(resp) =>
             getBazOkDecoder.decode(resp, strict = false).fold(throw _, identity).map(GetBazResponse.Ok)
           case resp =>
-            effect.raiseError(UnexpectedStatus(resp.status))
+            F.raiseError(UnexpectedStatus(resp.status))
         })
       }
       def postFoo(headers: List[Header] = List.empty): F[PostFooResponse] = {
@@ -146,9 +146,9 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
         val req = Request[F](method = Method.POST, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders))
         httpClient.fetch(req)({
           case Ok(_) =>
-            effect.pure(PostFooResponse.Ok)
+            F.pure(PostFooResponse.Ok)
           case resp =>
-            effect.raiseError(UnexpectedStatus(resp.status))
+            F.raiseError(UnexpectedStatus(resp.status))
         })
       }
       def getFoo(headers: List[Header] = List.empty): F[GetFooResponse] = {
@@ -156,9 +156,9 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
         val req = Request[F](method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders))
         httpClient.fetch(req)({
           case Ok(_) =>
-            effect.pure(GetFooResponse.Ok)
+            F.pure(GetFooResponse.Ok)
           case resp =>
-            effect.raiseError(UnexpectedStatus(resp.status))
+            F.raiseError(UnexpectedStatus(resp.status))
         })
       }
       def putFoo(headers: List[Header] = List.empty): F[PutFooResponse] = {
@@ -166,9 +166,9 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
         val req = Request[F](method = Method.PUT, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders))
         httpClient.fetch(req)({
           case Ok(_) =>
-            effect.pure(PutFooResponse.Ok)
+            F.pure(PutFooResponse.Ok)
           case resp =>
-            effect.raiseError(UnexpectedStatus(resp.status))
+            F.raiseError(UnexpectedStatus(resp.status))
         })
       }
       def patchFoo(headers: List[Header] = List.empty): F[PatchFooResponse] = {
@@ -176,9 +176,9 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
         val req = Request[F](method = Method.PATCH, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders))
         httpClient.fetch(req)({
           case Ok(_) =>
-            effect.pure(PatchFooResponse.Ok)
+            F.pure(PatchFooResponse.Ok)
           case resp =>
-            effect.raiseError(UnexpectedStatus(resp.status))
+            F.raiseError(UnexpectedStatus(resp.status))
         })
       }
       def deleteFoo(headers: List[Header] = List.empty): F[DeleteFooResponse] = {
@@ -186,9 +186,9 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
         val req = Request[F](method = Method.DELETE, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders))
         httpClient.fetch(req)({
           case Ok(_) =>
-            effect.pure(DeleteFooResponse.Ok)
+            F.pure(DeleteFooResponse.Ok)
           case resp =>
-            effect.raiseError(UnexpectedStatus(resp.status))
+            F.raiseError(UnexpectedStatus(resp.status))
         })
       }
     }"""


### PR DESCRIPTION
Both http4s generated server and client require implicit instance of `Effect[F]`. This seems as way too powerful constraint that limits certain use cases. One example would be `type F[T] = ReaderT[IO, Context, T]`. It does not have instance of `Effect`. If we were to change the requirement from `Effect` to `Async`, it would remove this limitation.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
