### PR TITLE
Add missing description field to operation params

### DIFF
--- a/docs/book.md
+++ b/docs/book.md
@@ -107,6 +107,13 @@ paths:                                      # All HTTP paths are direct children
                                             # parameter name.
 
         in: path                            # Where to look for the parameter
+        
+        description: The ID of the user     # The optional `description` parameter is not used in guardrail,
+                                            # but is useful for providing a detailed explanation on what is
+                                            # expected as a value for the parameter. For example: 
+                                            # `description: User IDs are strings comprised of the concatenation 
+                                            # of the two upper-case letters ID and a UUID stripped of any dashes
+                                            # i.e. ID4d9b1c54e4664c9d92aba94151a7f59f`
 
         required: true                      # Required fields cannot be missing. `required: false` fields are
                                             # represented as `Option[T]`


### PR DESCRIPTION
Parameter descriptions provide good insight on specificities of what values are expected for each parameter. The field is optional and is described as such

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
