### PR TITLE
DW/Jersey java8 time support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,7 @@ val exampleCases: List[(java.io.File, String, Boolean, List[String])] = List(
   (sampleResource("issues/issue164.yaml"), "issues.issue164", false, List.empty),
   (sampleResource("issues/issue215.yaml"), "issues.issue215", false, List.empty),
   (sampleResource("issues/issue218.yaml"), "issues.issue218", false, List.empty),
+  (sampleResource("multipart-form-data.yaml"), "multipartFormData", false, List.empty),
   (sampleResource("petstore.json"), "examples", false, List("--import", "support.PositiveLong")),
   (sampleResource("plain.json"), "tests.dtos", false, List.empty),
   (sampleResource("polymorphism.yaml"), "polymorphism", false, List.empty),
@@ -285,7 +286,7 @@ lazy val dropwizardSample = (project in file("modules/sample-dropwizard"))
     testOptions in Test += Tests.Argument(TestFrameworks.JUnit, "-a", "-v"),
     libraryDependencies ++= Seq(
       "io.dropwizard"              %  "dropwizard-core"        % dropwizardVersion,
-      "org.glassfish.jersey.media" %  "jersey-media-multipart" % jerseyVersion,
+      "io.dropwizard"              %  "dropwizard-forms"       % dropwizardVersion,
       "org.asynchttpclient"        %  "async-http-client"      % ahcVersion,
       "org.scala-lang.modules"     %% "scala-java8-compat"     % "0.9.0"            % Test,
       "org.scalatest"              %% "scalatest"              % scalatestVersion   % Test,

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
@@ -341,7 +341,7 @@ object DropwizardServerGenerator {
                   (parameters.pathParams, "PathParam"),
                   (parameters.headerParams, "HeaderParam"),
                   (parameters.queryStringParams, "QueryParam"),
-                  (parameters.formParams, if (parameters.formParams.exists(_.isFile)) "FormDataParam" else "FormParam")
+                  (parameters.formParams, if (consumes.contains(RouteMeta.MultipartFormData)) "FormDataParam" else "FormParam")
                 ).flatMap({
                   case (params, annotationName) =>
                     params.map(param => addParamAnnotation(param.param, annotationName, param.argName.value))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
@@ -543,6 +543,8 @@ object DropwizardServerGenerator {
           ).traverse(safeParseRawImport)
 
           shower <- SerializationHelpers.showerSupportDef
+
+          jersey <- SerializationHelpers.guardrailJerseySupportDef
         } yield {
           def httpMethodAnnotation(name: String): SupportDefinition[JavaLanguage] = {
             val annotationDecl = new AnnotationDeclaration(util.EnumSet.of(PUBLIC), name)
@@ -557,6 +559,7 @@ object DropwizardServerGenerator {
 
           List(
             shower,
+            jersey,
             httpMethodAnnotation("PATCH"),
             httpMethodAnnotation("TRACE")
           )

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SerializationHelpers.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SerializationHelpers.scala
@@ -89,4 +89,341 @@ object SerializationHelpers {
       }
     """
   )
+
+  def guardrailJerseySupportDef: Target[SupportDefinition[JavaLanguage]] = loadSupportDefinitionFromString(
+    "GuardrailJerseySupport",
+    """
+      import io.dropwizard.setup.Bootstrap;
+      import io.dropwizard.setup.Environment;
+      import org.glassfish.hk2.api.Factory;
+      import org.glassfish.hk2.api.InjectionResolver;
+      import org.glassfish.hk2.api.ServiceLocator;
+      import org.glassfish.hk2.api.TypeLiteral;
+      import org.glassfish.hk2.utilities.binding.AbstractBinder;
+      import org.glassfish.jersey.internal.inject.ExtractorException;
+      import org.glassfish.jersey.server.ParamException;
+      import org.glassfish.jersey.server.internal.inject.AbstractContainerRequestValueFactory;
+      import org.glassfish.jersey.server.internal.inject.AbstractValueFactoryProvider;
+      import org.glassfish.jersey.server.internal.inject.MultivaluedParameterExtractor;
+      import org.glassfish.jersey.server.internal.inject.MultivaluedParameterExtractorProvider;
+      import org.glassfish.jersey.server.internal.inject.ParamInjectionResolver;
+      import org.glassfish.jersey.server.model.Parameter;
+
+      import javax.inject.Inject;
+      import javax.inject.Singleton;
+      import javax.ws.rs.FormParam;
+      import javax.ws.rs.HeaderParam;
+      import javax.ws.rs.ProcessingException;
+      import javax.ws.rs.QueryParam;
+      import javax.ws.rs.WebApplicationException;
+      import javax.ws.rs.core.Form;
+      import javax.ws.rs.core.MultivaluedHashMap;
+      import javax.ws.rs.core.MultivaluedMap;
+      import javax.ws.rs.ext.ParamConverter;
+      import javax.ws.rs.ext.ParamConverterProvider;
+      import java.lang.annotation.Annotation;
+      import java.lang.reflect.Type;
+      import java.time.Duration;
+      import java.time.Instant;
+      import java.time.LocalDate;
+      import java.time.LocalDateTime;
+      import java.time.LocalTime;
+      import java.time.OffsetDateTime;
+      import java.time.OffsetTime;
+      import java.time.ZonedDateTime;
+      import java.time.format.DateTimeFormatter;
+      import java.time.temporal.TemporalAccessor;
+      import java.util.Collections;
+      import java.util.HashMap;
+      import java.util.Map;
+      import java.util.Optional;
+      import java.util.function.Function;
+
+      public class GuardrailJerseySupport {
+          public static class Jsr310 {
+              private static class ParameterExtractor<T> implements MultivaluedParameterExtractor<T> {
+                  private final String name;
+                  private final ParamConverter<T> converter;
+
+                  ParameterExtractor(final String name, final ParamConverter<T> converter) {
+                      this.name = name;
+                      this.converter = converter;
+                  }
+
+                  @Override
+                  public String getName() {
+                      return this.name;
+                  }
+
+                  @Override
+                  public String getDefaultValueString() {
+                      return null;
+                  }
+
+                  @Override
+                  public T extract(final MultivaluedMap<String, String> parameters) {
+                      final Optional<String> value = Optional.ofNullable(parameters.getFirst(getName()));
+                      try {
+                          return value.map(converter::fromString).orElse(null);
+                      } catch (final WebApplicationException | ProcessingException ex) {
+                          throw ex;
+                      } catch (final Exception ex) {
+                          throw new ExtractorException(ex);
+                      }
+                  }
+              }
+
+              private static class ParamFactoryProviders {
+                  private static abstract class BaseParamFactoryProvider extends AbstractValueFactoryProvider {
+                      @Inject
+                      BaseParamFactoryProvider(final MultivaluedParameterExtractorProvider mpep,
+                                               final ServiceLocator locator,
+                                               final Parameter.Source source) {
+                          super(mpep, locator, source);
+                      }
+
+                      @Override
+                      protected Factory<?> createValueFactory(final Parameter parameter) {
+                          return Optional.ofNullable(parameter.getSourceName())
+                                  .filter(name -> !name.isEmpty())
+                                  .flatMap(name -> buildExtractor(parameter.getRawType(), name))
+                                  .map(extractor -> buildFactory(extractor, !parameter.isEncoded()))
+                                  .orElse(null);
+                      }
+
+                      private Optional<MultivaluedParameterExtractor<?>> buildExtractor(final Class<?> cls, final String name) {
+                          return Optional.ofNullable(PARAM_CONVERTERS.get(cls))
+                                  .map(conv -> new ParameterExtractor<>(name, conv));
+                      }
+
+                      protected abstract AbstractContainerRequestValueFactory<?> buildFactory(final MultivaluedParameterExtractor<?> extractor, final boolean decode);
+                  }
+
+                  private static class QueryParamFactoryProvider extends BaseParamFactoryProvider {
+                      protected QueryParamFactoryProvider(MultivaluedParameterExtractorProvider mpep, ServiceLocator locator, Parameter.Source source) {
+                          super(mpep, locator, source);
+                      }
+
+                      @Override
+                      protected AbstractContainerRequestValueFactory<?> buildFactory(final MultivaluedParameterExtractor<?> extractor, final boolean decode) {
+                          return new ValueFactories.QueryParamValueFactory(extractor, decode);
+                      }
+                  }
+
+                  private static class FormParamFactoryProvider extends BaseParamFactoryProvider {
+                      protected FormParamFactoryProvider(MultivaluedParameterExtractorProvider mpep, ServiceLocator locator, Parameter.Source source) {
+                          super(mpep, locator, source);
+                      }
+
+                      @Override
+                      protected AbstractContainerRequestValueFactory<?> buildFactory(final MultivaluedParameterExtractor<?> extractor, final boolean decode) {
+                          return new ValueFactories.FormParamValueFactory(extractor);
+                      }
+                  }
+
+                  private static class HeaderParamFactoryProvider extends BaseParamFactoryProvider {
+                      protected HeaderParamFactoryProvider(MultivaluedParameterExtractorProvider mpep, ServiceLocator locator, Parameter.Source source) {
+                          super(mpep, locator, source);
+                      }
+
+                      @Override
+                      protected AbstractContainerRequestValueFactory<?> buildFactory(final MultivaluedParameterExtractor<?> extractor, final boolean decode) {
+                          return new ValueFactories.HeaderParamValueFactory(extractor);
+                      }
+                  }
+              }
+
+              private static class ValueFactories {
+                  private static class QueryParamValueFactory extends AbstractContainerRequestValueFactory<Object> {
+                      private final MultivaluedParameterExtractor<?> extractor;
+                      private final boolean decode;
+
+                      QueryParamValueFactory(final MultivaluedParameterExtractor<?> extractor, final boolean decode) {
+                          this.extractor = extractor;
+                          this.decode = decode;
+                      }
+
+                      @Override
+                      public Object provide() {
+                          try {
+                              return this.extractor.extract(getContainerRequest().getUriInfo().getQueryParameters(decode));
+                          } catch (final ProcessingException e) {
+                              throw new ParamException.QueryParamException(e.getCause(), this.extractor.getName(), this.extractor.getDefaultValueString());
+                          }
+                      }
+                  }
+
+                  private static class FormParamValueFactory extends AbstractContainerRequestValueFactory<Object> {
+                      private final MultivaluedParameterExtractor<?> extractor;
+
+                      FormParamValueFactory(final MultivaluedParameterExtractor<?> extractor) {
+                          this.extractor = extractor;
+                      }
+
+                      @Override
+                      public Object provide() {
+                          try {
+                              getContainerRequest().bufferEntity();
+                              final Form form = getContainerRequest().readEntity(Form.class);
+                              return extractor.extract(form.asMap());
+                          } catch (final ProcessingException e) {
+                              throw new ParamException.FormParamException(e.getCause(), this.extractor.getName(), this.extractor.getDefaultValueString());
+                          }
+                      }
+                  }
+
+                  private static class HeaderParamValueFactory extends AbstractContainerRequestValueFactory<Object> {
+                      private final MultivaluedParameterExtractor<?> extractor;
+
+                      HeaderParamValueFactory(final MultivaluedParameterExtractor<?> extractor) {
+                          this.extractor = extractor;
+                      }
+
+                      @Override
+                      public Object provide() {
+                          try {
+                              return extractor.extract(getContainerRequest().getHeaders());
+                          } catch (final ProcessingException e) {
+                              throw new ParamException.HeaderParamException(e.getCause(), this.extractor.getName(), this.extractor.getDefaultValueString());
+                          }
+                      }
+                  }
+              }
+
+              private static class ParamInjectionResolvers {
+                  private static class QueryParamInjectionResolver extends ParamInjectionResolver<QueryParam> {
+                      public QueryParamInjectionResolver() {
+                          super(ParamFactoryProviders.QueryParamFactoryProvider.class);
+                      }
+                  }
+
+                  private static class FormParamInjectionResolver extends ParamInjectionResolver<FormParam> {
+                      public FormParamInjectionResolver() {
+                          super(ParamFactoryProviders.FormParamFactoryProvider.class);
+                      }
+                  }
+
+                  private static class HeaderParamInjectionResolver extends ParamInjectionResolver<HeaderParam> {
+                      public HeaderParamInjectionResolver() {
+                          super(ParamFactoryProviders.HeaderParamFactoryProvider.class);
+                      }
+                  }
+              }
+
+              private static class Jsr310ParamConverter<T extends TemporalAccessor> implements ParamConverter<T> {
+                  private final Function<String, T> parser;
+                  private final DateTimeFormatter formatter;
+
+                  Jsr310ParamConverter(final Function<String, T> parser, final DateTimeFormatter formatter) {
+                      this.parser = parser;
+                      this.formatter = formatter;
+                  }
+
+                  @Override
+                  public T fromString(final String value) {
+                      return parser.apply(value);
+                  }
+
+                  @Override
+                  public String toString(final T value) {
+                      return formatter.format(value);
+                  }
+              }
+
+              private static class Jsr310DurationParamConverter implements ParamConverter<Duration> {
+                  @Override
+                  public Duration fromString(final String value) {
+                      return Duration.parse(value);
+                  }
+
+                  @Override
+                  public String toString(final Duration value) {
+                      return value.toString();
+                  }
+              }
+
+              private static final Map<Class<?>, ParamConverter<?>> PARAM_CONVERTERS;
+
+              static {
+                  final Map<Class<?>, ParamConverter<?>> paramConverters = new HashMap<>();
+                  paramConverters.put(Instant.class, new Jsr310ParamConverter<>(
+                          Instant::parse,
+                          DateTimeFormatter.ISO_INSTANT
+                  ));
+                  paramConverters.put(OffsetDateTime.class, new Jsr310ParamConverter<>(
+                          OffsetDateTime::parse,
+                          DateTimeFormatter.ISO_OFFSET_DATE_TIME
+                  ));
+                  paramConverters.put(ZonedDateTime.class, new Jsr310ParamConverter<>(
+                          ZonedDateTime::parse,
+                          DateTimeFormatter.ISO_ZONED_DATE_TIME
+                  ));
+                  paramConverters.put(LocalDateTime.class, new Jsr310ParamConverter<>(
+                          LocalDateTime::parse,
+                          DateTimeFormatter.ISO_LOCAL_DATE_TIME
+                  ));
+                  paramConverters.put(LocalDate.class, new Jsr310ParamConverter<>(
+                          LocalDate::parse,
+                          DateTimeFormatter.ISO_LOCAL_DATE
+                  ));
+                  paramConverters.put(LocalTime.class, new Jsr310ParamConverter<>(
+                          LocalTime::parse,
+                          DateTimeFormatter.ISO_TIME
+                  ));
+                  paramConverters.put(OffsetTime.class, new Jsr310ParamConverter<>(
+                          OffsetTime::parse,
+                          DateTimeFormatter.ISO_OFFSET_TIME
+                  ));
+                  paramConverters.put(Duration.class, new Jsr310DurationParamConverter());
+                  PARAM_CONVERTERS = Collections.unmodifiableMap(paramConverters);
+              }
+
+              private static class ParamConvertersProvider implements ParamConverterProvider {
+                  @Override
+                  @SuppressWarnings("unchecked")
+                  public <T> ParamConverter<T> getConverter(final Class<T> rawType, final Type genericType, final Annotation[] annotations) {
+                      return (ParamConverter<T>) PARAM_CONVERTERS.get(rawType);
+                  }
+              }
+
+              public static class Binder extends AbstractBinder {
+                  @Override
+                  protected void configure() {
+                      bind(ParamInjectionResolvers.QueryParamInjectionResolver.class)
+                              .to(new TypeLiteral<InjectionResolver<QueryParam>>() {
+                              })
+                              .in(Singleton.class);
+
+                      bind(ParamInjectionResolvers.FormParamInjectionResolver.class)
+                              .to(new TypeLiteral<InjectionResolver<FormParam>>() {
+                              })
+                              .in(Singleton.class);
+
+                      bind(ParamInjectionResolvers.HeaderParamInjectionResolver.class)
+                              .to(new TypeLiteral<InjectionResolver<HeaderParam>>() {
+                              })
+                              .in(Singleton.class);
+
+                      bind(ParamConvertersProvider.class)
+                              .to(ParamConverterProvider.class)
+                              .in(Singleton.class);
+                  }
+              }
+
+              public static class Bundle implements io.dropwizard.Bundle {
+                  @Override
+                  public void initialize(final Bootstrap<?> bootstrap) {
+                  }
+
+                  @Override
+                  public void run(final Environment environment) {
+                      environment.jersey().register(new Binder());
+                  }
+              }
+          }
+
+          private GuardrailJerseySupport() {}
+      }
+    """
+  )
 }

--- a/modules/sample-dropwizard/src/test/java/core/Dropwizard/DropwizardMultiPartTest.java
+++ b/modules/sample-dropwizard/src/test/java/core/Dropwizard/DropwizardMultiPartTest.java
@@ -1,5 +1,6 @@
 package core.Dropwizard;
 
+import helpers.JerseyTestHelpers;
 import io.dropwizard.testing.junit.ResourceTestRule;
 import multipartFormData.server.dropwizard.GuardrailJerseySupport;
 import multipartFormData.server.dropwizard.definitions.Foo;
@@ -21,6 +22,10 @@ import java.util.concurrent.CompletionStage;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class DropwizardMultiPartTest {
+    static {
+        JerseyTestHelpers.setRandomJerseyTestContainerPort();
+    }
+
     private static final FooHandler fooHandler = new FooHandler() {
         @Override
         public CompletionStage<DoFooResponse> doFoo(long id, OffsetDateTime date, Optional<OffsetDateTime> optionalDate) {

--- a/modules/sample-dropwizard/src/test/java/core/Dropwizard/DropwizardMultiPartTest.java
+++ b/modules/sample-dropwizard/src/test/java/core/Dropwizard/DropwizardMultiPartTest.java
@@ -1,0 +1,58 @@
+package core.Dropwizard;
+
+import io.dropwizard.testing.junit.ResourceTestRule;
+import multipartFormData.server.dropwizard.GuardrailJerseySupport;
+import multipartFormData.server.dropwizard.definitions.Foo;
+import multipartFormData.server.dropwizard.foo.FooHandler;
+import multipartFormData.server.dropwizard.foo.FooResource;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.glassfish.jersey.media.multipart.MultiPartFeature;
+import org.glassfish.jersey.test.grizzly.GrizzlyTestContainerFactory;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import javax.ws.rs.client.Entity;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DropwizardMultiPartTest {
+    private static final FooHandler fooHandler = new FooHandler() {
+        @Override
+        public CompletionStage<DoFooResponse> doFoo(long id, OffsetDateTime date, Optional<OffsetDateTime> optionalDate) {
+            final Foo.Builder builder = Foo.builder(id, date);
+            optionalDate.ifPresent(builder::withOptionalDate);
+            return CompletableFuture.completedFuture(FooHandler.DoFooResponse.Created(builder.build()));
+        }
+    };
+
+    @ClassRule
+    public static final ResourceTestRule resources = ResourceTestRule.builder()
+            .setTestContainerFactory(new GrizzlyTestContainerFactory())
+            .addProvider(new MultiPartFeature())
+            .addProvider(new GuardrailJerseySupport.Jsr310.Binder())
+            .addResource(new FooResource(fooHandler))
+            .build();
+
+    @Test
+    public void testJava8TimeMultiPartFormData() {
+        final OffsetDateTime now = OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC);
+        final FormDataMultiPart multiPart = new FormDataMultiPart()
+                .field("id", "42")
+                .field("date", now.toString())
+                .field("optional_date", now.toString());
+        final Foo response = resources
+                .target("/foo")
+                .register(new MultiPartFeature())
+                .request()
+                .post(Entity.entity(multiPart, multiPart.getMediaType()))
+                .readEntity(Foo.class);
+        assertThat(response.getId()).isEqualTo(42);
+        assertThat(response.getDate()).isEqualTo(now);
+        assertThat(response.getOptionalDate().get()).isEqualTo(now);
+    }
+}

--- a/modules/sample-dropwizard/src/test/java/core/Dropwizard/DropwizardResourceTest.java
+++ b/modules/sample-dropwizard/src/test/java/core/Dropwizard/DropwizardResourceTest.java
@@ -6,6 +6,7 @@ import examples.server.dropwizard.user.UserHandler.CreateUserResponse;
 import examples.server.dropwizard.user.UserHandler.GetUserByNameResponse;
 import examples.server.dropwizard.user.UserHandler.LoginUserResponse;
 import examples.server.dropwizard.user.UserResource;
+import helpers.JerseyTestHelpers;
 import io.dropwizard.testing.junit.ResourceTestRule;
 import org.glassfish.jersey.test.grizzly.GrizzlyTestContainerFactory;
 import org.junit.Before;
@@ -25,6 +26,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class DropwizardResourceTest {
+    static {
+        JerseyTestHelpers.setRandomJerseyTestContainerPort();
+    }
+
     private static final String USERNAME = "foobar";
     private static final String PASSWORD = "sekrit";
     private static final String TOKEN = "abc123";

--- a/modules/sample-dropwizard/src/test/java/helpers/JerseyTestHelpers.java
+++ b/modules/sample-dropwizard/src/test/java/helpers/JerseyTestHelpers.java
@@ -1,0 +1,41 @@
+package helpers;
+
+import org.glassfish.jersey.test.TestProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.util.Random;
+
+public abstract class JerseyTestHelpers {
+    private static final Logger logger = LoggerFactory.getLogger(JerseyTestHelpers.class);
+    private static final Random random = new Random();
+
+    public static void setRandomJerseyTestContainerPort() {
+        // Default container port is 9998, which isn't always available.  This is racy, of course, but
+        // there's no way to tell Jersey to use a random port and to retry on other ports if it's in use.
+        int attemptsLeft = 100;
+        while (attemptsLeft > 0) {
+            final int port = random.nextInt(20000) + 20000;
+            try {
+                final ServerSocket socket = new ServerSocket();
+                socket.setReuseAddress(true);
+                socket.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), port));
+                socket.close();
+                System.setProperty(TestProperties.CONTAINER_PORT, String.valueOf(port));
+                logger.info("Selected port {} for the Jersey test container", port);
+                return;
+            } catch (final IOException e) {
+                attemptsLeft -= 1;
+            }
+        }
+
+        throw new IllegalStateException("Failed to find unusued random port for the Jersey test container");
+    }
+
+    private JerseyTestHelpers() {}
+}
+

--- a/modules/sample/src/main/resources/multipart-form-data.yaml
+++ b/modules/sample/src/main/resources/multipart-form-data.yaml
@@ -1,0 +1,58 @@
+openapi: 3.0.2
+info:
+  title: Whatever
+  version: 1.0.0
+servers:
+  - url: http://localhost:1234
+paths:
+  /foo:
+    post:
+      operationId: doFoo
+      x-scala-package: foo
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              # Including `type` causes us to emit the three form parameters as expected,
+              # but also a fourth body parameter of an uspecified JSON object type.  Not
+              # sure if this is a problem with the parser, or a problem with guardrail,
+              # or if you really are just supposed to leave out `type` here, despite the
+              # examples on the OpenAPI website including it.
+              # type: object
+              required:
+                - id
+                - date
+              properties:
+                id:
+                  type: integer
+                  format: int64
+                date:
+                  type: string
+                  format: date-time
+                optional_date:
+                  type: string
+                  format: date-time
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Foo'
+components:
+  schemas:
+    Foo:
+      type: object
+      required:
+        - id
+        - date
+      properties:
+        id:
+          type: integer
+          format: int64
+        date:
+          type: string
+          format: date-time
+        optional_date:
+          type: string
+          format: date-time


### PR DESCRIPTION
Adds a Jersey binder to allow using the java8/jsr310 datetime classes (`OffsetDateTime`, `LocalDate`, etc.) in DW server method parameters.

Unfortunately this requires the user to add code to their server initialization to register the binder.  Will add docs around that when I write the full Java docs.

Also fixes a small bug where if an operation was defined to consume multipart/form-data, but there were no form parameters of type `File`, the server generator would incorrectly use the `@FormParam` annotation for parameters rather than `@FormDataParam`.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
