### PR TITLE
Fix enum naming

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,6 +42,7 @@ val exampleCases: List[(java.io.File, String, Boolean, List[String])] = List(
   (sampleResource("issues/issue215.yaml"), "issues.issue215", false, List.empty),
   (sampleResource("issues/issue218.yaml"), "issues.issue218", false, List.empty),
   (sampleResource("issues/issue249.yaml"), "issues.issue249", false, List.empty),
+  (sampleResource("issues/issue264.yaml"), "issues.issue264", false, List.empty),
   (sampleResource("multipart-form-data.yaml"), "multipartFormData", false, List.empty),
   (sampleResource("petstore.json"), "examples", false, List("--import", "support.PositiveLong")),
   (sampleResource("plain.json"), "tests.dtos", false, List.empty),

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
@@ -5,7 +5,6 @@ import _root_.io.swagger.v3.oas.models.media._
 import cats.free.Free
 import cats.implicits._
 import com.twilio.guardrail.extract.VendorExtension.VendorExtensible._
-import com.twilio.guardrail.generators.syntax.RichString
 import com.twilio.guardrail.languages.LA
 import com.twilio.guardrail.protocol.terms.protocol._
 import com.twilio.guardrail.terms.framework.FrameworkTerms
@@ -69,8 +68,8 @@ object ProtocolGenerator {
     def validProg(enum: List[String], tpe: L#Type): Free[F, EnumDefinition[L]] =
       for {
         elems <- enum.traverse { elem =>
-          val termName = elem.toPascalCase
           for {
+            termName  <- formatEnumName(elem)
             valueTerm <- pureTermName(termName)
             accessor  <- buildAccessor(clsName, termName)
           } yield (elem, valueTerm, accessor)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
@@ -497,7 +497,7 @@ object AsyncHttpClientClientGenerator {
                   Some(
                     new MethodDeclaration(
                       util.EnumSet.of(PUBLIC),
-                      s"with${param.getNameAsString.unescapeReservedWord.capitalize}",
+                      s"with${param.getNameAsString.unescapeIdentifier.capitalize}",
                       callBuilderType,
                       List(
                         new Parameter(util.EnumSet.of(FINAL), argType, new SimpleName(methodParamName))
@@ -529,7 +529,7 @@ object AsyncHttpClientClientGenerator {
 
                 val mainMethod = new MethodDeclaration(
                   util.EnumSet.of(PUBLIC),
-                  s"with${param.getNameAsString.unescapeReservedWord.capitalize}",
+                  s"with${param.getNameAsString.unescapeIdentifier.capitalize}",
                   callBuilderType,
                   List(
                     new Parameter(util.EnumSet.of(FINAL), containedType, new SimpleName(param.getNameAsString))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
@@ -316,7 +316,7 @@ object JacksonGenerator {
                 ).mapN((_, _))
               )(Function.const(Target.pure((tpe, defaultValue))) _)
             (finalDeclType, finalDefaultValue) = _declDefaultPair
-            term <- safeParseParameter(s"final ${finalDeclType} ${argName.escapeReservedWord}")
+            term <- safeParseParameter(s"final ${finalDeclType} ${argName.escapeIdentifier}")
             dep = classDep.filterNot(_.value == clsName) // Filter out our own class name
           } yield ProtocolParameter[JavaLanguage](term, name, dep, readOnlyKey, emptyToNull, defaultValue)
         }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
@@ -103,7 +103,7 @@ object JacksonGenerator {
           case (value, termName, _) =>
             new EnumConstantDeclaration(
               new NodeList(),
-              new SimpleName(termName.getIdentifier.toSnakeCase.toUpperCase(Locale.US)),
+              new SimpleName(termName.getIdentifier),
               new NodeList(new StringLiteralExpr(value)),
               new NodeList()
             )

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
@@ -137,13 +137,13 @@ object JavaGenerator {
         Option(tpe).map(_.trim).filterNot(_.isEmpty).traverse(safeParseName)
 
       case PureTermName(tpe) =>
-        Option(tpe).map(_.trim).filterNot(_.isEmpty).map(_.escapeReservedWord).map(safeParseName).getOrElse(Target.raiseError("A structure's name is empty"))
+        Option(tpe).map(_.trim).filterNot(_.isEmpty).map(_.escapeIdentifier).map(safeParseName).getOrElse(Target.raiseError("A structure's name is empty"))
 
       case PureTypeName(tpe) =>
         Option(tpe).map(_.trim).filterNot(_.isEmpty).map(safeParseName).getOrElse(Target.raiseError("A structure's name is empty"))
 
       case PureMethodParameter(nameStr, tpe, default) =>
-        safeParseSimpleName(nameStr.asString.escapeReservedWord).map(name => new Parameter(util.EnumSet.of(Modifier.FINAL), tpe, name))
+        safeParseSimpleName(nameStr.asString.escapeIdentifier).map(name => new Parameter(util.EnumSet.of(Modifier.FINAL), tpe, name))
 
       case TypeNamesEqual(a, b) =>
         Target.pure(a.asString == b.asString)
@@ -169,7 +169,7 @@ object JavaGenerator {
         Target.pure(term.asString)
 
       case AlterMethodParameterName(param, name) =>
-        safeParseSimpleName(name.asString.escapeReservedWord).map(
+        safeParseSimpleName(name.asString.escapeIdentifier).map(
           new Parameter(
             param.getTokenRange.orElse(null),
             param.getModifiers,

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
@@ -13,11 +13,13 @@ import com.google.googlejavaformat.java.{ Formatter, JavaFormatterOptions }
 import com.twilio.guardrail._
 import com.twilio.guardrail.Common.resolveFile
 import com.twilio.guardrail.generators.syntax.Java._
+import com.twilio.guardrail.generators.syntax.RichString
 import com.twilio.guardrail.languages.JavaLanguage
 import com.twilio.guardrail.terms._
 import java.nio.charset.StandardCharsets
 import java.nio.file.Path
 import java.util
+import java.util.Locale
 import scala.collection.JavaConverters._
 
 object JavaGenerator {
@@ -105,6 +107,7 @@ object JavaGenerator {
             Target.raiseError(s"Enumeration ${tpe} somehow has a default value that isn't a string")
         }
       }
+      case FormatEnumName(enumValue) => Target.pure(enumValue.toSnakeCase.toUpperCase(Locale.US))
       case EmbedArray(tpe) =>
         tpe match {
           case SwaggerUtil.Deferred(tpe) =>

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
@@ -4,6 +4,7 @@ import cats.syntax.either._
 import cats.~>
 import com.twilio.guardrail._
 import com.twilio.guardrail.Common.resolveFile
+import com.twilio.guardrail.generators.syntax.RichString
 import com.twilio.guardrail.generators.syntax.Scala._
 import com.twilio.guardrail.languages.ScalaLanguage
 import com.twilio.guardrail.terms._
@@ -50,6 +51,7 @@ object ScalaGenerator {
             Target.raiseError[Term.Select](s"Enumeration ${tpe} somehow has a default value that isn't a string")
         }
       }
+      case FormatEnumName(enumValue) => Target.pure(enumValue.toPascalCase)
       case EmbedArray(tpe) =>
         tpe match {
           case SwaggerUtil.Deferred(tpe) =>

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/Java.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/Java.scala
@@ -170,6 +170,19 @@ object Java {
       } else {
         s
       }
+
+    def escapeIdentifier: String = {
+      val reservedEscaped = s.escapeReservedWord
+      if (reservedEscaped.nonEmpty && reservedEscaped.charAt(0) >= '0' && reservedEscaped.charAt(0) <= '9') "_" + reservedEscaped
+      else reservedEscaped
+    }
+
+    def unescapeIdentifier: String = {
+      val removedLeadingUnderscore =
+        if (s.startsWith("_") && s.length >= 2 && s.charAt(1) >= '0' && s.charAt(1) <= '9') s.substring(1)
+        else s
+      removedLeadingUnderscore.unescapeReservedWord
+    }
   }
 
   def sortDefinitions(defns: List[BodyDeclaration[_ <: BodyDeclaration[_]]]): List[BodyDeclaration[_ <: BodyDeclaration[_]]] = {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/package.scala
@@ -38,6 +38,7 @@ package object syntax {
         "^([A-Z])".r.replaceAllIn(s, m => m.group(1).toLowerCase(Locale.US))
       "([A-Z])".r
         .replaceAllIn(lowercased, m => '-' +: m.group(1).toLowerCase(Locale.US))
+        .replaceAllLiterally(" ", "-")
     }
   }
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/package.scala
@@ -9,7 +9,7 @@ package object syntax {
   )
 
   private val toPascalRegexes = List(
-    "[\\._-]([a-z])".r, // dotted, snake, or dashed case
+    "[\\._-]([a-z0-9])".r, // dotted, snake, or dashed case
     "\\s+([a-zA-Z])".r, // spaces
     "^([a-z])".r // initial letter
   )

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/package.scala
@@ -30,7 +30,7 @@ package object syntax {
     def toSnakeCase: String = {
       val noPascal  = "^[A-Z]".r.replaceAllIn(s, _.group(0).toLowerCase(Locale.US))
       val fromCamel = "[A-Z]".r.replaceAllIn(noPascal, "_" + _.group(0))
-      fromCamel.replaceAllLiterally("-", "_")
+      fromCamel.replaceAll("[- ]", "_")
     }
 
     def toDashedCase: String = {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/package.scala
@@ -22,7 +22,7 @@ package object syntax {
 
     def toCamelCase: String = {
       val fromSnakeOrDashed =
-        "[_-]([a-z])".r.replaceAllIn(s, m => m.group(1).toUpperCase(Locale.US))
+        "[-_ ]([a-z])".r.replaceAllIn(s, m => m.group(1).toUpperCase(Locale.US))
       "^([A-Z])".r
         .replaceAllIn(fromSnakeOrDashed, m => m.group(1).toLowerCase(Locale.US))
     }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerm.scala
@@ -24,6 +24,7 @@ case class LiftMapType[L <: LA](value: L#Type)      extends ScalaTerm[L, L#Type]
 
 case class LookupEnumDefaultValue[L <: LA](tpe: L#TypeName, defaultValue: L#Term, values: List[(String, L#TermName, L#TermSelect)])
     extends ScalaTerm[L, L#TermSelect]
+case class FormatEnumName[L <: LA](enumValue: String) extends ScalaTerm[L, String]
 
 case class EmbedArray[L <: LA](tpe: LazyResolvedType[L]) extends ScalaTerm[L, LazyResolvedType[L]]
 case class EmbedMap[L <: LA](tpe: LazyResolvedType[L])   extends ScalaTerm[L, LazyResolvedType[L]]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerms.scala
@@ -25,6 +25,7 @@ class ScalaTerms[L <: LA, F[_]](implicit I: InjectK[ScalaTerm[L, ?], F]) {
 
   def lookupEnumDefaultValue(tpe: L#TypeName, defaultValue: L#Term, values: List[(String, L#TermName, L#TermSelect)]): Free[F, L#TermSelect] =
     Free.inject[ScalaTerm[L, ?], F](LookupEnumDefaultValue(tpe, defaultValue, values))
+  def formatEnumName(enumValue: String): Free[F, String] = Free.inject[ScalaTerm[L, ?], F](FormatEnumName(enumValue))
 
   def embedArray(tpe: LazyResolvedType[L]): Free[F, LazyResolvedType[L]] = Free.inject[ScalaTerm[L, ?], F](EmbedArray(tpe))
   def embedMap(tpe: LazyResolvedType[L]): Free[F, LazyResolvedType[L]]   = Free.inject[ScalaTerm[L, ?], F](EmbedMap(tpe))

--- a/modules/codegen/src/test/scala/com/twilio/guardrail/generators/syntax/JavaSyntaxTest.scala
+++ b/modules/codegen/src/test/scala/com/twilio/guardrail/generators/syntax/JavaSyntaxTest.scala
@@ -1,0 +1,85 @@
+package com.twilio.guardrail.generators.syntax
+
+import com.twilio.guardrail.generators.syntax.Java._
+import org.scalatest.{ FreeSpec, Matchers }
+import scala.util.Random
+
+object JavaSyntaxTest {
+  val TEST_RESERVED_WORDS = List(
+    "for",
+    "public",
+    "if",
+    "else",
+    "throw"
+  )
+}
+
+class JavaSyntaxTest extends FreeSpec with Matchers {
+  import JavaSyntaxTest._
+
+  "Reserved work escaper should" - {
+    "Escape reserved words" in {
+      TEST_RESERVED_WORDS.foreach({ word =>
+        word.escapeReservedWord shouldBe (word + "_")
+      })
+    }
+
+    "Not escape non-reserved words" in {
+      List(
+        "foo",
+        "bar",
+        "baz",
+        "monkey",
+        "cheese",
+        "blah-moo",
+        "aasdad2"
+      ).foreach({ word =>
+        word.escapeReservedWord shouldBe word
+      })
+    }
+  }
+
+  "Identifier escaper should" - {
+    "Escape identifiers that are reserved words" in {
+      TEST_RESERVED_WORDS.foreach({ word =>
+        word.escapeIdentifier shouldBe (word + "_")
+      })
+    }
+
+    "Escape identifiers that start with a number" in {
+      List(
+        "2",
+        "3foo",
+        "4-bar"
+      ).foreach({ word =>
+        word.escapeIdentifier shouldBe ("_" + word)
+      })
+    }
+
+    "Not escape identifiers that don't start with numbers" in {
+      List(
+        "f",
+        "foo",
+        "bar-baz",
+        "quux"
+      ).foreach({ word =>
+        word.escapeIdentifier shouldBe word
+      })
+    }
+
+    "Escape properly with a bunch of random stuff thrown at it" in {
+      new Random().alphanumeric
+        .grouped(20)
+        .take(500)
+        .foreach({ wordChars =>
+          val word    = wordChars.mkString
+          val escaped = word.escapeIdentifier
+          if ("^[0-9]".r.findFirstMatchIn(word).isDefined) {
+            escaped shouldBe ("_" + word)
+          } else {
+            escaped shouldBe word
+          }
+        })
+    }
+  }
+}

--- a/modules/sample/src/main/resources/issues/issue264.yaml
+++ b/modules/sample/src/main/resources/issues/issue264.yaml
@@ -20,3 +20,4 @@ components:
       enum:
         - foo-bar-1
         - baz-quux-2-flurb
+        - 3-moo-cow

--- a/modules/sample/src/main/resources/issues/issue264.yaml
+++ b/modules/sample/src/main/resources/issues/issue264.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.1
+info:
+  version: 1.0.0
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      parameters:
+        - in: query
+          name: FooEnum
+          $ref: "#/components/schemas/FooEnum"
+          required: true
+      responses:
+        204:
+          description: OK
+components:
+  schemas:
+    FooEnum:
+      type: string
+      enum:
+        - foo-bar-1
+        - baz-quux-2-flurb

--- a/modules/sample/src/main/resources/issues/issue264.yaml
+++ b/modules/sample/src/main/resources/issues/issue264.yaml
@@ -20,4 +20,4 @@ components:
       enum:
         - foo-bar-1
         - baz-quux-2-flurb
-        - 3-moo-cow
+#        - 3-moo-cow


### PR DESCRIPTION
Addresses https://github.com/twilio/guardrail/issues/264

This also cleans up some deficiencies with our case converters, namely not handling spaces as separators in the original identifier, and not handling numbers as the initial character in a grouping when converting to pascal case.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
