### PR TITLE
Adding support for too many arguments

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,7 @@ val exampleCases: List[(java.io.File, String, Boolean, List[String])] = List(
   (sampleResource("custom-header-type.yaml"), "tests.customTypes.customHeader", false, List.empty),
   (sampleResource("edgecases/defaults.yaml"), "edgecases.defaults", false, List.empty),
   (sampleResource("formData.yaml"), "form", false, List.empty),
+  (sampleResource("issues/issue45.yaml"), "issues.issue45", false, List.empty),
   (sampleResource("issues/issue121.yaml"), "issues.issue121", false, List.empty),
   (sampleResource("issues/issue127.yaml"), "issues.issue127", false, List.empty),
   (sampleResource("issues/issue143.yaml"), "issues.issue143", false, List.empty),

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
@@ -603,7 +603,7 @@ object SwaggerUtil {
             throw new UnsupportedOperationException
         )
 
-    def generateUrlAkkaPathExtractors(path: String, pathArgs: List[ScalaParameter[ScalaLanguage]]): Target[Term] = {
+    def generateUrlAkkaPathExtractors(path: String, pathArgs: List[ScalaParameter[ScalaLanguage]]): Target[(Term, List[Term.Name])] = {
       import akkaExtractor._
       for {
         partsQS <- runParse(path, pathArgs)
@@ -624,7 +624,8 @@ object SwaggerUtil {
         result = queryParams.fold(trailingSlashed) { qs =>
           q"${trailingSlashed} & ${qs}"
         }
-      } yield result
+      } yield
+        (result, bindings) // FIXME: The path matching term here can still produce directives greater than 22 parameters long. A strategy for handling this is to separate the matchers into separate extractors as well as chunking the bindings into a proper List[List[Term.Name]].
     }
 
     def generateUrlHttp4sPathExtractors(path: String, pathArgs: List[ScalaParameter[ScalaLanguage]]): Target[(Pat, Option[Pat])] = {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
@@ -1,6 +1,6 @@
 package com.twilio.guardrail
 
-import cats.data.EitherT
+import cats.data.{ EitherT, NonEmptyList }
 import io.swagger.v3.oas.models._
 import io.swagger.v3.oas.models.PathItem._
 import io.swagger.v3.oas.models.media._
@@ -603,29 +603,34 @@ object SwaggerUtil {
             throw new UnsupportedOperationException
         )
 
-    def generateUrlAkkaPathExtractors(path: String, pathArgs: List[ScalaParameter[ScalaLanguage]]): Target[(Term, List[Term.Name])] = {
+    def generateUrlAkkaPathExtractors(path: String, pathArgs: List[ScalaParameter[ScalaLanguage]]): Target[NonEmptyList[(Term, List[Term.Name])]] = {
       import akkaExtractor._
       for {
         partsQS <- runParse(path, pathArgs)
         (parts, (trailingSlash, queryParams)) = partsQS
-        (directive, bindings) = parts
-          .foldLeft[(Term, List[Term.Name])]((q"pathEnd", List.empty))({
-            case ((q"pathEnd   ", bindings), (termName, b)) =>
-              (q"path(${b}       )", bindings ++ termName)
-            case ((q"path(${a })", bindings), (termName, c)) =>
-              (q"path(${a} / ${c})", bindings ++ termName)
+        allPairs = parts
+          .foldLeft[NonEmptyList[(Term, List[Term.Name])]](NonEmptyList.one((q"pathEnd", List.empty)))({
+            case (NonEmptyList((q"pathEnd   ", bindings), xs), (termName, b)) =>
+              NonEmptyList((q"path(${b}       )", bindings ++ termName), xs)
+            case (NonEmptyList((q"path(${a })", bindings), xs), (termName, c)) =>
+              val newBindings = bindings ++ termName
+              if (newBindings.length < 22) {
+                NonEmptyList((q"path(${a} / ${c})", newBindings), xs)
+              } else {
+                NonEmptyList((q"pathEnd", List.empty), (q"pathPrefix(${a} / ${c})", newBindings) :: xs)
+              }
           })
         trailingSlashed = if (trailingSlash) {
-          directive match {
-            case q"path(${a })" => q"pathPrefix(${a}) & pathEndOrSingleSlash"
-            case q"pathEnd"     => q"pathEndOrSingleSlash"
+          allPairs match {
+            case NonEmptyList((q"path(${a })", bindings), xs) => NonEmptyList((q"pathPrefix(${a}) & pathEndOrSingleSlash", bindings), xs)
+            case NonEmptyList((q"pathEnd", bindings), xs)     => NonEmptyList((q"pathEndOrSingleSlash", bindings), xs)
           }
-        } else directive
+        } else allPairs
         result = queryParams.fold(trailingSlashed) { qs =>
-          q"${trailingSlashed} & ${qs}"
+          val NonEmptyList((directives, bindings), xs) = trailingSlashed
+          NonEmptyList((q"${directives} & ${qs}", bindings), xs)
         }
-      } yield
-        (result, bindings) // FIXME: The path matching term here can still produce directives greater than 22 parameters long. A strategy for handling this is to separate the matchers into separate extractors as well as chunking the bindings into a proper List[List[Term.Name]].
+      } yield result.reverse
     }
 
     def generateUrlHttp4sPathExtractors(path: String, pathArgs: List[ScalaParameter[ScalaLanguage]]): Target[(Pat, Option[Pat])] = {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
@@ -622,13 +622,14 @@ object AkkaHttpServerGenerator {
                     Term.Apply(directive, List(Term.Function(xs.map(x => Term.Param(List.empty, x, None, None)), next)))
               }
             }
-          val pathMatcher    = bindParams(Some(q"${akkaMethod} & ${akkaPath}"), consumedPathParams)
+          val methodMatcher  = bindParams(Some(akkaMethod), List.empty)
+          val pathMatcher    = bindParams(Some(akkaPath), consumedPathParams)
           val qsMatcher      = bindParams(akkaQs, qsArgs.map(_.paramName))
           val headerMatcher  = bindParams(akkaHeaders, headerArgs.map(_.paramName))
           val tracingMatcher = bindParams(tracingFields.map(_.term), tracingFields.map(_.param.paramName).toList)
           val bodyMatcher    = bindParams(Some(entityProcessor), (bodyArgs ++ formArgs).toList.map(_.paramName))
 
-          pathMatcher compose qsMatcher compose headerMatcher compose tracingMatcher compose bodyMatcher
+          methodMatcher compose pathMatcher compose qsMatcher compose headerMatcher compose tracingMatcher compose bodyMatcher
         }
         val handlerCallArgs: List[List[Term.Name]] = List(List(responseCompanionTerm)) ++ orderedParameters.map(_.map(_.paramName))
         val fullRoute: Term                        = fullRouteMatcher(q"complete(handler.${Term.Name(operationId)}(...${handlerCallArgs}))")

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
@@ -163,7 +163,12 @@ object AkkaHttpServerGenerator {
           routesParams = List(param"handler: ${Type.Name(handlerName)}") ++ extraRouteParams
         } yield List(q"""
           object ${Term.Name(resourceName)} {
-            def discardEntity(implicit mat: akka.stream.Materializer): Directive0 = extractRequest.flatMap({ req => req.discardEntityBytes().future; Directive.Empty })
+            def discardEntity: Directive0 = extractMaterializer.flatMap { implicit mat =>
+              extractRequest.flatMap { req =>
+                req.discardEntityBytes().future
+                Directive.Empty
+              }
+            }
 
             ..${supportDefinitions};
             def routes(..${routesParams})(implicit mat: akka.stream.Materializer): Route = {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
@@ -629,7 +629,7 @@ object AkkaHttpServerGenerator {
           val tracingMatcher = bindParams(tracingFields.map(_.term), tracingFields.map(_.param.paramName).toList)
           val bodyMatcher    = bindParams(Some(entityProcessor), (bodyArgs ++ formArgs).toList.map(_.paramName))
 
-          pathMatcher compose qsMatcher compose bodyMatcher compose headerMatcher compose tracingMatcher
+          pathMatcher compose qsMatcher compose headerMatcher compose tracingMatcher compose bodyMatcher
         }
         val handlerCallArgs: List[List[Term.Name]] = List(List(responseCompanionTerm)) ++ orderedParameters.map(_.map(_.paramName))
         val fullRoute: Term                        = fullRouteMatcher(q"complete(handler.${Term.Name(operationId)}(...${handlerCallArgs}))")

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
@@ -634,7 +634,7 @@ object AkkaHttpServerGenerator {
           methodMatcher compose pathMatcher compose qsMatcher compose headerMatcher compose tracingMatcher compose bodyMatcher
         }
         val handlerCallArgs: List[List[Term.Name]] = List(List(responseCompanionTerm)) ++ orderedParameters.map(_.map(_.paramName))
-        val fullRoute: Term                        = fullRouteMatcher(q"complete(handler.${Term.Name(operationId)}(...${handlerCallArgs}))")
+        val fullRoute: Term                        = Term.Block(List(fullRouteMatcher(q"complete(handler.${Term.Name(operationId)}(...${handlerCallArgs}))")))
 
         val respond: List[List[Term.Param]] = List(List(param"respond: ${Term.Name(resourceName)}.${responseCompanionTerm}.type"))
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
@@ -3,10 +3,7 @@ package generators
 
 import cats.arrow.FunctionK
 import cats.data.NonEmptyList
-import cats.instances.all._
-import cats.syntax.flatMap._
-import cats.syntax.functor._
-import cats.syntax.traverse._
+import cats.implicits._
 import com.twilio.guardrail.extract.{ ScalaPackage, ScalaTracingLabel, ServerRawResponse }
 import com.twilio.guardrail.generators.syntax.Scala._
 import com.twilio.guardrail.languages.ScalaLanguage
@@ -475,19 +472,32 @@ object Http4sServerGenerator {
             q"$handlerCall flatMap ${Term.PartialFunction(marshallers)}"
           }(_ => handlerCall)
         val matchers = (http4sForm ++ http4sHeaders).flatMap(_.matcher)
-        val responseInMatch =
-          matchers match {
-            case Nil => responseExpr
-            case (expr, pat) :: Nil =>
-              Term.Match(expr, List(Case(pat, None, responseExpr), Case(p"_", None, q"""BadRequest("Invalid data")""")))
-            case _ =>
-              q"""
-              (..${matchers.map(_._1)}) match {
-                case (..${matchers.map(_._2)}) => $responseExpr
-                case _ => BadRequest("Invalid data")
-              }
-              """
-          }
+        val responseInMatch = NonEmptyList.fromList(matchers).fold(responseExpr) {
+          case NonEmptyList((expr, pat), Nil) =>
+            Term.Match(expr, List(Case(pat, None, responseExpr), Case(p"_", None, q"""BadRequest("Invalid data")""")))
+          case matchers @ NonEmptyList(_, _) =>
+            val NonEmptyList(head, xs) = matchers.reverse
+            val (base, rest)           = xs.splitAt(21).bimap(left => NonEmptyList(head, left).reverse, _.grouped(21).map(_.reverse.unzip).toList)
+            val (buildTerms, buildPat) = rest.foldLeft[(Term => Term, Pat => Pat)]((identity, identity)) {
+              case ((accTerm, accPat), (nextTermGroup, nextPatGroup)) =>
+                (next => accTerm(q"(..${nextTermGroup :+ next})"), next => accPat(p"(..${nextPatGroup :+ next})"))
+            }
+
+            val (fullTerm, fullPat) = base match {
+              case NonEmptyList((term, pat), Nil) =>
+                (buildTerms(term), buildPat(pat))
+              case NonEmptyList((term, pat), xs) =>
+                val (terms, pats) = xs.unzip
+                (buildTerms(q"(..${term +: terms})"), buildPat(p"(..${pat +: pats})"))
+            }
+            Term.Match(
+              fullTerm,
+              List(
+                Case(fullPat, None, responseExpr),
+                Case(Pat.Wildcard(), None, q"""BadRequest("Invalid data")""")
+              )
+            )
+        }
         val responseInMatchInFor = (http4sForm ++ http4sHeaders).flatMap(_.generator) match {
           case Nil        => responseInMatch
           case generators => q"for {..${generators :+ enumerator"response <- $responseInMatch"}} yield response"

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
@@ -446,9 +446,8 @@ object Http4sServerGenerator {
           .orElse(Some((content: Term) => q"req.decode[UrlForm] { urlForm => $content }").filter(_ => formArgs.nonEmpty && formArgs.forall(!_.isFile)))
           .orElse(Some((content: Term) => q"req.decode[Multipart[F]] { multipart => $content }").filter(_ => formArgs.nonEmpty))
         val fullRouteMatcher =
-          List(additionalQs, http4sQs).flatten match {
-            case Nil => p"$http4sMethod -> $http4sPath"
-            case qs  => p"$http4sMethod -> $http4sPath :? ${qs.reduceLeft((a, n) => p"$a :& $n")}"
+          NonEmptyList.fromList(List(additionalQs, http4sQs).flatten).fold(p"$http4sMethod -> $http4sPath") { qs =>
+            p"$http4sMethod -> $http4sPath :? ${qs.reduceLeft((a, n) => p"$a :& $n")}"
           }
         val fullRouteWithTracingMatcher = tracingFields
           .map(_ => p"$fullRouteMatcher ${Term.Name(s"usingFor${operationId.capitalize}")}(traceBuilder)")

--- a/modules/codegen/src/test/scala/core/issues/Issue126.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue126.scala
@@ -42,8 +42,10 @@ class Issue126 extends FunSuite with Matchers with SwaggerSpecRunner {
           }
         }
         def routes(handler: StoreHandler)(implicit mat: akka.stream.Materializer): Route = {
-          (options & pathEndOrSingleSlash & discardEntity) {
-            complete(handler.getRoot(getRootResponse)())
+          (options & pathEndOrSingleSlash) {
+            discardEntity {
+              complete(handler.getRoot(getRootResponse)())
+            }
           }
         }
         sealed abstract class getRootResponse(val statusCode: StatusCode)

--- a/modules/codegen/src/test/scala/core/issues/Issue126.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue126.scala
@@ -42,7 +42,9 @@ class Issue126 extends FunSuite with Matchers with SwaggerSpecRunner {
           }
         }
         def routes(handler: StoreHandler)(implicit mat: akka.stream.Materializer): Route = {
-          options(pathEndOrSingleSlash(discardEntity(complete(handler.getRoot(getRootResponse)()))))
+          {
+            options(pathEndOrSingleSlash(discardEntity(complete(handler.getRoot(getRootResponse)()))))
+          }
         }
         sealed abstract class getRootResponse(val statusCode: StatusCode)
         case object getRootResponseOK extends getRootResponse(StatusCodes.OK)

--- a/modules/codegen/src/test/scala/core/issues/Issue126.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue126.scala
@@ -35,9 +35,11 @@ class Issue126 extends FunSuite with Matchers with SwaggerSpecRunner {
     """
     val resource = q"""
       object StoreResource {
-        def discardEntity(implicit mat: akka.stream.Materializer): Directive0 = extractRequest.flatMap { req =>
-          req.discardEntityBytes().future
-          Directive.Empty
+        def discardEntity: Directive0 = extractMaterializer.flatMap { implicit mat =>
+          extractRequest.flatMap { req =>
+            req.discardEntityBytes().future
+            Directive.Empty
+          }
         }
         def routes(handler: StoreHandler)(implicit mat: akka.stream.Materializer): Route = {
           (options & pathEndOrSingleSlash & discardEntity) {

--- a/modules/codegen/src/test/scala/core/issues/Issue126.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue126.scala
@@ -42,7 +42,7 @@ class Issue126 extends FunSuite with Matchers with SwaggerSpecRunner {
           }
         }
         def routes(handler: StoreHandler)(implicit mat: akka.stream.Materializer): Route = {
-          (options & pathEndOrSingleSlash)(discardEntity(complete(handler.getRoot(getRootResponse)())))
+          options(pathEndOrSingleSlash(discardEntity(complete(handler.getRoot(getRootResponse)()))))
         }
         sealed abstract class getRootResponse(val statusCode: StatusCode)
         case object getRootResponseOK extends getRootResponse(StatusCodes.OK)

--- a/modules/codegen/src/test/scala/core/issues/Issue126.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue126.scala
@@ -42,11 +42,7 @@ class Issue126 extends FunSuite with Matchers with SwaggerSpecRunner {
           }
         }
         def routes(handler: StoreHandler)(implicit mat: akka.stream.Materializer): Route = {
-          (options & pathEndOrSingleSlash) {
-            discardEntity {
-              complete(handler.getRoot(getRootResponse)())
-            }
-          }
+          (options & pathEndOrSingleSlash)(discardEntity(complete(handler.getRoot(getRootResponse)())))
         }
         sealed abstract class getRootResponse(val statusCode: StatusCode)
         case object getRootResponseOK extends getRootResponse(StatusCodes.OK)

--- a/modules/codegen/src/test/scala/core/issues/Issue127.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue127.scala
@@ -70,9 +70,11 @@ class Issue127 extends FunSuite with Matchers with SwaggerSpecRunner {
 
     val resource = q"""
       object Resource {
-        def discardEntity(implicit mat: akka.stream.Materializer): Directive0 = extractRequest.flatMap { req =>
-          req.discardEntityBytes().future
-          Directive.Empty
+        def discardEntity: Directive0 = extractMaterializer.flatMap { implicit mat =>
+          extractRequest.flatMap { req =>
+            req.discardEntityBytes().future
+            Directive.Empty
+          }
         }
         def routes(handler: Handler)(implicit mat: akka.stream.Materializer): Route = {
           (post & path("file") & ({

--- a/modules/codegen/src/test/scala/core/issues/Issue127.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue127.scala
@@ -77,7 +77,7 @@ class Issue127 extends FunSuite with Matchers with SwaggerSpecRunner {
           }
         }
         def routes(handler: Handler)(implicit mat: akka.stream.Materializer): Route = {
-          (post & path("file"))(({
+          post(path("file")(({
             object uploadFileParts {
               sealed trait Part
               case class IgnoredPart(unit: Unit) extends Part
@@ -146,7 +146,7 @@ class Issue127 extends FunSuite with Matchers with SwaggerSpecRunner {
                 }
                 maybe.fold(reject(_), tprovide(_))
             }))
-          }: Directive[Tuple1[(File, Option[String], ContentType)]])(file => complete(handler.uploadFile(uploadFileResponse)(file))))
+          }: Directive[Tuple1[(File, Option[String], ContentType)]])(file => complete(handler.uploadFile(uploadFileResponse)(file)))))
         }
         sealed abstract class uploadFileResponse(val statusCode: StatusCode)
         case object uploadFileResponseCreated extends uploadFileResponse(StatusCodes.Created)

--- a/modules/codegen/src/test/scala/core/issues/Issue127.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue127.scala
@@ -77,80 +77,76 @@ class Issue127 extends FunSuite with Matchers with SwaggerSpecRunner {
           }
         }
         def routes(handler: Handler)(implicit mat: akka.stream.Materializer): Route = {
-          (post & path("file")) {
-            ({
-              object uploadFileParts {
-                sealed trait Part
-                case class IgnoredPart(unit: Unit) extends Part
-                case class file(value: (File, Option[String], ContentType)) extends Part
-              }
-              val UnmarshalfilePart: Unmarshaller[Multipart.FormData.BodyPart, uploadFileParts.file] = handler.uploadFileUnmarshalToFile[Option](None, handler.uploadFileMapFileField(_, _, _)).map({
-                case (v1, v2, v3, v4) =>
-                  uploadFileParts.file((v1, v2, v3))
-              })
-              extractExecutionContext.flatMap { implicit executionContext =>
-                extractMaterializer.flatMap { implicit mat =>
-                  val fileReferences = new AtomicReference(List.empty[File])
-                  (extractSettings.flatMap {
-                    settings => handleExceptions(ExceptionHandler({
-                      case EntityStreamSizeException(limit, contentLength) =>
-                        fileReferences.get().foreach(_.delete())
-                        val summary = contentLength match {
-                          case Some(cl) =>
-                            s"Request Content-Length of $$cl bytes exceeds the configured limit of $$limit bytes"
-                          case None =>
-                            s"Aggregated data length of request entity exceeds the configured limit of $$limit bytes"
-                        }
-                        val info = new ErrorInfo(summary, "Consider increasing the value of akka.http.server.parsing.max-content-length")
-                        val status = StatusCodes.RequestEntityTooLarge
-                        val msg = if (settings.verboseErrorMessages) info.formatPretty else info.summary
-                        complete(HttpResponse(status, entity = msg))
-                      case e: Throwable =>
-                        fileReferences.get().foreach(_.delete())
-                        throw e
-                    }))
-                  } & handleRejections { (rejections: scala.collection.immutable.Seq[Rejection]) =>
-                    fileReferences.get().foreach(_.delete())
-                    None
-                  } & mapResponse { resp =>
-                    fileReferences.get().foreach(_.delete())
-                    resp
-                  } & entity(as[Multipart.FormData])).flatMap { formData =>
-                    val collectedPartsF: Future[Either[Throwable, Tuple1[Option[(File, Option[String], ContentType)]]]] = for (results <- formData.parts.mapConcat {
-                      part => if (Set[String]("file").contains(part.name)) part :: Nil else {
-                        part.entity.discardBytes()
-                        Nil
+          (post & path("file"))(({
+            object uploadFileParts {
+              sealed trait Part
+              case class IgnoredPart(unit: Unit) extends Part
+              case class file(value: (File, Option[String], ContentType)) extends Part
+            }
+            val UnmarshalfilePart: Unmarshaller[Multipart.FormData.BodyPart, uploadFileParts.file] = handler.uploadFileUnmarshalToFile[Option](None, handler.uploadFileMapFileField(_, _, _)).map({
+              case (v1, v2, v3, v4) =>
+                uploadFileParts.file((v1, v2, v3))
+            })
+            extractExecutionContext.flatMap { implicit executionContext =>
+              extractMaterializer.flatMap { implicit mat =>
+                val fileReferences = new AtomicReference(List.empty[File])
+                (extractSettings.flatMap {
+                  settings => handleExceptions(ExceptionHandler({
+                    case EntityStreamSizeException(limit, contentLength) =>
+                      fileReferences.get().foreach(_.delete())
+                      val summary = contentLength match {
+                        case Some(cl) =>
+                          s"Request Content-Length of $$cl bytes exceeds the configured limit of $$limit bytes"
+                        case None =>
+                          s"Aggregated data length of request entity exceeds the configured limit of $$limit bytes"
                       }
-                    }.mapAsync(1) { part => {
-                      part.name match {
-                        case "file" =>
-                          SafeUnmarshaller(AccumulatingUnmarshaller(fileReferences, UnmarshalfilePart)(_.value._1)).apply(part)
-                        case _ =>
-                          SafeUnmarshaller(implicitly[Unmarshaller[Multipart.FormData.BodyPart, Unit]].map(uploadFileParts.IgnoredPart.apply(_))).apply(part)
-                      }
-                    }}.toMat(Sink.seq[Either[Throwable, uploadFileParts.Part]])(Keep.right).run()) yield {
-                      results.toList.sequence.map { successes =>
-                        val fileO = successes.collectFirst({
-                          case uploadFileParts.file((v1, v2, v3)) =>
-                            (v1, v2, v3)
-                        })
-                        Tuple1(fileO)
-                      }
+                      val info = new ErrorInfo(summary, "Consider increasing the value of akka.http.server.parsing.max-content-length")
+                      val status = StatusCodes.RequestEntityTooLarge
+                      val msg = if (settings.verboseErrorMessages) info.formatPretty else info.summary
+                      complete(HttpResponse(status, entity = msg))
+                    case e: Throwable =>
+                      fileReferences.get().foreach(_.delete())
+                      throw e
+                  }))
+                } & handleRejections { (rejections: scala.collection.immutable.Seq[Rejection]) =>
+                  fileReferences.get().foreach(_.delete())
+                  None
+                } & mapResponse { resp =>
+                  fileReferences.get().foreach(_.delete())
+                  resp
+                } & entity(as[Multipart.FormData])).flatMap { formData =>
+                  val collectedPartsF: Future[Either[Throwable, Tuple1[Option[(File, Option[String], ContentType)]]]] = for (results <- formData.parts.mapConcat {
+                    part => if (Set[String]("file").contains(part.name)) part :: Nil else {
+                      part.entity.discardBytes()
+                      Nil
                     }
-                    onSuccess(collectedPartsF)
+                  }.mapAsync(1) {
+                    part => part.name match {
+                      case "file" =>
+                        SafeUnmarshaller(AccumulatingUnmarshaller(fileReferences, UnmarshalfilePart)(_.value._1)).apply(part)
+                      case _ =>
+                        SafeUnmarshaller(implicitly[Unmarshaller[Multipart.FormData.BodyPart, Unit]].map(uploadFileParts.IgnoredPart.apply(_))).apply(part)
+                    }
+                  }.toMat(Sink.seq[Either[Throwable, uploadFileParts.Part]])(Keep.right).run()) yield {
+                    results.toList.sequence.map { successes =>
+                      val fileO = successes.collectFirst({
+                        case uploadFileParts.file((v1, v2, v3)) =>
+                          (v1, v2, v3)
+                      })
+                      Tuple1(fileO)
+                    }
                   }
+                  onSuccess(collectedPartsF)
                 }
-              }.flatMap(_.fold(t => throw t, {
-                case Tuple1(fileO) =>
-                  val maybe: Either[Rejection, Tuple1[(File, Option[String], ContentType)]] = for (file <- fileO.toRight(MissingFormFieldRejection("file"))) yield {
-                    Tuple1(file)
-                  }
-                  maybe.fold(reject(_), tprovide(_))
-              }))
-            }: Directive[Tuple1[(File, Option[String], ContentType)]]) { file => {
-              complete(handler.uploadFile(uploadFileResponse)(file))
-            } }
-          }
+              }
+            }.flatMap(_.fold(t => throw t, {
+              case Tuple1(fileO) =>
+                val maybe: Either[Rejection, Tuple1[(File, Option[String], ContentType)]] = for (file <- fileO.toRight(MissingFormFieldRejection("file"))) yield {
+                  Tuple1(file)
+                }
+                maybe.fold(reject(_), tprovide(_))
+            }))
+          }: Directive[Tuple1[(File, Option[String], ContentType)]])(file => complete(handler.uploadFile(uploadFileResponse)(file))))
         }
         sealed abstract class uploadFileResponse(val statusCode: StatusCode)
         case object uploadFileResponseCreated extends uploadFileResponse(StatusCodes.Created)

--- a/modules/codegen/src/test/scala/core/issues/Issue127.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue127.scala
@@ -77,79 +77,79 @@ class Issue127 extends FunSuite with Matchers with SwaggerSpecRunner {
           }
         }
         def routes(handler: Handler)(implicit mat: akka.stream.Materializer): Route = {
-          (post & path("file") & ({
-            object uploadFileParts {
-              sealed trait Part
-              case class IgnoredPart(unit: Unit) extends Part
-              case class file(value: (File, Option[String], ContentType)) extends Part
-            }
-            val UnmarshalfilePart: Unmarshaller[Multipart.FormData.BodyPart, uploadFileParts.file] = handler.uploadFileUnmarshalToFile[Option](None, handler.uploadFileMapFileField(_, _, _)).map({
-              case (v1, v2, v3, v4) =>
-                uploadFileParts.file((v1, v2, v3))
-            })
-            extractExecutionContext.flatMap { implicit executionContext =>
-              extractMaterializer.flatMap { implicit mat =>
-                val fileReferences = new AtomicReference(List.empty[File])
-                (extractSettings.flatMap {
-                  settings => handleExceptions(ExceptionHandler({
-                    case EntityStreamSizeException(limit, contentLength) =>
-                      fileReferences.get().foreach(_.delete())
-                      val summary = contentLength match {
-                        case Some(cl) =>
-                          s"Request Content-Length of $$cl bytes exceeds the configured limit of $$limit bytes"
-                        case None =>
-                          s"Aggregated data length of request entity exceeds the configured limit of $$limit bytes"
+          (post & path("file")) {
+            ({
+              object uploadFileParts {
+                sealed trait Part
+                case class IgnoredPart(unit: Unit) extends Part
+                case class file(value: (File, Option[String], ContentType)) extends Part
+              }
+              val UnmarshalfilePart: Unmarshaller[Multipart.FormData.BodyPart, uploadFileParts.file] = handler.uploadFileUnmarshalToFile[Option](None, handler.uploadFileMapFileField(_, _, _)).map({
+                case (v1, v2, v3, v4) =>
+                  uploadFileParts.file((v1, v2, v3))
+              })
+              extractExecutionContext.flatMap { implicit executionContext =>
+                extractMaterializer.flatMap { implicit mat =>
+                  val fileReferences = new AtomicReference(List.empty[File])
+                  (extractSettings.flatMap {
+                    settings => handleExceptions(ExceptionHandler({
+                      case EntityStreamSizeException(limit, contentLength) =>
+                        fileReferences.get().foreach(_.delete())
+                        val summary = contentLength match {
+                          case Some(cl) =>
+                            s"Request Content-Length of $$cl bytes exceeds the configured limit of $$limit bytes"
+                          case None =>
+                            s"Aggregated data length of request entity exceeds the configured limit of $$limit bytes"
+                        }
+                        val info = new ErrorInfo(summary, "Consider increasing the value of akka.http.server.parsing.max-content-length")
+                        val status = StatusCodes.RequestEntityTooLarge
+                        val msg = if (settings.verboseErrorMessages) info.formatPretty else info.summary
+                        complete(HttpResponse(status, entity = msg))
+                      case e: Throwable =>
+                        fileReferences.get().foreach(_.delete())
+                        throw e
+                    }))
+                  } & handleRejections { (rejections: scala.collection.immutable.Seq[Rejection]) =>
+                    fileReferences.get().foreach(_.delete())
+                    None
+                  } & mapResponse { resp =>
+                    fileReferences.get().foreach(_.delete())
+                    resp
+                  } & entity(as[Multipart.FormData])).flatMap { formData =>
+                    val collectedPartsF: Future[Either[Throwable, Tuple1[Option[(File, Option[String], ContentType)]]]] = for (results <- formData.parts.mapConcat {
+                      part => if (Set[String]("file").contains(part.name)) part :: Nil else {
+                        part.entity.discardBytes()
+                        Nil
                       }
-                      val info = new ErrorInfo(summary, "Consider increasing the value of akka.http.server.parsing.max-content-length")
-                      val status = StatusCodes.RequestEntityTooLarge
-                      val msg = if (settings.verboseErrorMessages) info.formatPretty else info.summary
-                      complete(HttpResponse(status, entity = msg))
-                    case e: Throwable =>
-                      fileReferences.get().foreach(_.delete())
-                      throw e
-                  }))
-                } & handleRejections { (rejections: scala.collection.immutable.Seq[Rejection]) =>
-                  fileReferences.get().foreach(_.delete())
-                  None
-                } & mapResponse { resp =>
-                  fileReferences.get().foreach(_.delete())
-                  resp
-                } & entity(as[Multipart.FormData])).flatMap { formData =>
-                  val collectedPartsF: Future[Either[Throwable, Tuple1[Option[(File, Option[String], ContentType)]]]] = for (results <- formData.parts.mapConcat {
-                    part => if (Set[String]("file").contains(part.name)) part :: Nil else {
-                      part.entity.discardBytes()
-                      Nil
-                    }
-                  }.mapAsync(1) { part =>
-                    {
+                    }.mapAsync(1) { part => {
                       part.name match {
                         case "file" =>
                           SafeUnmarshaller(AccumulatingUnmarshaller(fileReferences, UnmarshalfilePart)(_.value._1)).apply(part)
                         case _ =>
                           SafeUnmarshaller(implicitly[Unmarshaller[Multipart.FormData.BodyPart, Unit]].map(uploadFileParts.IgnoredPart.apply(_))).apply(part)
                       }
+                    }}.toMat(Sink.seq[Either[Throwable, uploadFileParts.Part]])(Keep.right).run()) yield {
+                      results.toList.sequence.map { successes =>
+                        val fileO = successes.collectFirst({
+                          case uploadFileParts.file((v1, v2, v3)) =>
+                            (v1, v2, v3)
+                        })
+                        Tuple1(fileO)
+                      }
                     }
-                  }.toMat(Sink.seq[Either[Throwable, uploadFileParts.Part]])(Keep.right).run()) yield {
-                    results.toList.sequence.map { successes =>
-                      val fileO = successes.collectFirst({
-                        case uploadFileParts.file((v1, v2, v3)) =>
-                          (v1, v2, v3)
-                      })
-                      Tuple1(fileO)
-                    }
+                    onSuccess(collectedPartsF)
                   }
-                  onSuccess(collectedPartsF)
                 }
-              }
-            }.flatMap(_.fold(t => throw t, {
-              case Tuple1(fileO) =>
-                val maybe: Either[Rejection, Tuple1[(File, Option[String], ContentType)]] = for (file <- fileO.toRight(MissingFormFieldRejection("file"))) yield {
-                  Tuple1(file)
-                }
-                maybe.fold(reject(_), tprovide(_))
-            }))
-          }: Directive[Tuple1[(File, Option[String], ContentType)]])) {
-            file => complete(handler.uploadFile(uploadFileResponse)(file))
+              }.flatMap(_.fold(t => throw t, {
+                case Tuple1(fileO) =>
+                  val maybe: Either[Rejection, Tuple1[(File, Option[String], ContentType)]] = for (file <- fileO.toRight(MissingFormFieldRejection("file"))) yield {
+                    Tuple1(file)
+                  }
+                  maybe.fold(reject(_), tprovide(_))
+              }))
+            }: Directive[Tuple1[(File, Option[String], ContentType)]]) { file => {
+              complete(handler.uploadFile(uploadFileResponse)(file))
+            } }
           }
         }
         sealed abstract class uploadFileResponse(val statusCode: StatusCode)

--- a/modules/codegen/src/test/scala/core/issues/Issue127.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue127.scala
@@ -77,76 +77,78 @@ class Issue127 extends FunSuite with Matchers with SwaggerSpecRunner {
           }
         }
         def routes(handler: Handler)(implicit mat: akka.stream.Materializer): Route = {
-          post(path("file")(({
-            object uploadFileParts {
-              sealed trait Part
-              case class IgnoredPart(unit: Unit) extends Part
-              case class file(value: (File, Option[String], ContentType)) extends Part
-            }
-            val UnmarshalfilePart: Unmarshaller[Multipart.FormData.BodyPart, uploadFileParts.file] = handler.uploadFileUnmarshalToFile[Option](None, handler.uploadFileMapFileField(_, _, _)).map({
-              case (v1, v2, v3, v4) =>
-                uploadFileParts.file((v1, v2, v3))
-            })
-            extractExecutionContext.flatMap { implicit executionContext =>
-              extractMaterializer.flatMap { implicit mat =>
-                val fileReferences = new AtomicReference(List.empty[File])
-                (extractSettings.flatMap {
-                  settings => handleExceptions(ExceptionHandler({
-                    case EntityStreamSizeException(limit, contentLength) =>
-                      fileReferences.get().foreach(_.delete())
-                      val summary = contentLength match {
-                        case Some(cl) =>
-                          s"Request Content-Length of $$cl bytes exceeds the configured limit of $$limit bytes"
-                        case None =>
-                          s"Aggregated data length of request entity exceeds the configured limit of $$limit bytes"
-                      }
-                      val info = new ErrorInfo(summary, "Consider increasing the value of akka.http.server.parsing.max-content-length")
-                      val status = StatusCodes.RequestEntityTooLarge
-                      val msg = if (settings.verboseErrorMessages) info.formatPretty else info.summary
-                      complete(HttpResponse(status, entity = msg))
-                    case e: Throwable =>
-                      fileReferences.get().foreach(_.delete())
-                      throw e
-                  }))
-                } & handleRejections { (rejections: scala.collection.immutable.Seq[Rejection]) =>
-                  fileReferences.get().foreach(_.delete())
-                  None
-                } & mapResponse { resp =>
-                  fileReferences.get().foreach(_.delete())
-                  resp
-                } & entity(as[Multipart.FormData])).flatMap { formData =>
-                  val collectedPartsF: Future[Either[Throwable, Tuple1[Option[(File, Option[String], ContentType)]]]] = for (results <- formData.parts.mapConcat {
-                    part => if (Set[String]("file").contains(part.name)) part :: Nil else {
-                      part.entity.discardBytes()
-                      Nil
-                    }
-                  }.mapAsync(1) {
-                    part => part.name match {
-                      case "file" =>
-                        SafeUnmarshaller(AccumulatingUnmarshaller(fileReferences, UnmarshalfilePart)(_.value._1)).apply(part)
-                      case _ =>
-                        SafeUnmarshaller(implicitly[Unmarshaller[Multipart.FormData.BodyPart, Unit]].map(uploadFileParts.IgnoredPart.apply(_))).apply(part)
-                    }
-                  }.toMat(Sink.seq[Either[Throwable, uploadFileParts.Part]])(Keep.right).run()) yield {
-                    results.toList.sequence.map { successes =>
-                      val fileO = successes.collectFirst({
-                        case uploadFileParts.file((v1, v2, v3)) =>
-                          (v1, v2, v3)
-                      })
-                      Tuple1(fileO)
-                    }
-                  }
-                  onSuccess(collectedPartsF)
-                }
+          {
+            post(path("file")(({
+              object uploadFileParts {
+                sealed trait Part
+                case class IgnoredPart(unit: Unit) extends Part
+                case class file(value: (File, Option[String], ContentType)) extends Part
               }
-            }.flatMap(_.fold(t => throw t, {
-              case Tuple1(fileO) =>
-                val maybe: Either[Rejection, Tuple1[(File, Option[String], ContentType)]] = for (file <- fileO.toRight(MissingFormFieldRejection("file"))) yield {
-                  Tuple1(file)
+              val UnmarshalfilePart: Unmarshaller[Multipart.FormData.BodyPart, uploadFileParts.file] = handler.uploadFileUnmarshalToFile[Option](None, handler.uploadFileMapFileField(_, _, _)).map({
+                case (v1, v2, v3, v4) =>
+                  uploadFileParts.file((v1, v2, v3))
+              })
+              extractExecutionContext.flatMap { implicit executionContext =>
+                extractMaterializer.flatMap { implicit mat =>
+                  val fileReferences = new AtomicReference(List.empty[File])
+                  (extractSettings.flatMap {
+                    settings => handleExceptions(ExceptionHandler({
+                      case EntityStreamSizeException(limit, contentLength) =>
+                        fileReferences.get().foreach(_.delete())
+                        val summary = contentLength match {
+                          case Some(cl) =>
+                            s"Request Content-Length of $$cl bytes exceeds the configured limit of $$limit bytes"
+                          case None =>
+                            s"Aggregated data length of request entity exceeds the configured limit of $$limit bytes"
+                        }
+                        val info = new ErrorInfo(summary, "Consider increasing the value of akka.http.server.parsing.max-content-length")
+                        val status = StatusCodes.RequestEntityTooLarge
+                        val msg = if (settings.verboseErrorMessages) info.formatPretty else info.summary
+                        complete(HttpResponse(status, entity = msg))
+                      case e: Throwable =>
+                        fileReferences.get().foreach(_.delete())
+                        throw e
+                    }))
+                  } & handleRejections { (rejections: scala.collection.immutable.Seq[Rejection]) =>
+                    fileReferences.get().foreach(_.delete())
+                    None
+                  } & mapResponse { resp =>
+                    fileReferences.get().foreach(_.delete())
+                    resp
+                  } & entity(as[Multipart.FormData])).flatMap { formData =>
+                    val collectedPartsF: Future[Either[Throwable, Tuple1[Option[(File, Option[String], ContentType)]]]] = for (results <- formData.parts.mapConcat {
+                      part => if (Set[String]("file").contains(part.name)) part :: Nil else {
+                        part.entity.discardBytes()
+                        Nil
+                      }
+                    }.mapAsync(1) {
+                      part => part.name match {
+                        case "file" =>
+                          SafeUnmarshaller(AccumulatingUnmarshaller(fileReferences, UnmarshalfilePart)(_.value._1)).apply(part)
+                        case _ =>
+                          SafeUnmarshaller(implicitly[Unmarshaller[Multipart.FormData.BodyPart, Unit]].map(uploadFileParts.IgnoredPart.apply(_))).apply(part)
+                      }
+                    }.toMat(Sink.seq[Either[Throwable, uploadFileParts.Part]])(Keep.right).run()) yield {
+                      results.toList.sequence.map { successes =>
+                        val fileO = successes.collectFirst({
+                          case uploadFileParts.file((v1, v2, v3)) =>
+                            (v1, v2, v3)
+                        })
+                        Tuple1(fileO)
+                      }
+                    }
+                    onSuccess(collectedPartsF)
+                  }
                 }
-                maybe.fold(reject(_), tprovide(_))
-            }))
-          }: Directive[Tuple1[(File, Option[String], ContentType)]])(file => complete(handler.uploadFile(uploadFileResponse)(file)))))
+              }.flatMap(_.fold(t => throw t, {
+                case Tuple1(fileO) =>
+                  val maybe: Either[Rejection, Tuple1[(File, Option[String], ContentType)]] = for (file <- fileO.toRight(MissingFormFieldRejection("file"))) yield {
+                    Tuple1(file)
+                  }
+                  maybe.fold(reject(_), tprovide(_))
+              }))
+            }: Directive[Tuple1[(File, Option[String], ContentType)]])(file => complete(handler.uploadFile(uploadFileResponse)(file)))))
+          }
         }
         sealed abstract class uploadFileResponse(val statusCode: StatusCode)
         case object uploadFileResponseCreated extends uploadFileResponse(StatusCodes.Created)

--- a/modules/codegen/src/test/scala/tests/core/PathParserSpec.scala
+++ b/modules/codegen/src/test/scala/tests/core/PathParserSpec.scala
@@ -1,5 +1,6 @@
 package tests.core
 
+import cats.data.NonEmptyList
 import com.twilio.guardrail.generators.ScalaParameter
 import com.twilio.guardrail.generators.syntax.Scala._
 import com.twilio.guardrail.{ SwaggerUtil, Target }
@@ -55,7 +56,7 @@ class PathParserSpec extends FunSuite with Matchers with EitherValues with Optio
   ).foreach {
     case (str, expected) =>
       test(s"Server ${str}") {
-        val (gen, _) = Target.unsafeExtract(SwaggerUtil.paths.generateUrlAkkaPathExtractors(str, args))
+        val NonEmptyList((gen, _), _) = Target.unsafeExtract(SwaggerUtil.paths.generateUrlAkkaPathExtractors(str, args))
         gen.toString shouldBe ((expected.toString))
       }
   }

--- a/modules/codegen/src/test/scala/tests/core/PathParserSpec.scala
+++ b/modules/codegen/src/test/scala/tests/core/PathParserSpec.scala
@@ -55,7 +55,7 @@ class PathParserSpec extends FunSuite with Matchers with EitherValues with Optio
   ).foreach {
     case (str, expected) =>
       test(s"Server ${str}") {
-        val gen = Target.unsafeExtract(SwaggerUtil.paths.generateUrlAkkaPathExtractors(str, args))
+        val (gen, _) = Target.unsafeExtract(SwaggerUtil.paths.generateUrlAkkaPathExtractors(str, args))
         gen.toString shouldBe ((expected.toString))
       }
   }

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/AkkaHttpServerTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/AkkaHttpServerTest.scala
@@ -148,7 +148,17 @@ class AkkaHttpServerTest extends FunSuite with Matchers with SwaggerSpecRunner {
           }
         }
         def routes(handler: StoreHandler)(implicit mat: akka.stream.Materializer): Route = {
-          get(pathEndOrSingleSlash(discardEntity(complete(handler.getRoot(getRootResponse)())))) ~ put(path("bar")(parameter(Symbol("bar").as[Long])(bar => discardEntity(complete(handler.putBar(putBarResponse)(bar)))))) ~ get((pathPrefix("foo") & pathEndOrSingleSlash)(discardEntity(complete(handler.getFoo(getFooResponse)())))) ~ get(path("foo" / LongNumber)(bar => discardEntity(complete(handler.getFooBar(getFooBarResponse)(bar))))) ~ get(path("store" / "order" / LongNumber)(orderId => parameter(Symbol("status").as[OrderStatus])(status => discardEntity(complete(handler.getOrderById(getOrderByIdResponse)(orderId, status))))))
+          {
+            get(pathEndOrSingleSlash(discardEntity(complete(handler.getRoot(getRootResponse)()))))
+          } ~ {
+            put(path("bar")(parameter(Symbol("bar").as[Long])(bar => discardEntity(complete(handler.putBar(putBarResponse)(bar))))))
+          } ~ {
+            get((pathPrefix("foo") & pathEndOrSingleSlash)(discardEntity(complete(handler.getFoo(getFooResponse)()))))
+          } ~ {
+            get(path("foo" / LongNumber)(bar => discardEntity(complete(handler.getFooBar(getFooBarResponse)(bar)))))
+          } ~ {
+            get(path("store" / "order" / LongNumber)(orderId => parameter(Symbol("status").as[OrderStatus])(status => discardEntity(complete(handler.getOrderById(getOrderByIdResponse)(orderId, status))))))
+          }
         }
         sealed abstract class getRootResponse(val statusCode: StatusCode)
         case object getRootResponseOK extends getRootResponse(StatusCodes.OK)
@@ -281,7 +291,17 @@ class AkkaHttpServerTest extends FunSuite with Matchers with SwaggerSpecRunner {
           }
         }
         def routes(handler: StoreHandler, trace: String => Directive1[TraceBuilder])(implicit mat: akka.stream.Materializer): Route = {
-          get(pathEndOrSingleSlash(trace("store:getRoot")(traceBuilder => discardEntity(complete(handler.getRoot(getRootResponse)()(traceBuilder)))))) ~ put(path("bar")(parameter(Symbol("bar").as[Long])(bar => trace("store:putBar")(traceBuilder => discardEntity(complete(handler.putBar(putBarResponse)(bar)(traceBuilder))))))) ~ get((pathPrefix("foo") & pathEndOrSingleSlash)(trace("store:getFoo")(traceBuilder => discardEntity(complete(handler.getFoo(getFooResponse)()(traceBuilder)))))) ~ get(path("foo" / LongNumber)(bar => trace("completely-custom-label")(traceBuilder => discardEntity(complete(handler.getFooBar(getFooBarResponse)(bar)(traceBuilder)))))) ~ get(path("store" / "order" / LongNumber)(orderId => parameter(Symbol("status").as[OrderStatus])(status => trace("store:getOrderById")(traceBuilder => discardEntity(complete(handler.getOrderById(getOrderByIdResponse)(orderId, status)(traceBuilder)))))))
+          {
+            get(pathEndOrSingleSlash(trace("store:getRoot")(traceBuilder => discardEntity(complete(handler.getRoot(getRootResponse)()(traceBuilder))))))
+          } ~ {
+            put(path("bar")(parameter(Symbol("bar").as[Long])(bar => trace("store:putBar")(traceBuilder => discardEntity(complete(handler.putBar(putBarResponse)(bar)(traceBuilder)))))))
+          } ~ {
+            get((pathPrefix("foo") & pathEndOrSingleSlash)(trace("store:getFoo")(traceBuilder => discardEntity(complete(handler.getFoo(getFooResponse)()(traceBuilder))))))
+          } ~ {
+            get(path("foo" / LongNumber)(bar => trace("completely-custom-label")(traceBuilder => discardEntity(complete(handler.getFooBar(getFooBarResponse)(bar)(traceBuilder))))))
+          } ~ {
+            get(path("store" / "order" / LongNumber)(orderId => parameter(Symbol("status").as[OrderStatus])(status => trace("store:getOrderById")(traceBuilder => discardEntity(complete(handler.getOrderById(getOrderByIdResponse)(orderId, status)(traceBuilder)))))))
+          }
         }
         sealed abstract class getRootResponse(val statusCode: StatusCode)
         case object getRootResponseOK extends getRootResponse(StatusCodes.OK)

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/AkkaHttpServerTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/AkkaHttpServerTest.scala
@@ -141,9 +141,11 @@ class AkkaHttpServerTest extends FunSuite with Matchers with SwaggerSpecRunner {
     """
     val resource = q"""
       object StoreResource {
-        def discardEntity(implicit mat: akka.stream.Materializer): Directive0 = extractRequest.flatMap { req =>
-          req.discardEntityBytes().future
-          Directive.Empty
+        def discardEntity: Directive0 = extractMaterializer.flatMap { implicit mat =>
+          extractRequest.flatMap { req =>
+            req.discardEntityBytes().future
+            Directive.Empty
+          }
         }
         def routes(handler: StoreHandler)(implicit mat: akka.stream.Materializer): Route = {
           (get & pathEndOrSingleSlash & discardEntity) {

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/AkkaHttpServerTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/AkkaHttpServerTest.scala
@@ -148,17 +148,31 @@ class AkkaHttpServerTest extends FunSuite with Matchers with SwaggerSpecRunner {
           }
         }
         def routes(handler: StoreHandler)(implicit mat: akka.stream.Materializer): Route = {
-          (get & pathEndOrSingleSlash & discardEntity) {
-            complete(handler.getRoot(getRootResponse)())
-          } ~ (put & path("bar") & parameter(Symbol("bar").as[Long]) & discardEntity) {
-            bar => complete(handler.putBar(putBarResponse)(bar))
-          } ~ (get & (pathPrefix("foo") & pathEndOrSingleSlash) & discardEntity) {
-            complete(handler.getFoo(getFooResponse)())
-          } ~ (get & path("foo" / LongNumber) & discardEntity) {
-            bar => complete(handler.getFooBar(getFooBarResponse)(bar))
-          } ~ (get & path("store" / "order" / LongNumber) & parameter(Symbol("status").as[OrderStatus]) & discardEntity) {
-            (orderId, status) => complete(handler.getOrderById(getOrderByIdResponse)(orderId, status))
-          }
+          (get & pathEndOrSingleSlash) {
+            discardEntity {
+              complete(handler.getRoot(getRootResponse)())
+            }
+          } ~ (put & path("bar")) {
+            parameter(Symbol("bar").as[Long]) { bar => {
+              discardEntity {
+                complete(handler.putBar(putBarResponse)(bar))
+              }
+            } }
+          } ~ (get & (pathPrefix("foo") & pathEndOrSingleSlash)) {
+            discardEntity {
+              complete(handler.getFoo(getFooResponse)())
+            }
+          } ~ (get & path("foo" / LongNumber)) { bar => {
+            discardEntity {
+              complete(handler.getFooBar(getFooBarResponse)(bar))
+            }
+          } } ~ (get & path("store" / "order" / LongNumber)) { orderId => {
+            parameter(Symbol("status").as[OrderStatus]) { status => {
+              discardEntity {
+                complete(handler.getOrderById(getOrderByIdResponse)(orderId, status))
+              }
+            } }
+          } }
         }
         sealed abstract class getRootResponse(val statusCode: StatusCode)
         case object getRootResponseOK extends getRootResponse(StatusCodes.OK)

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/AkkaHttpServerTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/AkkaHttpServerTest.scala
@@ -148,31 +148,7 @@ class AkkaHttpServerTest extends FunSuite with Matchers with SwaggerSpecRunner {
           }
         }
         def routes(handler: StoreHandler)(implicit mat: akka.stream.Materializer): Route = {
-          (get & pathEndOrSingleSlash) {
-            discardEntity {
-              complete(handler.getRoot(getRootResponse)())
-            }
-          } ~ (put & path("bar")) {
-            parameter(Symbol("bar").as[Long]) { bar => {
-              discardEntity {
-                complete(handler.putBar(putBarResponse)(bar))
-              }
-            } }
-          } ~ (get & (pathPrefix("foo") & pathEndOrSingleSlash)) {
-            discardEntity {
-              complete(handler.getFoo(getFooResponse)())
-            }
-          } ~ (get & path("foo" / LongNumber)) { bar => {
-            discardEntity {
-              complete(handler.getFooBar(getFooBarResponse)(bar))
-            }
-          } } ~ (get & path("store" / "order" / LongNumber)) { orderId => {
-            parameter(Symbol("status").as[OrderStatus]) { status => {
-              discardEntity {
-                complete(handler.getOrderById(getOrderByIdResponse)(orderId, status))
-              }
-            } }
-          } }
+          (get & pathEndOrSingleSlash)(discardEntity(complete(handler.getRoot(getRootResponse)()))) ~ (put & path("bar"))(parameter(Symbol("bar").as[Long])(bar => discardEntity(complete(handler.putBar(putBarResponse)(bar))))) ~ (get & (pathPrefix("foo") & pathEndOrSingleSlash))(discardEntity(complete(handler.getFoo(getFooResponse)()))) ~ (get & path("foo" / LongNumber))(bar => discardEntity(complete(handler.getFooBar(getFooBarResponse)(bar)))) ~ (get & path("store" / "order" / LongNumber))(orderId => parameter(Symbol("status").as[OrderStatus])(status => discardEntity(complete(handler.getOrderById(getOrderByIdResponse)(orderId, status)))))
         }
         sealed abstract class getRootResponse(val statusCode: StatusCode)
         case object getRootResponseOK extends getRootResponse(StatusCodes.OK)

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/CustomHeaderTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/CustomHeaderTest.scala
@@ -54,11 +54,17 @@ class CustomHeaderTest extends FunSuite with Matchers with SwaggerSpecRunner {
           }
         }
         def routes(handler: Handler)(implicit mat: akka.stream.Materializer): Route = {
-          (get & path("foo") & discardEntity & headerValueByName("CustomHeader").flatMap(str => onComplete(Unmarshal(str).to[Bar]).flatMap[Tuple1[Bar]]({
-            case Failure(e) => reject(MalformedHeaderRejection("CustomHeader", e.getMessage, Some(e)))
-            case Success(x) => provide(x)
-          }))) {
-            customHeader => complete(handler.getFoo(getFooResponse)(customHeader))
+          (get & path("foo")) {
+            headerValueByName("CustomHeader").flatMap(str => onComplete(Unmarshal(str).to[Bar]).flatMap[Tuple1[Bar]]({
+              case Failure(e) =>
+                reject(MalformedHeaderRejection("CustomHeader", e.getMessage, Some(e)))
+              case Success(x) =>
+                provide(x)
+            })) { customHeader => {
+              discardEntity {
+                complete(handler.getFoo(getFooResponse)(customHeader))
+              }
+            } }
           }
         }
         sealed abstract class getFooResponse(val statusCode: StatusCode)

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/CustomHeaderTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/CustomHeaderTest.scala
@@ -54,12 +54,14 @@ class CustomHeaderTest extends FunSuite with Matchers with SwaggerSpecRunner {
           }
         }
         def routes(handler: Handler)(implicit mat: akka.stream.Materializer): Route = {
-          get(path("foo")(headerValueByName("CustomHeader").flatMap(str => onComplete(Unmarshal(str).to[Bar]).flatMap[Tuple1[Bar]]({
-            case Failure(e) =>
-              reject(MalformedHeaderRejection("CustomHeader", e.getMessage, Some(e)))
-            case Success(x) =>
-              provide(x)
-          }))(customHeader => discardEntity(complete(handler.getFoo(getFooResponse)(customHeader))))))
+          {
+            get(path("foo")(headerValueByName("CustomHeader").flatMap(str => onComplete(Unmarshal(str).to[Bar]).flatMap[Tuple1[Bar]]({
+              case Failure(e) =>
+                reject(MalformedHeaderRejection("CustomHeader", e.getMessage, Some(e)))
+              case Success(x) =>
+                provide(x)
+            }))(customHeader => discardEntity(complete(handler.getFoo(getFooResponse)(customHeader))))))
+          }
         }
         sealed abstract class getFooResponse(val statusCode: StatusCode)
         case object getFooResponseOK extends getFooResponse(StatusCodes.OK)

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/CustomHeaderTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/CustomHeaderTest.scala
@@ -47,9 +47,11 @@ class CustomHeaderTest extends FunSuite with Matchers with SwaggerSpecRunner {
 
     val resource = q"""
       object Resource {
-        def discardEntity(implicit mat: akka.stream.Materializer): Directive0 = extractRequest.flatMap { req =>
-          req.discardEntityBytes().future
-          Directive.Empty
+        def discardEntity: Directive0 = extractMaterializer.flatMap { implicit mat =>
+          extractRequest.flatMap { req =>
+            req.discardEntityBytes().future
+            Directive.Empty
+          }
         }
         def routes(handler: Handler)(implicit mat: akka.stream.Materializer): Route = {
           (get & path("foo") & discardEntity & headerValueByName("CustomHeader").flatMap(str => onComplete(Unmarshal(str).to[Bar]).flatMap[Tuple1[Bar]]({

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/CustomHeaderTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/CustomHeaderTest.scala
@@ -54,12 +54,12 @@ class CustomHeaderTest extends FunSuite with Matchers with SwaggerSpecRunner {
           }
         }
         def routes(handler: Handler)(implicit mat: akka.stream.Materializer): Route = {
-          (get & path("foo"))(headerValueByName("CustomHeader").flatMap(str => onComplete(Unmarshal(str).to[Bar]).flatMap[Tuple1[Bar]]({
+          get(path("foo")(headerValueByName("CustomHeader").flatMap(str => onComplete(Unmarshal(str).to[Bar]).flatMap[Tuple1[Bar]]({
             case Failure(e) =>
               reject(MalformedHeaderRejection("CustomHeader", e.getMessage, Some(e)))
             case Success(x) =>
               provide(x)
-          }))(customHeader => discardEntity(complete(handler.getFoo(getFooResponse)(customHeader)))))
+          }))(customHeader => discardEntity(complete(handler.getFoo(getFooResponse)(customHeader))))))
         }
         sealed abstract class getFooResponse(val statusCode: StatusCode)
         case object getFooResponseOK extends getFooResponse(StatusCodes.OK)

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/StaticParametersTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/StaticParametersTest.scala
@@ -50,15 +50,7 @@ class StaticParametersTest extends FunSuite with Matchers with SwaggerSpecRunner
           }
         }
         def routes(handler: Handler)(implicit mat: akka.stream.Materializer): Route = {
-          (get & (pathPrefix("foo") & pathEndOrSingleSlash & parameter("bar").require(_ == "2"))) {
-            discardEntity {
-              complete(handler.getFoo2(getFoo2Response)())
-            }
-          } ~ (get & (path("foo") & parameter("bar").require(_ == "1"))) {
-            discardEntity {
-              complete(handler.getFoo1(getFoo1Response)())
-            }
-          }
+          (get & (pathPrefix("foo") & pathEndOrSingleSlash & parameter("bar").require(_ == "2")))(discardEntity(complete(handler.getFoo2(getFoo2Response)()))) ~ (get & (path("foo") & parameter("bar").require(_ == "1")))(discardEntity(complete(handler.getFoo1(getFoo1Response)())))
         }
         sealed abstract class getFoo2Response(val statusCode: StatusCode)
         case object getFoo2ResponseOK extends getFoo2Response(StatusCodes.OK)

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/StaticParametersTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/StaticParametersTest.scala
@@ -50,10 +50,14 @@ class StaticParametersTest extends FunSuite with Matchers with SwaggerSpecRunner
           }
         }
         def routes(handler: Handler)(implicit mat: akka.stream.Materializer): Route = {
-          (get & (pathPrefix("foo") & pathEndOrSingleSlash & parameter("bar").require(_ == "2")) & discardEntity) {
-            complete(handler.getFoo2(getFoo2Response)())
-          } ~ (get & (path("foo") & parameter("bar").require(_ == "1")) & discardEntity) {
-            complete(handler.getFoo1(getFoo1Response)())
+          (get & (pathPrefix("foo") & pathEndOrSingleSlash & parameter("bar").require(_ == "2"))) {
+            discardEntity {
+              complete(handler.getFoo2(getFoo2Response)())
+            }
+          } ~ (get & (path("foo") & parameter("bar").require(_ == "1"))) {
+            discardEntity {
+              complete(handler.getFoo1(getFoo1Response)())
+            }
           }
         }
         sealed abstract class getFoo2Response(val statusCode: StatusCode)

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/StaticParametersTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/StaticParametersTest.scala
@@ -50,7 +50,7 @@ class StaticParametersTest extends FunSuite with Matchers with SwaggerSpecRunner
           }
         }
         def routes(handler: Handler)(implicit mat: akka.stream.Materializer): Route = {
-          (get & (pathPrefix("foo") & pathEndOrSingleSlash & parameter("bar").require(_ == "2")))(discardEntity(complete(handler.getFoo2(getFoo2Response)()))) ~ (get & (path("foo") & parameter("bar").require(_ == "1")))(discardEntity(complete(handler.getFoo1(getFoo1Response)())))
+          get((pathPrefix("foo") & pathEndOrSingleSlash & parameter("bar").require(_ == "2"))(discardEntity(complete(handler.getFoo2(getFoo2Response)())))) ~ get((path("foo") & parameter("bar").require(_ == "1"))(discardEntity(complete(handler.getFoo1(getFoo1Response)()))))
         }
         sealed abstract class getFoo2Response(val statusCode: StatusCode)
         case object getFoo2ResponseOK extends getFoo2Response(StatusCodes.OK)

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/StaticParametersTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/StaticParametersTest.scala
@@ -43,9 +43,11 @@ class StaticParametersTest extends FunSuite with Matchers with SwaggerSpecRunner
 
     val resource = q"""
       object Resource {
-        def discardEntity(implicit mat: akka.stream.Materializer): Directive0 = extractRequest.flatMap { req =>
-          req.discardEntityBytes().future
-          Directive.Empty
+        def discardEntity: Directive0 = extractMaterializer.flatMap { implicit mat =>
+          extractRequest.flatMap { req =>
+            req.discardEntityBytes().future
+            Directive.Empty
+          }
         }
         def routes(handler: Handler)(implicit mat: akka.stream.Materializer): Route = {
           (get & (pathPrefix("foo") & pathEndOrSingleSlash & parameter("bar").require(_ == "2")) & discardEntity) {

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/StaticParametersTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/StaticParametersTest.scala
@@ -50,7 +50,11 @@ class StaticParametersTest extends FunSuite with Matchers with SwaggerSpecRunner
           }
         }
         def routes(handler: Handler)(implicit mat: akka.stream.Materializer): Route = {
-          get((pathPrefix("foo") & pathEndOrSingleSlash & parameter("bar").require(_ == "2"))(discardEntity(complete(handler.getFoo2(getFoo2Response)())))) ~ get((path("foo") & parameter("bar").require(_ == "1"))(discardEntity(complete(handler.getFoo1(getFoo1Response)()))))
+          {
+            get((pathPrefix("foo") & pathEndOrSingleSlash & parameter("bar").require(_ == "2"))(discardEntity(complete(handler.getFoo2(getFoo2Response)()))))
+          } ~ {
+            get((path("foo") & parameter("bar").require(_ == "1"))(discardEntity(complete(handler.getFoo1(getFoo1Response)()))))
+          }
         }
         sealed abstract class getFoo2Response(val statusCode: StatusCode)
         case object getFoo2ResponseOK extends getFoo2Response(StatusCodes.OK)

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
@@ -86,67 +86,67 @@ class FormFieldsServerTest extends FunSuite with Matchers with SwaggerSpecRunner
           }
         }
         def routes(handler: Handler)(implicit mat: akka.stream.Materializer): Route = {
-          (put & path("foo") & ({
-            object putFooParts {
-              sealed trait Part
-              case class IgnoredPart(unit: Unit) extends Part
-              case class foo(value: String) extends Part
-              case class bar(value: Long) extends Part
-              case class baz(value: (File, Option[String], ContentType, String)) extends Part
-            }
-            val UnmarshalfooPart: Unmarshaller[Multipart.FormData.BodyPart, putFooParts.foo] = Unmarshaller { implicit executionContext =>
-              part => {
-                val json: Unmarshaller[Multipart.FormData.BodyPart, String] = MFDBPviaFSU(jsonEntityUnmarshaller[String])
-                val string: Unmarshaller[Multipart.FormData.BodyPart, String] = MFDBPviaFSU(BPEviaFSU(jsonDecoderUnmarshaller))
-                Unmarshaller.firstOf(json, string).apply(part).map(putFooParts.foo.apply)
+          (put & path("foo")) {
+            ({
+              object putFooParts {
+                sealed trait Part
+                case class IgnoredPart(unit: Unit) extends Part
+                case class foo(value: String) extends Part
+                case class bar(value: Long) extends Part
+                case class baz(value: (File, Option[String], ContentType, String)) extends Part
               }
-            }
-            val UnmarshalbarPart: Unmarshaller[Multipart.FormData.BodyPart, putFooParts.bar] = Unmarshaller { implicit executionContext =>
-              part => {
-                val json: Unmarshaller[Multipart.FormData.BodyPart, Long] = MFDBPviaFSU(jsonEntityUnmarshaller[Long])
-                val string: Unmarshaller[Multipart.FormData.BodyPart, Long] = MFDBPviaFSU(BPEviaFSU(jsonDecoderUnmarshaller))
-                Unmarshaller.firstOf(json, string).apply(part).map(putFooParts.bar.apply)
+              val UnmarshalfooPart: Unmarshaller[Multipart.FormData.BodyPart, putFooParts.foo] = Unmarshaller { implicit executionContext =>
+                part => {
+                  val json: Unmarshaller[Multipart.FormData.BodyPart, String] = MFDBPviaFSU(jsonEntityUnmarshaller[String])
+                  val string: Unmarshaller[Multipart.FormData.BodyPart, String] = MFDBPviaFSU(BPEviaFSU(jsonDecoderUnmarshaller))
+                  Unmarshaller.firstOf(json, string).apply(part).map(putFooParts.foo.apply)
+                }
               }
-            }
-            val UnmarshalbazPart: Unmarshaller[Multipart.FormData.BodyPart, putFooParts.baz] = handler.putFooUnmarshalToFile[Id]("SHA-512", handler.putFooMapFileField(_, _, _)).map({
-              case (v1, v2, v3, v4) =>
-                putFooParts.baz((v1, v2, v3, v4))
-            })
-            extractExecutionContext.flatMap { implicit executionContext =>
-              extractMaterializer.flatMap { implicit mat =>
-                val fileReferences = new AtomicReference(List.empty[File])
-                (extractSettings.flatMap {
-                  settings => handleExceptions(ExceptionHandler({
-                    case EntityStreamSizeException(limit, contentLength) =>
-                      fileReferences.get().foreach(_.delete())
-                      val summary = contentLength match {
-                        case Some(cl) =>
-                          s"Request Content-Length of $$cl bytes exceeds the configured limit of $$limit bytes"
-                        case None =>
-                          s"Aggregated data length of request entity exceeds the configured limit of $$limit bytes"
+              val UnmarshalbarPart: Unmarshaller[Multipart.FormData.BodyPart, putFooParts.bar] = Unmarshaller { implicit executionContext =>
+                part => {
+                  val json: Unmarshaller[Multipart.FormData.BodyPart, Long] = MFDBPviaFSU(jsonEntityUnmarshaller[Long])
+                  val string: Unmarshaller[Multipart.FormData.BodyPart, Long] = MFDBPviaFSU(BPEviaFSU(jsonDecoderUnmarshaller))
+                  Unmarshaller.firstOf(json, string).apply(part).map(putFooParts.bar.apply)
+                }
+              }
+              val UnmarshalbazPart: Unmarshaller[Multipart.FormData.BodyPart, putFooParts.baz] = handler.putFooUnmarshalToFile[Id]("SHA-512", handler.putFooMapFileField(_, _, _)).map({
+                case (v1, v2, v3, v4) =>
+                  putFooParts.baz((v1, v2, v3, v4))
+              })
+              extractExecutionContext.flatMap { implicit executionContext =>
+                extractMaterializer.flatMap { implicit mat =>
+                  val fileReferences = new AtomicReference(List.empty[File])
+                  (extractSettings.flatMap {
+                    settings => handleExceptions(ExceptionHandler({
+                      case EntityStreamSizeException(limit, contentLength) =>
+                        fileReferences.get().foreach(_.delete())
+                        val summary = contentLength match {
+                          case Some(cl) =>
+                            s"Request Content-Length of $$cl bytes exceeds the configured limit of $$limit bytes"
+                          case None =>
+                            s"Aggregated data length of request entity exceeds the configured limit of $$limit bytes"
+                        }
+                        val info = new ErrorInfo(summary, "Consider increasing the value of akka.http.server.parsing.max-content-length")
+                        val status = StatusCodes.RequestEntityTooLarge
+                        val msg = if (settings.verboseErrorMessages) info.formatPretty else info.summary
+                        complete(HttpResponse(status, entity = msg))
+                      case e: Throwable =>
+                        fileReferences.get().foreach(_.delete())
+                        throw e
+                    }))
+                  } & handleRejections { (rejections: scala.collection.immutable.Seq[Rejection]) =>
+                    fileReferences.get().foreach(_.delete())
+                    None
+                  } & mapResponse { resp =>
+                    fileReferences.get().foreach(_.delete())
+                    resp
+                  } & entity(as[Multipart.FormData])).flatMap { formData =>
+                    val collectedPartsF: Future[Either[Throwable, (Option[String], Option[Long], Option[(File, Option[String], ContentType, String)])]] = for (results <- formData.parts.mapConcat {
+                      part => if (Set[String]("foo", "bar", "baz").contains(part.name)) part :: Nil else {
+                        part.entity.discardBytes()
+                        Nil
                       }
-                      val info = new ErrorInfo(summary, "Consider increasing the value of akka.http.server.parsing.max-content-length")
-                      val status = StatusCodes.RequestEntityTooLarge
-                      val msg = if (settings.verboseErrorMessages) info.formatPretty else info.summary
-                      complete(HttpResponse(status, entity = msg))
-                    case e: Throwable =>
-                      fileReferences.get().foreach(_.delete())
-                      throw e
-                  }))
-                } & handleRejections { (rejections: scala.collection.immutable.Seq[Rejection]) =>
-                  fileReferences.get().foreach(_.delete())
-                  None
-                } & mapResponse { resp =>
-                  fileReferences.get().foreach(_.delete())
-                  resp
-                } & entity(as[Multipart.FormData])).flatMap { formData =>
-                  val collectedPartsF: Future[Either[Throwable, (Option[String], Option[Long], Option[(File, Option[String], ContentType, String)])]] = for (results <- formData.parts.mapConcat {
-                    part => if (Set[String]("foo", "bar", "baz").contains(part.name)) part :: Nil else {
-                      part.entity.discardBytes()
-                      Nil
-                    }
-                  }.mapAsync(1) { part =>
-                    {
+                    }.mapAsync(1) { part => {
                       part.name match {
                         case "foo" =>
                           SafeUnmarshaller(UnmarshalfooPart).apply(part)
@@ -157,34 +157,34 @@ class FormFieldsServerTest extends FunSuite with Matchers with SwaggerSpecRunner
                         case _ =>
                           SafeUnmarshaller(implicitly[Unmarshaller[Multipart.FormData.BodyPart, Unit]].map(putFooParts.IgnoredPart.apply(_))).apply(part)
                       }
+                    } }.toMat(Sink.seq[Either[Throwable, putFooParts.Part]])(Keep.right).run()) yield {
+                      results.toList.sequence.map { successes =>
+                        val fooO = successes.collectFirst({
+                          case putFooParts.foo(v1) => v1
+                        })
+                        val barO = successes.collectFirst({
+                          case putFooParts.bar(v1) => v1
+                        })
+                        val bazO = successes.collectFirst({
+                          case putFooParts.baz((v1, v2, v3, v4)) =>
+                            (v1, v2, v3, v4)
+                        })
+                        (fooO, barO, bazO)
+                      }
                     }
-                  }.toMat(Sink.seq[Either[Throwable, putFooParts.Part]])(Keep.right).run()) yield {
-                    results.toList.sequence.map { successes =>
-                      val fooO = successes.collectFirst({
-                        case putFooParts.foo(v1) => v1
-                      })
-                      val barO = successes.collectFirst({
-                        case putFooParts.bar(v1) => v1
-                      })
-                      val bazO = successes.collectFirst({
-                        case putFooParts.baz((v1, v2, v3, v4)) =>
-                          (v1, v2, v3, v4)
-                      })
-                      (fooO, barO, bazO)
-                    }
+                    onSuccess(collectedPartsF)
                   }
-                  onSuccess(collectedPartsF)
                 }
-              }
-            }.flatMap(_.fold(t => throw t, {
-              case (fooO, barO, bazO) =>
-                val maybe: Either[Rejection, (String, Long, (File, Option[String], ContentType, String))] = for (foo <- fooO.toRight(MissingFormFieldRejection("foo")); bar <- barO.toRight(MissingFormFieldRejection("bar")); baz <- bazO.toRight(MissingFormFieldRejection("baz"))) yield {
-                  (foo, bar, baz)
-                }
-                maybe.fold(reject(_), tprovide(_))
-            }))
-          }: Directive[(String, Long, (File, Option[String], ContentType, String))])) {
-            (foo, bar, baz) => complete(handler.putFoo(putFooResponse)(foo, bar, baz))
+              }.flatMap(_.fold(t => throw t, {
+                case (fooO, barO, bazO) =>
+                  val maybe: Either[Rejection, (String, Long, (File, Option[String], ContentType, String))] = for (foo <- fooO.toRight(MissingFormFieldRejection("foo")); bar <- barO.toRight(MissingFormFieldRejection("bar")); baz <- bazO.toRight(MissingFormFieldRejection("baz"))) yield {
+                    (foo, bar, baz)
+                  }
+                  maybe.fold(reject(_), tprovide(_))
+              }))
+            }: Directive[(String, Long, (File, Option[String], ContentType, String))]) { (foo, bar, baz) => {
+              complete(handler.putFoo(putFooResponse)(foo, bar, baz))
+            } }
           }
         }
         sealed abstract class putFooResponse(val statusCode: StatusCode)

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
@@ -86,102 +86,104 @@ class FormFieldsServerTest extends FunSuite with Matchers with SwaggerSpecRunner
           }
         }
         def routes(handler: Handler)(implicit mat: akka.stream.Materializer): Route = {
-          put(path("foo")(({
-            object putFooParts {
-              sealed trait Part
-              case class IgnoredPart(unit: Unit) extends Part
-              case class foo(value: String) extends Part
-              case class bar(value: Long) extends Part
-              case class baz(value: (File, Option[String], ContentType, String)) extends Part
-            }
-            val UnmarshalfooPart: Unmarshaller[Multipart.FormData.BodyPart, putFooParts.foo] = Unmarshaller { implicit executionContext =>
-              part => {
-                val json: Unmarshaller[Multipart.FormData.BodyPart, String] = MFDBPviaFSU(jsonEntityUnmarshaller[String])
-                val string: Unmarshaller[Multipart.FormData.BodyPart, String] = MFDBPviaFSU(BPEviaFSU(jsonDecoderUnmarshaller))
-                Unmarshaller.firstOf(json, string).apply(part).map(putFooParts.foo.apply)
+          {
+            put(path("foo")(({
+              object putFooParts {
+                sealed trait Part
+                case class IgnoredPart(unit: Unit) extends Part
+                case class foo(value: String) extends Part
+                case class bar(value: Long) extends Part
+                case class baz(value: (File, Option[String], ContentType, String)) extends Part
               }
-            }
-            val UnmarshalbarPart: Unmarshaller[Multipart.FormData.BodyPart, putFooParts.bar] = Unmarshaller { implicit executionContext =>
-              part => {
-                val json: Unmarshaller[Multipart.FormData.BodyPart, Long] = MFDBPviaFSU(jsonEntityUnmarshaller[Long])
-                val string: Unmarshaller[Multipart.FormData.BodyPart, Long] = MFDBPviaFSU(BPEviaFSU(jsonDecoderUnmarshaller))
-                Unmarshaller.firstOf(json, string).apply(part).map(putFooParts.bar.apply)
+              val UnmarshalfooPart: Unmarshaller[Multipart.FormData.BodyPart, putFooParts.foo] = Unmarshaller { implicit executionContext =>
+                part => {
+                  val json: Unmarshaller[Multipart.FormData.BodyPart, String] = MFDBPviaFSU(jsonEntityUnmarshaller[String])
+                  val string: Unmarshaller[Multipart.FormData.BodyPart, String] = MFDBPviaFSU(BPEviaFSU(jsonDecoderUnmarshaller))
+                  Unmarshaller.firstOf(json, string).apply(part).map(putFooParts.foo.apply)
+                }
               }
-            }
-            val UnmarshalbazPart: Unmarshaller[Multipart.FormData.BodyPart, putFooParts.baz] = handler.putFooUnmarshalToFile[Id]("SHA-512", handler.putFooMapFileField(_, _, _)).map({
-              case (v1, v2, v3, v4) =>
-                putFooParts.baz((v1, v2, v3, v4))
-            })
-            extractExecutionContext.flatMap { implicit executionContext =>
-              extractMaterializer.flatMap { implicit mat =>
-                val fileReferences = new AtomicReference(List.empty[File])
-                (extractSettings.flatMap {
-                  settings => handleExceptions(ExceptionHandler({
-                    case EntityStreamSizeException(limit, contentLength) =>
-                      fileReferences.get().foreach(_.delete())
-                      val summary = contentLength match {
-                        case Some(cl) =>
-                          s"Request Content-Length of $$cl bytes exceeds the configured limit of $$limit bytes"
-                        case None =>
-                          s"Aggregated data length of request entity exceeds the configured limit of $$limit bytes"
+              val UnmarshalbarPart: Unmarshaller[Multipart.FormData.BodyPart, putFooParts.bar] = Unmarshaller { implicit executionContext =>
+                part => {
+                  val json: Unmarshaller[Multipart.FormData.BodyPart, Long] = MFDBPviaFSU(jsonEntityUnmarshaller[Long])
+                  val string: Unmarshaller[Multipart.FormData.BodyPart, Long] = MFDBPviaFSU(BPEviaFSU(jsonDecoderUnmarshaller))
+                  Unmarshaller.firstOf(json, string).apply(part).map(putFooParts.bar.apply)
+                }
+              }
+              val UnmarshalbazPart: Unmarshaller[Multipart.FormData.BodyPart, putFooParts.baz] = handler.putFooUnmarshalToFile[Id]("SHA-512", handler.putFooMapFileField(_, _, _)).map({
+                case (v1, v2, v3, v4) =>
+                  putFooParts.baz((v1, v2, v3, v4))
+              })
+              extractExecutionContext.flatMap { implicit executionContext =>
+                extractMaterializer.flatMap { implicit mat =>
+                  val fileReferences = new AtomicReference(List.empty[File])
+                  (extractSettings.flatMap {
+                    settings => handleExceptions(ExceptionHandler({
+                      case EntityStreamSizeException(limit, contentLength) =>
+                        fileReferences.get().foreach(_.delete())
+                        val summary = contentLength match {
+                          case Some(cl) =>
+                            s"Request Content-Length of $$cl bytes exceeds the configured limit of $$limit bytes"
+                          case None =>
+                            s"Aggregated data length of request entity exceeds the configured limit of $$limit bytes"
+                        }
+                        val info = new ErrorInfo(summary, "Consider increasing the value of akka.http.server.parsing.max-content-length")
+                        val status = StatusCodes.RequestEntityTooLarge
+                        val msg = if (settings.verboseErrorMessages) info.formatPretty else info.summary
+                        complete(HttpResponse(status, entity = msg))
+                      case e: Throwable =>
+                        fileReferences.get().foreach(_.delete())
+                        throw e
+                    }))
+                  } & handleRejections { (rejections: scala.collection.immutable.Seq[Rejection]) =>
+                    fileReferences.get().foreach(_.delete())
+                    None
+                  } & mapResponse { resp =>
+                    fileReferences.get().foreach(_.delete())
+                    resp
+                  } & entity(as[Multipart.FormData])).flatMap { formData =>
+                    val collectedPartsF: Future[Either[Throwable, (Option[String], Option[Long], Option[(File, Option[String], ContentType, String)])]] = for (results <- formData.parts.mapConcat {
+                      part => if (Set[String]("foo", "bar", "baz").contains(part.name)) part :: Nil else {
+                        part.entity.discardBytes()
+                        Nil
                       }
-                      val info = new ErrorInfo(summary, "Consider increasing the value of akka.http.server.parsing.max-content-length")
-                      val status = StatusCodes.RequestEntityTooLarge
-                      val msg = if (settings.verboseErrorMessages) info.formatPretty else info.summary
-                      complete(HttpResponse(status, entity = msg))
-                    case e: Throwable =>
-                      fileReferences.get().foreach(_.delete())
-                      throw e
-                  }))
-                } & handleRejections { (rejections: scala.collection.immutable.Seq[Rejection]) =>
-                  fileReferences.get().foreach(_.delete())
-                  None
-                } & mapResponse { resp =>
-                  fileReferences.get().foreach(_.delete())
-                  resp
-                } & entity(as[Multipart.FormData])).flatMap { formData =>
-                  val collectedPartsF: Future[Either[Throwable, (Option[String], Option[Long], Option[(File, Option[String], ContentType, String)])]] = for (results <- formData.parts.mapConcat {
-                    part => if (Set[String]("foo", "bar", "baz").contains(part.name)) part :: Nil else {
-                      part.entity.discardBytes()
-                      Nil
+                    }.mapAsync(1) {
+                      part => part.name match {
+                        case "foo" =>
+                          SafeUnmarshaller(UnmarshalfooPart).apply(part)
+                        case "bar" =>
+                          SafeUnmarshaller(UnmarshalbarPart).apply(part)
+                        case "baz" =>
+                          SafeUnmarshaller(AccumulatingUnmarshaller(fileReferences, UnmarshalbazPart)(_.value._1)).apply(part)
+                        case _ =>
+                          SafeUnmarshaller(implicitly[Unmarshaller[Multipart.FormData.BodyPart, Unit]].map(putFooParts.IgnoredPart.apply(_))).apply(part)
+                      }
+                    }.toMat(Sink.seq[Either[Throwable, putFooParts.Part]])(Keep.right).run()) yield {
+                      results.toList.sequence.map { successes =>
+                        val fooO = successes.collectFirst({
+                          case putFooParts.foo(v1) => v1
+                        })
+                        val barO = successes.collectFirst({
+                          case putFooParts.bar(v1) => v1
+                        })
+                        val bazO = successes.collectFirst({
+                          case putFooParts.baz((v1, v2, v3, v4)) =>
+                            (v1, v2, v3, v4)
+                        })
+                        (fooO, barO, bazO)
+                      }
                     }
-                  }.mapAsync(1) {
-                    part => part.name match {
-                      case "foo" =>
-                        SafeUnmarshaller(UnmarshalfooPart).apply(part)
-                      case "bar" =>
-                        SafeUnmarshaller(UnmarshalbarPart).apply(part)
-                      case "baz" =>
-                        SafeUnmarshaller(AccumulatingUnmarshaller(fileReferences, UnmarshalbazPart)(_.value._1)).apply(part)
-                      case _ =>
-                        SafeUnmarshaller(implicitly[Unmarshaller[Multipart.FormData.BodyPart, Unit]].map(putFooParts.IgnoredPart.apply(_))).apply(part)
-                    }
-                  }.toMat(Sink.seq[Either[Throwable, putFooParts.Part]])(Keep.right).run()) yield {
-                    results.toList.sequence.map { successes =>
-                      val fooO = successes.collectFirst({
-                        case putFooParts.foo(v1) => v1
-                      })
-                      val barO = successes.collectFirst({
-                        case putFooParts.bar(v1) => v1
-                      })
-                      val bazO = successes.collectFirst({
-                        case putFooParts.baz((v1, v2, v3, v4)) =>
-                          (v1, v2, v3, v4)
-                      })
-                      (fooO, barO, bazO)
-                    }
+                    onSuccess(collectedPartsF)
                   }
-                  onSuccess(collectedPartsF)
                 }
-              }
-            }.flatMap(_.fold(t => throw t, {
-              case (fooO, barO, bazO) =>
-                val maybe: Either[Rejection, (String, Long, (File, Option[String], ContentType, String))] = for (foo <- fooO.toRight(MissingFormFieldRejection("foo")); bar <- barO.toRight(MissingFormFieldRejection("bar")); baz <- bazO.toRight(MissingFormFieldRejection("baz"))) yield {
-                  (foo, bar, baz)
-                }
-                maybe.fold(reject(_), tprovide(_))
-            }))
-          }: Directive[(String, Long, (File, Option[String], ContentType, String))])((foo, bar, baz) => complete(handler.putFoo(putFooResponse)(foo, bar, baz)))))
+              }.flatMap(_.fold(t => throw t, {
+                case (fooO, barO, bazO) =>
+                  val maybe: Either[Rejection, (String, Long, (File, Option[String], ContentType, String))] = for (foo <- fooO.toRight(MissingFormFieldRejection("foo")); bar <- barO.toRight(MissingFormFieldRejection("bar")); baz <- bazO.toRight(MissingFormFieldRejection("baz"))) yield {
+                    (foo, bar, baz)
+                  }
+                  maybe.fold(reject(_), tprovide(_))
+              }))
+            }: Directive[(String, Long, (File, Option[String], ContentType, String))])((foo, bar, baz) => complete(handler.putFoo(putFooResponse)(foo, bar, baz)))))
+          }
         }
         sealed abstract class putFooResponse(val statusCode: StatusCode)
         case object putFooResponseOK extends putFooResponse(StatusCodes.OK)

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
@@ -86,106 +86,102 @@ class FormFieldsServerTest extends FunSuite with Matchers with SwaggerSpecRunner
           }
         }
         def routes(handler: Handler)(implicit mat: akka.stream.Materializer): Route = {
-          (put & path("foo")) {
-            ({
-              object putFooParts {
-                sealed trait Part
-                case class IgnoredPart(unit: Unit) extends Part
-                case class foo(value: String) extends Part
-                case class bar(value: Long) extends Part
-                case class baz(value: (File, Option[String], ContentType, String)) extends Part
+          (put & path("foo"))(({
+            object putFooParts {
+              sealed trait Part
+              case class IgnoredPart(unit: Unit) extends Part
+              case class foo(value: String) extends Part
+              case class bar(value: Long) extends Part
+              case class baz(value: (File, Option[String], ContentType, String)) extends Part
+            }
+            val UnmarshalfooPart: Unmarshaller[Multipart.FormData.BodyPart, putFooParts.foo] = Unmarshaller { implicit executionContext =>
+              part => {
+                val json: Unmarshaller[Multipart.FormData.BodyPart, String] = MFDBPviaFSU(jsonEntityUnmarshaller[String])
+                val string: Unmarshaller[Multipart.FormData.BodyPart, String] = MFDBPviaFSU(BPEviaFSU(jsonDecoderUnmarshaller))
+                Unmarshaller.firstOf(json, string).apply(part).map(putFooParts.foo.apply)
               }
-              val UnmarshalfooPart: Unmarshaller[Multipart.FormData.BodyPart, putFooParts.foo] = Unmarshaller { implicit executionContext =>
-                part => {
-                  val json: Unmarshaller[Multipart.FormData.BodyPart, String] = MFDBPviaFSU(jsonEntityUnmarshaller[String])
-                  val string: Unmarshaller[Multipart.FormData.BodyPart, String] = MFDBPviaFSU(BPEviaFSU(jsonDecoderUnmarshaller))
-                  Unmarshaller.firstOf(json, string).apply(part).map(putFooParts.foo.apply)
-                }
+            }
+            val UnmarshalbarPart: Unmarshaller[Multipart.FormData.BodyPart, putFooParts.bar] = Unmarshaller { implicit executionContext =>
+              part => {
+                val json: Unmarshaller[Multipart.FormData.BodyPart, Long] = MFDBPviaFSU(jsonEntityUnmarshaller[Long])
+                val string: Unmarshaller[Multipart.FormData.BodyPart, Long] = MFDBPviaFSU(BPEviaFSU(jsonDecoderUnmarshaller))
+                Unmarshaller.firstOf(json, string).apply(part).map(putFooParts.bar.apply)
               }
-              val UnmarshalbarPart: Unmarshaller[Multipart.FormData.BodyPart, putFooParts.bar] = Unmarshaller { implicit executionContext =>
-                part => {
-                  val json: Unmarshaller[Multipart.FormData.BodyPart, Long] = MFDBPviaFSU(jsonEntityUnmarshaller[Long])
-                  val string: Unmarshaller[Multipart.FormData.BodyPart, Long] = MFDBPviaFSU(BPEviaFSU(jsonDecoderUnmarshaller))
-                  Unmarshaller.firstOf(json, string).apply(part).map(putFooParts.bar.apply)
-                }
-              }
-              val UnmarshalbazPart: Unmarshaller[Multipart.FormData.BodyPart, putFooParts.baz] = handler.putFooUnmarshalToFile[Id]("SHA-512", handler.putFooMapFileField(_, _, _)).map({
-                case (v1, v2, v3, v4) =>
-                  putFooParts.baz((v1, v2, v3, v4))
-              })
-              extractExecutionContext.flatMap { implicit executionContext =>
-                extractMaterializer.flatMap { implicit mat =>
-                  val fileReferences = new AtomicReference(List.empty[File])
-                  (extractSettings.flatMap {
-                    settings => handleExceptions(ExceptionHandler({
-                      case EntityStreamSizeException(limit, contentLength) =>
-                        fileReferences.get().foreach(_.delete())
-                        val summary = contentLength match {
-                          case Some(cl) =>
-                            s"Request Content-Length of $$cl bytes exceeds the configured limit of $$limit bytes"
-                          case None =>
-                            s"Aggregated data length of request entity exceeds the configured limit of $$limit bytes"
-                        }
-                        val info = new ErrorInfo(summary, "Consider increasing the value of akka.http.server.parsing.max-content-length")
-                        val status = StatusCodes.RequestEntityTooLarge
-                        val msg = if (settings.verboseErrorMessages) info.formatPretty else info.summary
-                        complete(HttpResponse(status, entity = msg))
-                      case e: Throwable =>
-                        fileReferences.get().foreach(_.delete())
-                        throw e
-                    }))
-                  } & handleRejections { (rejections: scala.collection.immutable.Seq[Rejection]) =>
-                    fileReferences.get().foreach(_.delete())
-                    None
-                  } & mapResponse { resp =>
-                    fileReferences.get().foreach(_.delete())
-                    resp
-                  } & entity(as[Multipart.FormData])).flatMap { formData =>
-                    val collectedPartsF: Future[Either[Throwable, (Option[String], Option[Long], Option[(File, Option[String], ContentType, String)])]] = for (results <- formData.parts.mapConcat {
-                      part => if (Set[String]("foo", "bar", "baz").contains(part.name)) part :: Nil else {
-                        part.entity.discardBytes()
-                        Nil
+            }
+            val UnmarshalbazPart: Unmarshaller[Multipart.FormData.BodyPart, putFooParts.baz] = handler.putFooUnmarshalToFile[Id]("SHA-512", handler.putFooMapFileField(_, _, _)).map({
+              case (v1, v2, v3, v4) =>
+                putFooParts.baz((v1, v2, v3, v4))
+            })
+            extractExecutionContext.flatMap { implicit executionContext =>
+              extractMaterializer.flatMap { implicit mat =>
+                val fileReferences = new AtomicReference(List.empty[File])
+                (extractSettings.flatMap {
+                  settings => handleExceptions(ExceptionHandler({
+                    case EntityStreamSizeException(limit, contentLength) =>
+                      fileReferences.get().foreach(_.delete())
+                      val summary = contentLength match {
+                        case Some(cl) =>
+                          s"Request Content-Length of $$cl bytes exceeds the configured limit of $$limit bytes"
+                        case None =>
+                          s"Aggregated data length of request entity exceeds the configured limit of $$limit bytes"
                       }
-                    }.mapAsync(1) { part => {
-                      part.name match {
-                        case "foo" =>
-                          SafeUnmarshaller(UnmarshalfooPart).apply(part)
-                        case "bar" =>
-                          SafeUnmarshaller(UnmarshalbarPart).apply(part)
-                        case "baz" =>
-                          SafeUnmarshaller(AccumulatingUnmarshaller(fileReferences, UnmarshalbazPart)(_.value._1)).apply(part)
-                        case _ =>
-                          SafeUnmarshaller(implicitly[Unmarshaller[Multipart.FormData.BodyPart, Unit]].map(putFooParts.IgnoredPart.apply(_))).apply(part)
-                      }
-                    } }.toMat(Sink.seq[Either[Throwable, putFooParts.Part]])(Keep.right).run()) yield {
-                      results.toList.sequence.map { successes =>
-                        val fooO = successes.collectFirst({
-                          case putFooParts.foo(v1) => v1
-                        })
-                        val barO = successes.collectFirst({
-                          case putFooParts.bar(v1) => v1
-                        })
-                        val bazO = successes.collectFirst({
-                          case putFooParts.baz((v1, v2, v3, v4)) =>
-                            (v1, v2, v3, v4)
-                        })
-                        (fooO, barO, bazO)
-                      }
+                      val info = new ErrorInfo(summary, "Consider increasing the value of akka.http.server.parsing.max-content-length")
+                      val status = StatusCodes.RequestEntityTooLarge
+                      val msg = if (settings.verboseErrorMessages) info.formatPretty else info.summary
+                      complete(HttpResponse(status, entity = msg))
+                    case e: Throwable =>
+                      fileReferences.get().foreach(_.delete())
+                      throw e
+                  }))
+                } & handleRejections { (rejections: scala.collection.immutable.Seq[Rejection]) =>
+                  fileReferences.get().foreach(_.delete())
+                  None
+                } & mapResponse { resp =>
+                  fileReferences.get().foreach(_.delete())
+                  resp
+                } & entity(as[Multipart.FormData])).flatMap { formData =>
+                  val collectedPartsF: Future[Either[Throwable, (Option[String], Option[Long], Option[(File, Option[String], ContentType, String)])]] = for (results <- formData.parts.mapConcat {
+                    part => if (Set[String]("foo", "bar", "baz").contains(part.name)) part :: Nil else {
+                      part.entity.discardBytes()
+                      Nil
                     }
-                    onSuccess(collectedPartsF)
+                  }.mapAsync(1) {
+                    part => part.name match {
+                      case "foo" =>
+                        SafeUnmarshaller(UnmarshalfooPart).apply(part)
+                      case "bar" =>
+                        SafeUnmarshaller(UnmarshalbarPart).apply(part)
+                      case "baz" =>
+                        SafeUnmarshaller(AccumulatingUnmarshaller(fileReferences, UnmarshalbazPart)(_.value._1)).apply(part)
+                      case _ =>
+                        SafeUnmarshaller(implicitly[Unmarshaller[Multipart.FormData.BodyPart, Unit]].map(putFooParts.IgnoredPart.apply(_))).apply(part)
+                    }
+                  }.toMat(Sink.seq[Either[Throwable, putFooParts.Part]])(Keep.right).run()) yield {
+                    results.toList.sequence.map { successes =>
+                      val fooO = successes.collectFirst({
+                        case putFooParts.foo(v1) => v1
+                      })
+                      val barO = successes.collectFirst({
+                        case putFooParts.bar(v1) => v1
+                      })
+                      val bazO = successes.collectFirst({
+                        case putFooParts.baz((v1, v2, v3, v4)) =>
+                          (v1, v2, v3, v4)
+                      })
+                      (fooO, barO, bazO)
+                    }
                   }
+                  onSuccess(collectedPartsF)
                 }
-              }.flatMap(_.fold(t => throw t, {
-                case (fooO, barO, bazO) =>
-                  val maybe: Either[Rejection, (String, Long, (File, Option[String], ContentType, String))] = for (foo <- fooO.toRight(MissingFormFieldRejection("foo")); bar <- barO.toRight(MissingFormFieldRejection("bar")); baz <- bazO.toRight(MissingFormFieldRejection("baz"))) yield {
-                    (foo, bar, baz)
-                  }
-                  maybe.fold(reject(_), tprovide(_))
-              }))
-            }: Directive[(String, Long, (File, Option[String], ContentType, String))]) { (foo, bar, baz) => {
-              complete(handler.putFoo(putFooResponse)(foo, bar, baz))
-            } }
-          }
+              }
+            }.flatMap(_.fold(t => throw t, {
+              case (fooO, barO, bazO) =>
+                val maybe: Either[Rejection, (String, Long, (File, Option[String], ContentType, String))] = for (foo <- fooO.toRight(MissingFormFieldRejection("foo")); bar <- barO.toRight(MissingFormFieldRejection("bar")); baz <- bazO.toRight(MissingFormFieldRejection("baz"))) yield {
+                  (foo, bar, baz)
+                }
+                maybe.fold(reject(_), tprovide(_))
+            }))
+          }: Directive[(String, Long, (File, Option[String], ContentType, String))])((foo, bar, baz) => complete(handler.putFoo(putFooResponse)(foo, bar, baz))))
         }
         sealed abstract class putFooResponse(val statusCode: StatusCode)
         case object putFooResponseOK extends putFooResponse(StatusCodes.OK)

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
@@ -79,9 +79,11 @@ class FormFieldsServerTest extends FunSuite with Matchers with SwaggerSpecRunner
     """
     val resource = q"""
       object Resource {
-        def discardEntity(implicit mat: akka.stream.Materializer): Directive0 = extractRequest.flatMap { req =>
-          req.discardEntityBytes().future
-          Directive.Empty
+        def discardEntity: Directive0 = extractMaterializer.flatMap { implicit mat =>
+          extractRequest.flatMap { req =>
+            req.discardEntityBytes().future
+            Directive.Empty
+          }
         }
         def routes(handler: Handler)(implicit mat: akka.stream.Materializer): Route = {
           (put & path("foo") & ({

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
@@ -86,7 +86,7 @@ class FormFieldsServerTest extends FunSuite with Matchers with SwaggerSpecRunner
           }
         }
         def routes(handler: Handler)(implicit mat: akka.stream.Materializer): Route = {
-          (put & path("foo"))(({
+          put(path("foo")(({
             object putFooParts {
               sealed trait Part
               case class IgnoredPart(unit: Unit) extends Part
@@ -181,7 +181,7 @@ class FormFieldsServerTest extends FunSuite with Matchers with SwaggerSpecRunner
                 }
                 maybe.fold(reject(_), tprovide(_))
             }))
-          }: Directive[(String, Long, (File, Option[String], ContentType, String))])((foo, bar, baz) => complete(handler.putFoo(putFooResponse)(foo, bar, baz))))
+          }: Directive[(String, Long, (File, Option[String], ContentType, String))])((foo, bar, baz) => complete(handler.putFoo(putFooResponse)(foo, bar, baz)))))
         }
         sealed abstract class putFooResponse(val statusCode: StatusCode)
         case object putFooResponseOK extends putFooResponse(StatusCodes.OK)

--- a/modules/sample-akkaHttp/src/test/scala/core/issues/Issue148.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/issues/Issue148.scala
@@ -38,49 +38,73 @@ class Issue148Suite extends FunSuite with Matchers with EitherValues with ScalaF
     })
 
     /* Correct mime type
+     * Missing header
+     */
+    Post("/test") ~> route ~> check {
+      rejection match {
+        case MissingHeaderRejection("x-header") => ()
+      }
+    }
+
+    /* Correct mime type
+     * Valid "x-header" value
      * Missing content
      */
-    Post("/test").withEntity(ContentTypes.`application/json`, "") ~> route ~> check {
+    Post("/test")
+      .withHeaders(RawHeader("x-header", "false"))
+      .withEntity(ContentTypes.`application/json`, "") ~> route ~> check {
       rejection match {
         case RequestEntityExpectedRejection => ()
       }
     }
 
     /* Correct mime type
+     * Valid "x-header" value
      * Invalid JSON
      */
-    Post("/test").withEntity(ContentTypes.`application/json`, "{") ~> route ~> check {
+    Post("/test")
+      .withHeaders(RawHeader("x-header", "false"))
+      .withEntity(ContentTypes.`application/json`, "{") ~> route ~> check {
       rejection match {
         case ex: MalformedRequestContentRejection => ex.message shouldBe "exhausted input"
       }
     }
 
     /* Correct mime type
+     * Valid "x-header" value
      * Valid JSON
      * Missing discriminator
      */
-    Post("/test").withEntity(ContentTypes.`application/json`, "{}") ~> route ~> check {
+    Post("/test")
+      .withHeaders(RawHeader("x-header", "false"))
+      .withEntity(ContentTypes.`application/json`, "{}") ~> route ~> check {
       rejection match {
         case ex: MalformedRequestContentRejection => ex.message shouldBe "Attempt to decode value on failed cursor: DownField(type)"
       }
     }
 
     /* Correct mime type
+     * Valid "x-header" value
      * Valid JSON
      * Invalid discriminator
      */
-    Post("/test").withEntity(ContentTypes.`application/json`, """{"type": "blep"}""") ~> route ~> check {
+    Post("/test")
+      .withHeaders(RawHeader("x-header", "false"))
+      .withEntity(ContentTypes.`application/json`, """{"type": "blep"}""") ~> route ~> check {
       rejection match {
         case ex: MalformedRequestContentRejection => ex.message shouldBe "Unknown value blep (valid: Bar): DownField(type)"
       }
     }
 
     /* Correct mime type
+     * Valid "x-header" value
      * Valid JSON
      * Valid discriminator
      * Missing "name" field
      */
-    Post("/test").withEntity(ContentTypes.`application/json`, """{"type": "Bar"}""") ~> route ~> check {
+    Post("/test")
+      .withHeaders(RawHeader("x-header", "false"))
+      .withEntity(ContentTypes.`application/json`, """{"type": "Bar"}""") ~> route ~> check {
       rejection match {
         case ex: MalformedRequestContentRejection => ex.message shouldBe "Attempt to decode value on failed cursor: DownField(name)"
       }

--- a/modules/sample/src/main/resources/issues/issue45.yaml
+++ b/modules/sample/src/main/resources/issues/issue45.yaml
@@ -1,0 +1,303 @@
+swagger: "2.0"
+info:
+  title: Whatever
+  version: 1.0.0
+host: localhost:1234
+schemes:
+  - http
+definitions:
+  User:
+    type: object
+    required:
+      - id
+    properties:
+      id:
+        type: string
+paths:
+  /{p1}/{p2}/{p3}/{p4}/{p5}/{p6}/{p7}/{p8}/{p9}/{p10}/{p11}/{p12}/{p13}/{p14}/{p15}/{p16}/{p17}/{p18}/{p19}/{p20}/{p21}/{p22}/{p23}/:
+    get:
+      operationId: ohNo_23
+      x-scala-package: pathological
+      produces:
+        - application/json
+      parameters:
+      - name: p1
+        in: path
+        required: true
+        type: string
+      - name: q1
+        in: query
+        required: true
+        type: string
+      - name: h1
+        in: header
+        required: true
+        type: string
+      - name: p2
+        in: path
+        required: true
+        type: string
+      - name: q2
+        in: query
+        required: true
+        type: string
+      - name: h2
+        in: header
+        required: true
+        type: string
+      - name: p3
+        in: path
+        required: true
+        type: string
+      - name: q3
+        in: query
+        required: true
+        type: string
+      - name: h3
+        in: header
+        required: true
+        type: string
+      - name: p4
+        in: path
+        required: true
+        type: string
+      - name: q4
+        in: query
+        required: true
+        type: string
+      - name: h4
+        in: header
+        required: true
+        type: string
+      - name: p5
+        in: path
+        required: true
+        type: string
+      - name: q5
+        in: query
+        required: true
+        type: string
+      - name: h5
+        in: header
+        required: true
+        type: string
+      - name: p6
+        in: path
+        required: true
+        type: string
+      - name: q6
+        in: query
+        required: true
+        type: string
+      - name: h6
+        in: header
+        required: true
+        type: string
+      - name: p7
+        in: path
+        required: true
+        type: string
+      - name: q7
+        in: query
+        required: true
+        type: string
+      - name: h7
+        in: header
+        required: true
+        type: string
+      - name: p8
+        in: path
+        required: true
+        type: string
+      - name: q8
+        in: query
+        required: true
+        type: string
+      - name: h8
+        in: header
+        required: true
+        type: string
+      - name: p9
+        in: path
+        required: true
+        type: string
+      - name: q9
+        in: query
+        required: true
+        type: string
+      - name: h9
+        in: header
+        required: true
+        type: string
+      - name: p10
+        in: path
+        required: true
+        type: string
+      - name: q10
+        in: query
+        required: true
+        type: string
+      - name: h10
+        in: header
+        required: true
+        type: string
+      - name: p11
+        in: path
+        required: true
+        type: string
+      - name: q11
+        in: query
+        required: true
+        type: string
+      - name: h11
+        in: header
+        required: true
+        type: string
+      - name: p12
+        in: path
+        required: true
+        type: string
+      - name: q12
+        in: query
+        required: true
+        type: string
+      - name: h12
+        in: header
+        required: true
+        type: string
+      - name: p13
+        in: path
+        required: true
+        type: string
+      - name: q13
+        in: query
+        required: true
+        type: string
+      - name: h13
+        in: header
+        required: true
+        type: string
+      - name: p14
+        in: path
+        required: true
+        type: string
+      - name: q14
+        in: query
+        required: true
+        type: string
+      - name: h14
+        in: header
+        required: true
+        type: string
+      - name: p15
+        in: path
+        required: true
+        type: string
+      - name: q15
+        in: query
+        required: true
+        type: string
+      - name: h15
+        in: header
+        required: true
+        type: string
+      - name: p16
+        in: path
+        required: true
+        type: string
+      - name: q16
+        in: query
+        required: true
+        type: string
+      - name: h16
+        in: header
+        required: true
+        type: string
+      - name: p17
+        in: path
+        required: true
+        type: string
+      - name: q17
+        in: query
+        required: true
+        type: string
+      - name: h17
+        in: header
+        required: true
+        type: string
+      - name: p18
+        in: path
+        required: true
+        type: string
+      - name: q18
+        in: query
+        required: true
+        type: string
+      - name: h18
+        in: header
+        required: true
+        type: string
+      - name: p19
+        in: path
+        required: true
+        type: string
+      - name: q19
+        in: query
+        required: true
+        type: string
+      - name: h19
+        in: header
+        required: true
+        type: string
+      - name: p20
+        in: path
+        required: true
+        type: string
+      - name: q20
+        in: query
+        required: true
+        type: string
+      - name: h20
+        in: header
+        required: true
+        type: string
+      - name: p21
+        in: path
+        required: true
+        type: string
+      - name: q21
+        in: query
+        required: true
+        type: string
+      - name: h21
+        in: header
+        required: true
+        type: string
+      - name: p22
+        in: path
+        required: true
+        type: string
+      - name: q22
+        in: query
+        required: true
+        type: string
+      - name: h22
+        in: header
+        required: true
+        type: string
+      - name: p23
+        in: path
+        required: true
+        type: string
+      - name: q23
+        in: query
+        required: true
+        type: string
+      - name: h23
+        in: header
+        required: true
+        type: string
+      responses:
+        '200':
+          schema:
+            $ref: '#/definitions/User'

--- a/support/write-pathological.sh
+++ b/support/write-pathological.sh
@@ -1,5 +1,6 @@
-target="modules/sample/src/main/resources/pathological-parameters.yaml"
-max=7
+target="modules/sample/src/main/resources/issues/issue45.yaml"
+min=23
+max=23
 cat >"${target}" <<!
 swagger: "2.0"
 info:
@@ -19,7 +20,7 @@ definitions:
 paths:
 !
 
-for c in $(seq 0 "$max"); do
+for c in $(seq "$min" "$max"); do
   echo -n '  /' >> "${target}"
 
 # Can't go higher than 7 due to 22 parameter limit


### PR DESCRIPTION
Resolves #45 

Finally got around to it, @manuelbernhardt!

Important notes
===

### Parse order
This changes the parse order of akka-http directives. Previously, we attempted to parse the entity before parsing the headers. Now, we parse everything we get in the base HTTP message before starting to parse the entity. This permits route failover before parsing the entity.

### Restrictions
~The only caveat is that this does not support more than 22 parameters in a single group (path, query string, headers, form fields). This may need to change, but the MVP here is to just split the individual groups; in the future, we'll need to divide the individual matchers into 22 parameter groups, but this should at least give a little bit of breathing room.~ Now it does!

### http4s
Turns out http4s also had a 22-parameter limit for the union between form field and header parameters, as they were added together then matched as a giant tuple. Now, the tuple is chunked into 21 parameter chunks, chaining the next tuple on the 22nd element.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
