### PR TITLE
Fixed issue 260

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
@@ -60,7 +60,7 @@ object Http4sServerGenerator {
             List(combinedRouteTerms),
             List.empty,
             methodSigs,
-            renderedRoutes.flatMap(_.supportDefinitions),
+            renderedRoutes.flatMap(_.supportDefinitions).groupBy(_.structure).map(_._2.head).toList, // Only unique supportDefinitions by structure
             renderedRoutes.flatMap(_.handlerDefinitions)
           )
         }

--- a/modules/codegen/src/test/scala/core/issues/Issue260.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue260.scala
@@ -1,0 +1,92 @@
+package core.issues
+
+import com.twilio.guardrail.generators.Http4s
+import com.twilio.guardrail.{Context, Server, Servers}
+import org.scalatest.{FunSpec, Matchers}
+import support.SwaggerSpecRunner
+
+class Issue260 extends FunSpec with Matchers with SwaggerSpecRunner {
+
+  describe("LocalDate path param is generated more than once") {
+
+    val swagger: String ="""
+      | openapi: "3.0.0"
+      | info:
+      |   title: Generator Error Sample
+      |   version: 1.0.0
+      | paths:
+      |   /users/{userId}/occasions/{date}:
+      |     parameters:
+      |       - $ref: '#/components/parameters/UserIdParam'
+      |       - $ref: '#/components/parameters/DateParam'
+      |     get:
+      |       operationId: getOccasionByDate
+      |       responses:
+      |         200:
+      |           description: Requested occasion
+      |           content:
+      |             application/json:
+      |               schema:
+      |                 $ref: '#/components/schemas/OccasionResponseJson'
+      |         404:
+      |           description: Requested user or occasion was not found
+      |     delete:
+      |       operationId: deleteOccasionByDate
+      |       responses:
+      |         204:
+      |           description: Succesfully deleted occasion
+      |         404:
+      |           description: Requested user or occasion was not found
+      | components:
+      |   parameters:
+      |     UserIdParam:
+      |       name: userId
+      |       in: path
+      |       description: Id of the specific user
+      |       required: true
+      |       schema:
+      |         type: string
+      |     DateParam:
+      |       name: date
+      |       in: path
+      |       description: Date of the specific occasion
+      |       required: true
+      |       schema:
+      |         type: string
+      |         format: date
+      |   schemas:
+      |     OccasionResponseJson:
+      |       type: object
+      |       properties:
+      |         date:
+      |           type: string
+      |           format: date
+      |       required:
+      |         - date""".stripMargin
+
+    val (
+      _, // ProtocolDefinitions
+      _, // clients
+      Servers(
+        Server(
+          _, // pkg
+          _, // extraImports
+          _, // genHandler
+          serverDefinition :: _
+        ) :: Nil,
+        _ // supportDefinitions
+      )
+    ) = runSwaggerSpec(swagger)(Context.empty, Http4s)
+
+    it("Ensure LocalDateVar is generated only once") {
+
+      val pattern = "object LocalDateVar".r
+
+      val hits = pattern.findAllIn(serverDefinition.toString()).length
+
+      println(serverDefinition.toString())
+
+      hits shouldBe 1
+    }
+  }
+}


### PR DESCRIPTION
Fix for issue: https://github.com/twilio/guardrail/issues/260

Using date as path param type in multiple paths will no longer generate multiple LocalDateVar objects.

This might also apply to other 'non native' path param types.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
