### PR TITLE
Don't wrap optional List properties in Optional

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,7 @@ val exampleCases: List[(java.io.File, String, Boolean, List[String])] = List(
   (sampleResource("issues/issue164.yaml"), "issues.issue164", false, List.empty),
   (sampleResource("issues/issue215.yaml"), "issues.issue215", false, List.empty),
   (sampleResource("issues/issue218.yaml"), "issues.issue218", false, List.empty),
+  (sampleResource("issues/issue247.yaml"), "issues.issue247", false, List.empty),
   (sampleResource("issues/issue249.yaml"), "issues.issue249", false, List.empty),
   (sampleResource("multipart-form-data.yaml"), "multipartFormData", false, List.empty),
   (sampleResource("petstore.json"), "examples", false, List("--import", "support.PositiveLong")),

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
@@ -38,6 +38,11 @@ object JacksonGenerator {
     params
       .map({
         case ProtocolParameter(term, name, _, _, _, selfDefaultValue) =>
+          val fieldType = if (term.getType.isOptional && term.getType.containedType.isNamed("List")) {
+            term.getType.containedType
+          } else {
+            term.getType
+          }
           val parameterType = if (term.getType.isOptional) {
             term.getType.containedType.unbox
           } else {
@@ -45,7 +50,7 @@ object JacksonGenerator {
           }
           val defaultValue = defaultValueToExpression(selfDefaultValue)
 
-          ParameterTerm(name, term.getNameAsString, term.getType, parameterType, defaultValue)
+          ParameterTerm(name, term.getNameAsString, fieldType, parameterType, defaultValue)
       })
       .partition(
         pt => !pt.fieldType.isOptional && pt.defaultValue.isEmpty

--- a/modules/sample-dropwizard/src/test/scala/issues/Issue247.scala
+++ b/modules/sample-dropwizard/src/test/scala/issues/Issue247.scala
@@ -1,0 +1,12 @@
+package issues
+
+import issues.issue247.client.dropwizard.definitions.Issue247Foo
+import org.scalatest.{FreeSpec, Matchers}
+
+class Issue247 extends FreeSpec with Matchers {
+  "Optional list properties in POJOs should not be wrapped in Optional" in {
+    val field = classOf[Issue247Foo].getDeclaredField("optionalList")
+    field shouldNot be(null)
+    field.getType shouldBe classOf[java.util.List[_]]
+  }
+}

--- a/modules/sample/src/main/resources/issues/issue247.yaml
+++ b/modules/sample/src/main/resources/issues/issue247.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.2
+info:
+  title: Whatever
+  version: 1.0.0
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      x-scala-package: issue247
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Issue247Foo"
+components:
+  schemas:
+    Issue247Foo:
+      type: object
+      properties:
+        optional_list:
+          type: array
+          items:
+            type: string


### PR DESCRIPTION
There's no need to do this, and it results in `null` for the property in the JSON rather than an empty list, which is usually not desired.

Addresses https://github.com/twilio/guardrail/issues/247

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
