### PR TITLE
Disambiguate akka-http when optional parameter lists are specified

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,7 @@ val exampleCases: List[(java.io.File, String, Boolean, List[String])] = List(
   (sampleResource("issues/issue164.yaml"), "issues.issue164", false, List.empty),
   (sampleResource("issues/issue215.yaml"), "issues.issue215", false, List.empty),
   (sampleResource("issues/issue218.yaml"), "issues.issue218", false, List.empty),
+  (sampleResource("issues/issue249.yaml"), "issues.issue249", false, List.empty),
   (sampleResource("multipart-form-data.yaml"), "multipartFormData", false, List.empty),
   (sampleResource("petstore.json"), "examples", false, List("--import", "support.PositiveLong")),
   (sampleResource("plain.json"), "tests.dtos", false, List.empty),

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
@@ -297,7 +297,7 @@ object AkkaHttpServerGenerator {
       directivesFromParams(
         arg => tpe => Target.pure(q"parameter(Symbol(${arg}).as[${tpe}])"),
         arg => tpe => Target.pure(q"parameter(Symbol(${arg}).as[${tpe}].*)"),
-        arg => tpe => Target.pure(q"parameter(Symbol(${arg}).as[${tpe}].*).map(xs => Option(xs)).apply"),
+        arg => tpe => Target.pure(q"parameter(Symbol(${arg}).as[${tpe}].*).map(xs => Option(xs).filterNot(_.isEmpty)).apply"),
         arg => tpe => Target.pure(q"parameter(Symbol(${arg}).as[${tpe}].?)")
       ) _
 
@@ -305,7 +305,7 @@ object AkkaHttpServerGenerator {
       directivesFromParams(
         arg => tpe => Target.pure(q"formField(Symbol(${arg}).as[${tpe}])"),
         arg => tpe => Target.pure(q"formField(Symbol(${arg}).as[${tpe}].*)"),
-        arg => tpe => Target.pure(q"formField(Symbol(${arg}).as[${tpe}].*).map(xs => Option(xs)).apply"),
+        arg => tpe => Target.pure(q"formField(Symbol(${arg}).as[${tpe}].*).map(xs => Option(xs).filterNot(_.isEmpty)).apply"),
         arg => tpe => Target.pure(q"formField(Symbol(${arg}).as[${tpe}].?)")
       ) _
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
@@ -218,10 +218,10 @@ object AkkaHttpServerGenerator {
     }
 
     def directivesFromParams(
-        required: Term => Type => Target[Term.Apply],
-        multi: Term => Type => Target[Term.Apply],
-        multiOpt: Term => Type => Target[Term.Apply],
-        optional: Term => Type => Target[Term.Apply]
+        required: Term => Type => Target[Term],
+        multi: Term => Type => Target[Term],
+        multiOpt: Term => Type => Target[Term],
+        optional: Term => Type => Target[Term]
     )(params: List[ScalaParameter[ScalaLanguage]]): Target[Option[Term]] =
       for {
         directives <- params.traverse {
@@ -297,7 +297,7 @@ object AkkaHttpServerGenerator {
       directivesFromParams(
         arg => tpe => Target.pure(q"parameter(Symbol(${arg}).as[${tpe}])"),
         arg => tpe => Target.pure(q"parameter(Symbol(${arg}).as[${tpe}].*)"),
-        arg => tpe => Target.pure(q"parameter(Symbol(${arg}).as[${tpe}].*).map(Option.apply _)"),
+        arg => tpe => Target.pure(q"parameter(Symbol(${arg}).as[${tpe}].*).map(xs => Option(xs)).apply"),
         arg => tpe => Target.pure(q"parameter(Symbol(${arg}).as[${tpe}].?)")
       ) _
 
@@ -305,7 +305,7 @@ object AkkaHttpServerGenerator {
       directivesFromParams(
         arg => tpe => Target.pure(q"formField(Symbol(${arg}).as[${tpe}])"),
         arg => tpe => Target.pure(q"formField(Symbol(${arg}).as[${tpe}].*)"),
-        arg => tpe => Target.pure(q"formField(Symbol(${arg}).as[${tpe}].*).map(Option.apply _)"),
+        arg => tpe => Target.pure(q"formField(Symbol(${arg}).as[${tpe}].*).map(xs => Option(xs)).apply"),
         arg => tpe => Target.pure(q"formField(Symbol(${arg}).as[${tpe}].?)")
       ) _
 

--- a/modules/sample/src/main/resources/issues/issue249.yaml
+++ b/modules/sample/src/main/resources/issues/issue249.yaml
@@ -1,0 +1,26 @@
+swagger: "2.0"
+host: localhost:1234
+schemes:
+  - http
+definitions:
+  Baz:
+    type: string
+    enum:
+      - beep
+      - borp
+      - blap
+paths:
+  "/foo":
+    get:
+      operationId: doFoo
+      produces:
+        - application/json
+      parameters:
+        - name: bar
+          in: query
+          type: array
+          items:
+            $ref: "#/definitions/Baz"
+      responses:
+        200:
+          description: OK

--- a/notes/0.47.1.md
+++ b/notes/0.47.1.md
@@ -1,0 +1,8 @@
+Adding support for too many arguments in Scala frameworks (22 parameter limit)
+====
+
+Included issues:
+- twilio/guardrail#45 Adding support for too many arguments in Scala frameworks (22 parameter limit)
+
+Contributors:
+- @blast-hardcheese


### PR DESCRIPTION
Resolves: #249 

- Resolves syntactic ambiguity for akka-http parameter matching
- Additionally, for optional `type: array` parameters, adds a `filter(_.nonEmpty)`, removing the possibility of `Some(Nil)`
- Also fixing optional list parameter matching compiler error in http4s that was exposed when adding the tests for akka-http.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
