### PR TITLE
Flatten Jackson inheritance hierarchies where needed

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
@@ -275,6 +275,348 @@ object JacksonGenerator {
     }
   }
 
+  private def renderDTOClass(clsName: String,
+                             selfParams: List[ProtocolParameter[JavaLanguage]],
+                             parents: List[SuperClass[JavaLanguage]]): Target[TypeDeclaration[_ <: TypeDeclaration[_]]] = {
+    val parentsWithDiscriminators = parents.collect({ case p if p.discriminators.nonEmpty => p })
+    for {
+      dtoClassType <- safeParseClassOrInterfaceType(clsName)
+      parentOpt <- (parentsWithDiscriminators, parents) match {
+        case _ if parentsWithDiscriminators.length > 1 =>
+          Target.raiseError[Option[SuperClass[JavaLanguage]]](
+            s"${clsName} requires unsupported multiple inheritance due to multiple parents with discriminators (${parentsWithDiscriminators.map(_.clsName).mkString(", ")})"
+          )
+        case _ if parentsWithDiscriminators.length == 1 => Target.pure(parentsWithDiscriminators.headOption)
+        case _ if parents.length == 1                   => Target.pure(parents.headOption)
+        case _                                          => Target.pure(None)
+      }
+    } yield {
+      val discriminators                             = parents.flatMap(_.discriminators)
+      val parentParams                               = parentOpt.toList.flatMap(_.params)
+      val parentParamNames                           = parentParams.map(_.name)
+      val (parentRequiredTerms, parentOptionalTerms) = sortParams(parentParams)
+      val parentTerms                                = parentRequiredTerms ++ parentOptionalTerms
+      val params = parents.filterNot(parent => parentOpt.contains(parent)).flatMap(_.params) ++ selfParams.filterNot(
+        param => discriminators.contains(param.term.getName.getIdentifier) || parentParamNames.contains(param.term.getName.getIdentifier)
+      )
+      val (requiredTerms, optionalTerms) = sortParams(params)
+      val terms                          = requiredTerms ++ optionalTerms
+
+      val dtoClass = new ClassOrInterfaceDeclaration(util.EnumSet.of(PUBLIC), false, clsName)
+      dtoClass.addAnnotation(
+        new NormalAnnotationExpr(
+          new Name("JsonIgnoreProperties"),
+          new NodeList(
+            new MemberValuePair(
+              "ignoreUnknown",
+              new BooleanLiteralExpr(true)
+            )
+          )
+        )
+      )
+
+      addParents(dtoClass, parentOpt)
+
+      def withoutDiscriminators(terms: List[ParameterTerm]): List[ParameterTerm] =
+        terms.filterNot(term => discriminators.contains(term.propertyName))
+
+      terms.foreach({
+        case ParameterTerm(propertyName, parameterName, fieldType, _, _) =>
+          val field: FieldDeclaration = dtoClass.addField(fieldType, parameterName, PRIVATE, FINAL)
+          field.addSingleMemberAnnotation("JsonProperty", new StringLiteralExpr(propertyName))
+      })
+
+      val primaryConstructor = dtoClass.addConstructor(PROTECTED)
+      primaryConstructor.addMarkerAnnotation("JsonCreator")
+      primaryConstructor.setParameters(
+        new NodeList(
+          withoutDiscriminators(parentTerms ++ terms).map({
+            case ParameterTerm(propertyName, parameterName, fieldType, _, _) =>
+              new Parameter(util.EnumSet.of(FINAL), fieldType, new SimpleName(parameterName))
+                .addAnnotation(new SingleMemberAnnotationExpr(new Name("JsonProperty"), new StringLiteralExpr(propertyName)))
+          }): _*
+        )
+      )
+      val superCall = new MethodCallExpr(
+        "super",
+        parentTerms.map({ term =>
+          if (discriminators.contains(term.propertyName)) {
+            new StringLiteralExpr(clsName)
+          } else {
+            new NameExpr(term.parameterName)
+          }
+        }): _*
+      )
+      primaryConstructor.setBody(dtoConstructorBody(superCall, terms))
+
+      terms.foreach(addParameterGetter(dtoClass, _))
+
+      def parameterGetterCall(term: ParameterTerm, scope: Option[String] = None): MethodCallExpr = {
+        val methodName = s"get${term.parameterName.unescapeIdentifier.capitalize}"
+        scope.fold(new MethodCallExpr(methodName))(s => new MethodCallExpr(new NameExpr(s), methodName))
+      }
+
+      val toStringFieldExprs = NonEmptyList
+        .fromList(parentTerms ++ terms)
+        .toList
+        .flatMap(
+          l =>
+            (new StringLiteralExpr(s"${l.head.parameterName}="), parameterGetterCall(l.head)) +:
+              l.tail.map(
+              term =>
+                (
+                  new StringLiteralExpr(s", ${term.parameterName}="),
+                  parameterGetterCall(term)
+              )
+          )
+        )
+
+      val toStringMethod = dtoClass
+        .addMethod("toString", PUBLIC)
+        .setType(STRING_TYPE)
+        .addMarkerAnnotation("Override")
+      toStringMethod.setBody(
+        new BlockStmt(
+          new NodeList(
+            new ReturnStmt(
+              new BinaryExpr(
+                toStringFieldExprs.foldLeft[Expression](new StringLiteralExpr(s"${clsName}{"))({
+                  case (prevExpr, (strExpr, fieldExpr)) =>
+                    new BinaryExpr(
+                      new BinaryExpr(prevExpr, strExpr, BinaryExpr.Operator.PLUS),
+                      fieldExpr,
+                      BinaryExpr.Operator.PLUS
+                    )
+                }),
+                new StringLiteralExpr("}"),
+                BinaryExpr.Operator.PLUS
+              )
+            )
+          )
+        )
+      )
+
+      val equalsConditions: List[Expression] = terms.map(
+        term =>
+          term.fieldType match {
+            case _: PrimitiveType =>
+              new BinaryExpr(
+                parameterGetterCall(term),
+                parameterGetterCall(term, Some("other")),
+                BinaryExpr.Operator.EQUALS
+              )
+            case _ =>
+              new MethodCallExpr(
+                parameterGetterCall(term),
+                "equals",
+                new NodeList[Expression](parameterGetterCall(term, Some("other")))
+              )
+        }
+      )
+      val returnExpr = NonEmptyList
+        .fromList(equalsConditions)
+        .map(
+          _.reduceLeft(
+            (prevExpr, condExpr) => new BinaryExpr(prevExpr, condExpr, BinaryExpr.Operator.AND)
+          )
+        )
+        .getOrElse(new BooleanLiteralExpr(true))
+
+      val equalsMethod = dtoClass
+        .addMethod("equals", PUBLIC)
+        .setType(PrimitiveType.booleanType)
+        .addMarkerAnnotation("Override")
+        .addParameter(new Parameter(util.EnumSet.of(FINAL), OBJECT_TYPE, new SimpleName("o")))
+      equalsMethod.setBody(
+        new BlockStmt(
+          new NodeList(
+            new IfStmt(
+              new BinaryExpr(new ThisExpr, new NameExpr("o"), BinaryExpr.Operator.EQUALS),
+              new BlockStmt(new NodeList(new ReturnStmt(new BooleanLiteralExpr(true)))),
+              null
+            ),
+            new IfStmt(
+              new BinaryExpr(
+                new BinaryExpr(new NameExpr("o"), new NullLiteralExpr, BinaryExpr.Operator.EQUALS),
+                new BinaryExpr(new MethodCallExpr("getClass"), new MethodCallExpr(new NameExpr("o"), "getClass"), BinaryExpr.Operator.NOT_EQUALS),
+                BinaryExpr.Operator.OR
+              ),
+              new BlockStmt(new NodeList(new ReturnStmt(new BooleanLiteralExpr(false)))),
+              null
+            ),
+            new ExpressionStmt(
+              new VariableDeclarationExpr(new VariableDeclarator(
+                                            dtoClassType,
+                                            "other",
+                                            new CastExpr(dtoClassType, new NameExpr("o"))
+                                          ),
+                                          FINAL)
+            ),
+            new ReturnStmt(returnExpr)
+          )
+        )
+      )
+
+      val hashCodeMethod = dtoClass
+        .addMethod("hashCode", PUBLIC)
+        .setType(PrimitiveType.intType)
+        .addMarkerAnnotation("Override")
+      hashCodeMethod.setBody(
+        new BlockStmt(
+          new NodeList(
+            new ReturnStmt(
+              new MethodCallExpr(
+                new NameExpr("java.util.Objects"),
+                "hash",
+                new NodeList[Expression]((parentTerms ++ terms).map(parameterGetterCall(_, None)): _*)
+              )
+            )
+          )
+        )
+      )
+
+      val builderClass = new ClassOrInterfaceDeclaration(util.EnumSet.of(PUBLIC, STATIC), false, "Builder")
+
+      withoutDiscriminators(parentRequiredTerms ++ requiredTerms).foreach({
+        case ParameterTerm(_, parameterName, fieldType, _, _) =>
+          builderClass.addField(fieldType, parameterName, PRIVATE, FINAL)
+      })
+      withoutDiscriminators(parentOptionalTerms ++ optionalTerms).foreach({
+        case ParameterTerm(_, parameterName, fieldType, _, defaultValue) =>
+          val initializer = defaultValue.fold[Expression](
+            new MethodCallExpr(new NameExpr("java.util.Optional"), "empty")
+          )(
+            dv =>
+              if (fieldType.isOptional) {
+                new MethodCallExpr(new NameExpr("java.util.Optional"), "of", new NodeList[Expression](dv))
+              } else {
+                dv
+            }
+          )
+          builderClass.addFieldWithInitializer(fieldType, parameterName, initializer, PRIVATE)
+      })
+
+      val builderConstructor = builderClass.addConstructor(PUBLIC)
+      builderConstructor.setParameters(
+        new NodeList(
+          withoutDiscriminators(parentRequiredTerms ++ requiredTerms).map({
+            case ParameterTerm(_, parameterName, _, parameterType, _) =>
+              new Parameter(util.EnumSet.of(FINAL), parameterType, new SimpleName(parameterName))
+          }): _*
+        )
+      )
+      builderConstructor.setBody(
+        new BlockStmt(
+          new NodeList(
+            withoutDiscriminators(parentRequiredTerms ++ requiredTerms).map({
+              case ParameterTerm(_, parameterName, fieldType, _, _) =>
+                new ExpressionStmt(
+                  new AssignExpr(
+                    new FieldAccessExpr(new ThisExpr, parameterName),
+                    fieldType match {
+                      case _: PrimitiveType => new NameExpr(parameterName)
+                      case _                => new MethodCallExpr("requireNonNull", new NameExpr(parameterName))
+                    },
+                    AssignExpr.Operator.ASSIGN
+                  )
+                )
+            }): _*
+          )
+        )
+      )
+
+      builderClass
+        .addConstructor(PUBLIC)
+        .setParameters(new NodeList(new Parameter(util.EnumSet.of(FINAL), dtoClassType, new SimpleName("template"))))
+        .setBody(
+          new BlockStmt(
+            withoutDiscriminators(parentTerms ++ terms)
+              .map({
+                case term @ ParameterTerm(_, parameterName, _, _, _) =>
+                  new ExpressionStmt(
+                    new AssignExpr(
+                      new FieldAccessExpr(new ThisExpr, parameterName),
+                      parameterGetterCall(term, Some("template")),
+                      AssignExpr.Operator.ASSIGN
+                    )
+                  ): Statement
+              })
+              .toNodeList
+          )
+        )
+
+      // TODO: leave out with${name}() if readOnlyKey?
+      withoutDiscriminators(parentOptionalTerms ++ optionalTerms).foreach({
+        case ParameterTerm(_, parameterName, fieldType, parameterType, _) =>
+          builderClass
+            .addMethod(s"with${parameterName.unescapeIdentifier.capitalize}", PUBLIC)
+            .setType(BUILDER_TYPE)
+            .addParameter(new Parameter(util.EnumSet.of(FINAL), parameterType, new SimpleName(parameterName)))
+            .setBody(
+              new BlockStmt(
+                new NodeList(
+                  new ExpressionStmt(
+                    new AssignExpr(
+                      new FieldAccessExpr(new ThisExpr, parameterName),
+                      fieldType match {
+                        case _: PrimitiveType    => new NameExpr(parameterName)
+                        case ft if ft.isOptional => new MethodCallExpr("java.util.Optional.of", new NameExpr(parameterName))
+                        case _                   => new MethodCallExpr("requireNonNull", new NameExpr(parameterName))
+                      },
+                      AssignExpr.Operator.ASSIGN
+                    )
+                  ),
+                  new ReturnStmt(new ThisExpr)
+                )
+              )
+            )
+
+          if (fieldType.isOptional && !parameterType.isOptional) {
+            builderClass
+              .addMethod(s"with${parameterName.unescapeIdentifier.capitalize}", PUBLIC)
+              .setType(BUILDER_TYPE)
+              .addParameter(new Parameter(util.EnumSet.of(FINAL), fieldType, new SimpleName(parameterName)))
+              .setBody(
+                new BlockStmt(
+                  new NodeList(
+                    new ExpressionStmt(
+                      new AssignExpr(
+                        new FieldAccessExpr(new ThisExpr, parameterName),
+                        new MethodCallExpr("requireNonNull", new NameExpr(parameterName)),
+                        AssignExpr.Operator.ASSIGN
+                      )
+                    ),
+                    new ReturnStmt(new ThisExpr)
+                  )
+                )
+              )
+          }
+      })
+
+      val buildMethod = builderClass.addMethod("build", PUBLIC)
+      buildMethod.setType(clsName)
+      buildMethod.setBody(
+        new BlockStmt(
+          new NodeList(
+            new ReturnStmt(
+              new ObjectCreationExpr(
+                null,
+                JavaParser.parseClassOrInterfaceType(clsName),
+                new NodeList(
+                  withoutDiscriminators(parentTerms ++ terms).map(param => new FieldAccessExpr(new ThisExpr, param.parameterName)): _*
+                )
+              )
+            )
+          )
+        )
+      )
+
+      dtoClass.addMember(builderClass)
+
+      dtoClass
+    }
+  }
+
   object ModelProtocolTermInterp extends (ModelProtocolTerm[JavaLanguage, ?] ~> Target) {
     def apply[T](term: ModelProtocolTerm[JavaLanguage, T]): Target[T] = term match {
       case ExtractProperties(swagger) =>
@@ -360,343 +702,7 @@ object JacksonGenerator {
         }
 
       case RenderDTOClass(clsName, selfParams, parents) =>
-        val parentsWithDiscriminators = parents.collect({ case p if p.discriminators.nonEmpty => p })
-        for {
-          dtoClassType <- safeParseClassOrInterfaceType(clsName)
-          parentOpt <- (parentsWithDiscriminators, parents) match {
-            case _ if parentsWithDiscriminators.length > 1 =>
-              Target.raiseError[Option[SuperClass[JavaLanguage]]](
-                s"${clsName} requires unsupported multiple inheritance due to multiple parents with discriminators (${parentsWithDiscriminators.map(_.clsName).mkString(", ")})"
-              )
-            case _ if parentsWithDiscriminators.length == 1 => Target.pure(parentsWithDiscriminators.headOption)
-            case _ if parents.length == 1                   => Target.pure(parents.headOption)
-            case _                                          => Target.pure(None)
-          }
-        } yield {
-          val discriminators                             = parents.flatMap(_.discriminators)
-          val parentParams                               = parentOpt.toList.flatMap(_.params)
-          val parentParamNames                           = parentParams.map(_.name)
-          val (parentRequiredTerms, parentOptionalTerms) = sortParams(parentParams)
-          val parentTerms                                = parentRequiredTerms ++ parentOptionalTerms
-          val params = parents.filterNot(parent => parentOpt.contains(parent)).flatMap(_.params) ++ selfParams.filterNot(
-            param => discriminators.contains(param.term.getName.getIdentifier) || parentParamNames.contains(param.term.getName.getIdentifier)
-          )
-          val (requiredTerms, optionalTerms) = sortParams(params)
-          val terms                          = requiredTerms ++ optionalTerms
-
-          val dtoClass = new ClassOrInterfaceDeclaration(util.EnumSet.of(PUBLIC), false, clsName)
-          dtoClass.addAnnotation(
-            new NormalAnnotationExpr(
-              new Name("JsonIgnoreProperties"),
-              new NodeList(
-                new MemberValuePair(
-                  "ignoreUnknown",
-                  new BooleanLiteralExpr(true)
-                )
-              )
-            )
-          )
-
-          addParents(dtoClass, parentOpt)
-
-          def withoutDiscriminators(terms: List[ParameterTerm]): List[ParameterTerm] =
-            terms.filterNot(term => discriminators.contains(term.propertyName))
-
-          terms.foreach({
-            case ParameterTerm(propertyName, parameterName, fieldType, _, _) =>
-              val field: FieldDeclaration = dtoClass.addField(fieldType, parameterName, PRIVATE, FINAL)
-              field.addSingleMemberAnnotation("JsonProperty", new StringLiteralExpr(propertyName))
-          })
-
-          val primaryConstructor = dtoClass.addConstructor(PROTECTED)
-          primaryConstructor.addMarkerAnnotation("JsonCreator")
-          primaryConstructor.setParameters(
-            new NodeList(
-              withoutDiscriminators(parentTerms ++ terms).map({
-                case ParameterTerm(propertyName, parameterName, fieldType, _, _) =>
-                  new Parameter(util.EnumSet.of(FINAL), fieldType, new SimpleName(parameterName))
-                    .addAnnotation(new SingleMemberAnnotationExpr(new Name("JsonProperty"), new StringLiteralExpr(propertyName)))
-              }): _*
-            )
-          )
-          val superCall = new MethodCallExpr(
-            "super",
-            parentTerms.map({ term =>
-              if (discriminators.contains(term.propertyName)) {
-                new StringLiteralExpr(clsName)
-              } else {
-                new NameExpr(term.parameterName)
-              }
-            }): _*
-          )
-          primaryConstructor.setBody(dtoConstructorBody(superCall, terms))
-
-          terms.foreach(addParameterGetter(dtoClass, _))
-
-          def parameterGetterCall(term: ParameterTerm, scope: Option[String] = None): MethodCallExpr = {
-            val methodName = s"get${term.parameterName.unescapeIdentifier.capitalize}"
-            scope.fold(new MethodCallExpr(methodName))(s => new MethodCallExpr(new NameExpr(s), methodName))
-          }
-
-          val toStringFieldExprs = NonEmptyList
-            .fromList(parentTerms ++ terms)
-            .toList
-            .flatMap(
-              l =>
-                (new StringLiteralExpr(s"${l.head.parameterName}="), parameterGetterCall(l.head)) +:
-                  l.tail.map(
-                  term =>
-                    (
-                      new StringLiteralExpr(s", ${term.parameterName}="),
-                      parameterGetterCall(term)
-                  )
-              )
-            )
-
-          val toStringMethod = dtoClass
-            .addMethod("toString", PUBLIC)
-            .setType(STRING_TYPE)
-            .addMarkerAnnotation("Override")
-          toStringMethod.setBody(
-            new BlockStmt(
-              new NodeList(
-                new ReturnStmt(
-                  new BinaryExpr(
-                    toStringFieldExprs.foldLeft[Expression](new StringLiteralExpr(s"${clsName}{"))({
-                      case (prevExpr, (strExpr, fieldExpr)) =>
-                        new BinaryExpr(
-                          new BinaryExpr(prevExpr, strExpr, BinaryExpr.Operator.PLUS),
-                          fieldExpr,
-                          BinaryExpr.Operator.PLUS
-                        )
-                    }),
-                    new StringLiteralExpr("}"),
-                    BinaryExpr.Operator.PLUS
-                  )
-                )
-              )
-            )
-          )
-
-          val equalsConditions: List[Expression] = terms.map(
-            term =>
-              term.fieldType match {
-                case _: PrimitiveType =>
-                  new BinaryExpr(
-                    parameterGetterCall(term),
-                    parameterGetterCall(term, Some("other")),
-                    BinaryExpr.Operator.EQUALS
-                  )
-                case _ =>
-                  new MethodCallExpr(
-                    parameterGetterCall(term),
-                    "equals",
-                    new NodeList[Expression](parameterGetterCall(term, Some("other")))
-                  )
-            }
-          )
-          val returnExpr = NonEmptyList
-            .fromList(equalsConditions)
-            .map(
-              _.reduceLeft(
-                (prevExpr, condExpr) => new BinaryExpr(prevExpr, condExpr, BinaryExpr.Operator.AND)
-              )
-            )
-            .getOrElse(new BooleanLiteralExpr(true))
-
-          val equalsMethod = dtoClass
-            .addMethod("equals", PUBLIC)
-            .setType(PrimitiveType.booleanType)
-            .addMarkerAnnotation("Override")
-            .addParameter(new Parameter(util.EnumSet.of(FINAL), OBJECT_TYPE, new SimpleName("o")))
-          equalsMethod.setBody(
-            new BlockStmt(
-              new NodeList(
-                new IfStmt(
-                  new BinaryExpr(new ThisExpr, new NameExpr("o"), BinaryExpr.Operator.EQUALS),
-                  new BlockStmt(new NodeList(new ReturnStmt(new BooleanLiteralExpr(true)))),
-                  null
-                ),
-                new IfStmt(
-                  new BinaryExpr(
-                    new BinaryExpr(new NameExpr("o"), new NullLiteralExpr, BinaryExpr.Operator.EQUALS),
-                    new BinaryExpr(new MethodCallExpr("getClass"), new MethodCallExpr(new NameExpr("o"), "getClass"), BinaryExpr.Operator.NOT_EQUALS),
-                    BinaryExpr.Operator.OR
-                  ),
-                  new BlockStmt(new NodeList(new ReturnStmt(new BooleanLiteralExpr(false)))),
-                  null
-                ),
-                new ExpressionStmt(
-                  new VariableDeclarationExpr(new VariableDeclarator(
-                                                dtoClassType,
-                                                "other",
-                                                new CastExpr(dtoClassType, new NameExpr("o"))
-                                              ),
-                                              FINAL)
-                ),
-                new ReturnStmt(returnExpr)
-              )
-            )
-          )
-
-          val hashCodeMethod = dtoClass
-            .addMethod("hashCode", PUBLIC)
-            .setType(PrimitiveType.intType)
-            .addMarkerAnnotation("Override")
-          hashCodeMethod.setBody(
-            new BlockStmt(
-              new NodeList(
-                new ReturnStmt(
-                  new MethodCallExpr(
-                    new NameExpr("java.util.Objects"),
-                    "hash",
-                    new NodeList[Expression]((parentTerms ++ terms).map(parameterGetterCall(_, None)): _*)
-                  )
-                )
-              )
-            )
-          )
-
-          val builderClass = new ClassOrInterfaceDeclaration(util.EnumSet.of(PUBLIC, STATIC), false, "Builder")
-
-          withoutDiscriminators(parentRequiredTerms ++ requiredTerms).foreach({
-            case ParameterTerm(_, parameterName, fieldType, _, _) =>
-              builderClass.addField(fieldType, parameterName, PRIVATE, FINAL)
-          })
-          withoutDiscriminators(parentOptionalTerms ++ optionalTerms).foreach({
-            case ParameterTerm(_, parameterName, fieldType, _, defaultValue) =>
-              val initializer = defaultValue.fold[Expression](
-                new MethodCallExpr(new NameExpr("java.util.Optional"), "empty")
-              )(
-                dv =>
-                  if (fieldType.isOptional) {
-                    new MethodCallExpr(new NameExpr("java.util.Optional"), "of", new NodeList[Expression](dv))
-                  } else {
-                    dv
-                }
-              )
-              builderClass.addFieldWithInitializer(fieldType, parameterName, initializer, PRIVATE)
-          })
-
-          val builderConstructor = builderClass.addConstructor(PUBLIC)
-          builderConstructor.setParameters(
-            new NodeList(
-              withoutDiscriminators(parentRequiredTerms ++ requiredTerms).map({
-                case ParameterTerm(_, parameterName, _, parameterType, _) =>
-                  new Parameter(util.EnumSet.of(FINAL), parameterType, new SimpleName(parameterName))
-              }): _*
-            )
-          )
-          builderConstructor.setBody(
-            new BlockStmt(
-              new NodeList(
-                withoutDiscriminators(parentRequiredTerms ++ requiredTerms).map({
-                  case ParameterTerm(_, parameterName, fieldType, _, _) =>
-                    new ExpressionStmt(
-                      new AssignExpr(
-                        new FieldAccessExpr(new ThisExpr, parameterName),
-                        fieldType match {
-                          case _: PrimitiveType => new NameExpr(parameterName)
-                          case _                => new MethodCallExpr("requireNonNull", new NameExpr(parameterName))
-                        },
-                        AssignExpr.Operator.ASSIGN
-                      )
-                    )
-                }): _*
-              )
-            )
-          )
-
-          builderClass
-            .addConstructor(PUBLIC)
-            .setParameters(new NodeList(new Parameter(util.EnumSet.of(FINAL), dtoClassType, new SimpleName("template"))))
-            .setBody(
-              new BlockStmt(
-                withoutDiscriminators(parentTerms ++ terms)
-                  .map({
-                    case term @ ParameterTerm(_, parameterName, _, _, _) =>
-                      new ExpressionStmt(
-                        new AssignExpr(
-                          new FieldAccessExpr(new ThisExpr, parameterName),
-                          parameterGetterCall(term, Some("template")),
-                          AssignExpr.Operator.ASSIGN
-                        )
-                      ): Statement
-                  })
-                  .toNodeList
-              )
-            )
-
-          // TODO: leave out with${name}() if readOnlyKey?
-          withoutDiscriminators(parentOptionalTerms ++ optionalTerms).foreach({
-            case ParameterTerm(_, parameterName, fieldType, parameterType, _) =>
-              builderClass
-                .addMethod(s"with${parameterName.unescapeIdentifier.capitalize}", PUBLIC)
-                .setType(BUILDER_TYPE)
-                .addParameter(new Parameter(util.EnumSet.of(FINAL), parameterType, new SimpleName(parameterName)))
-                .setBody(
-                  new BlockStmt(
-                    new NodeList(
-                      new ExpressionStmt(
-                        new AssignExpr(
-                          new FieldAccessExpr(new ThisExpr, parameterName),
-                          fieldType match {
-                            case _: PrimitiveType    => new NameExpr(parameterName)
-                            case ft if ft.isOptional => new MethodCallExpr("java.util.Optional.of", new NameExpr(parameterName))
-                            case _                   => new MethodCallExpr("requireNonNull", new NameExpr(parameterName))
-                          },
-                          AssignExpr.Operator.ASSIGN
-                        )
-                      ),
-                      new ReturnStmt(new ThisExpr)
-                    )
-                  )
-                )
-
-              if (fieldType.isOptional && !parameterType.isOptional) {
-                builderClass
-                  .addMethod(s"with${parameterName.unescapeIdentifier.capitalize}", PUBLIC)
-                  .setType(BUILDER_TYPE)
-                  .addParameter(new Parameter(util.EnumSet.of(FINAL), fieldType, new SimpleName(parameterName)))
-                  .setBody(
-                    new BlockStmt(
-                      new NodeList(
-                        new ExpressionStmt(
-                          new AssignExpr(
-                            new FieldAccessExpr(new ThisExpr, parameterName),
-                            new MethodCallExpr("requireNonNull", new NameExpr(parameterName)),
-                            AssignExpr.Operator.ASSIGN
-                          )
-                        ),
-                        new ReturnStmt(new ThisExpr)
-                      )
-                    )
-                  )
-              }
-          })
-
-          val buildMethod = builderClass.addMethod("build", PUBLIC)
-          buildMethod.setType(clsName)
-          buildMethod.setBody(
-            new BlockStmt(
-              new NodeList(
-                new ReturnStmt(
-                  new ObjectCreationExpr(
-                    null,
-                    JavaParser.parseClassOrInterfaceType(clsName),
-                    new NodeList(
-                      withoutDiscriminators(parentTerms ++ terms).map(param => new FieldAccessExpr(new ThisExpr, param.parameterName)): _*
-                    )
-                  )
-                )
-              )
-            )
-          )
-
-          dtoClass.addMember(builderClass)
-
-          dtoClass
-        }
+        renderDTOClass(clsName, selfParams, parents)
 
       case EncodeModel(clsName, needCamelSnakeConversion, selfParams, parents) =>
         Target.pure(None)
@@ -750,6 +756,105 @@ object JacksonGenerator {
     }
   }
 
+  private def renderSealedTrait(className: String,
+                                selfParams: List[ProtocolParameter[JavaLanguage]],
+                                discriminator: String,
+                                parents: List[SuperClass[JavaLanguage]],
+                                children: List[String]): Target[ClassOrInterfaceDeclaration] = {
+    val parentsWithDiscriminators = parents.collect({ case p if p.discriminators.nonEmpty => p })
+    for {
+      parentOpt <- (parentsWithDiscriminators, parents) match {
+        case _ if parentsWithDiscriminators.length > 1 =>
+          Target.raiseError[Option[SuperClass[JavaLanguage]]](
+            s"${className} requires unsupported multiple inheritance due to multiple parents with discriminators (${parentsWithDiscriminators.map(_.clsName).mkString(", ")})"
+          )
+        case _ if parentsWithDiscriminators.length == 1 => Target.pure(parentsWithDiscriminators.headOption)
+        case _ if parents.length == 1                   => Target.pure(parents.headOption)
+        case _                                          => Target.pure(None)
+      }
+    } yield {
+      val parentParams                               = parentOpt.toList.flatMap(_.params)
+      val parentParamNames                           = parentParams.map(_.name)
+      val (parentRequiredTerms, parentOptionalTerms) = sortParams(parentParams)
+      val parentTerms                                = parentRequiredTerms ++ parentOptionalTerms
+      val params = parents.filterNot(parent => parentOpt.contains(parent)).flatMap(_.params) ++ selfParams.filterNot(
+        param => parentParamNames.contains(param.term.getName.getIdentifier)
+      )
+      val (requiredTerms, optionalTerms) = sortParams(params)
+      val terms                          = requiredTerms ++ optionalTerms
+
+      val abstractClass = new ClassOrInterfaceDeclaration(util.EnumSet.of(PUBLIC, ABSTRACT), false, className)
+      abstractClass.addAnnotation(
+        new NormalAnnotationExpr(
+          new Name("JsonIgnoreProperties"),
+          new NodeList(
+            new MemberValuePair(
+              "ignoreUnknown",
+              new BooleanLiteralExpr(true)
+            )
+          )
+        )
+      )
+      abstractClass.addAnnotation(
+        new NormalAnnotationExpr(
+          new Name("JsonTypeInfo"),
+          new NodeList(
+            new MemberValuePair(
+              "use",
+              new FieldAccessExpr(new NameExpr("JsonTypeInfo.Id"), "NAME")
+            ),
+            new MemberValuePair(
+              "include",
+              new FieldAccessExpr(new NameExpr("JsonTypeInfo.As"), "PROPERTY")
+            ),
+            new MemberValuePair(
+              "property",
+              new StringLiteralExpr(discriminator)
+            )
+          )
+        )
+      )
+      abstractClass.addSingleMemberAnnotation(
+        "JsonSubTypes",
+        new ArrayInitializerExpr(
+          new NodeList(
+            children.map(
+              child =>
+                new NormalAnnotationExpr(
+                  new Name("JsonSubTypes.Type"),
+                  new NodeList(
+                    new MemberValuePair("name", new StringLiteralExpr(child)),
+                    new MemberValuePair("value", new ClassExpr(JavaParser.parseType(child)))
+                  )
+              )
+            ): _*
+          )
+        )
+      )
+
+      addParents(abstractClass, parentOpt)
+
+      terms.foreach({ term =>
+        val field = abstractClass.addField(term.fieldType, term.parameterName, PRIVATE, FINAL)
+        field.addAnnotation(new SingleMemberAnnotationExpr(new Name("JsonProperty"), new StringLiteralExpr(term.propertyName)))
+      })
+
+      val superCall = new MethodCallExpr("super", parentTerms.map(term => new NameExpr(term.parameterName)): _*)
+      abstractClass
+        .addConstructor(PROTECTED)
+        .setParameters(
+          (parentTerms ++ terms)
+            .map(term => new Parameter(util.EnumSet.of(FINAL), term.fieldType, new SimpleName(term.parameterName)))
+            .toNodeList
+        )
+        .setBody(dtoConstructorBody(superCall, requiredTerms ++ optionalTerms))
+
+      terms.foreach(addParameterGetter(abstractClass, _))
+
+      abstractClass
+    }
+  }
+
   object PolyProtocolTermInterp extends (PolyProtocolTerm[JavaLanguage, ?] ~> Target) {
     override def apply[A](fa: PolyProtocolTerm[JavaLanguage, A]): Target[A] = fa match {
       case ExtractSuperClass(swagger, definitions) =>
@@ -793,98 +898,7 @@ object JacksonGenerator {
         Target.pure(None)
 
       case RenderSealedTrait(className, selfParams, discriminator, parents, children) =>
-        val parentsWithDiscriminators = parents.collect({ case p if p.discriminators.nonEmpty => p })
-        for {
-          parentOpt <- (parentsWithDiscriminators, parents) match {
-            case _ if parentsWithDiscriminators.length > 1 =>
-              Target.raiseError[Option[SuperClass[JavaLanguage]]](
-                s"${className} requires unsupported multiple inheritance due to multiple parents with discriminators (${parentsWithDiscriminators.map(_.clsName).mkString(", ")})"
-              )
-            case _ if parentsWithDiscriminators.length == 1 => Target.pure(parentsWithDiscriminators.headOption)
-            case _ if parents.length == 1                   => Target.pure(parents.headOption)
-            case _                                          => Target.pure(None)
-          }
-        } yield {
-          val parentParams                               = parentOpt.toList.flatMap(_.params)
-          val parentParamNames                           = parentParams.map(_.name)
-          val (parentRequiredTerms, parentOptionalTerms) = sortParams(parentParams)
-          val parentTerms                                = parentRequiredTerms ++ parentOptionalTerms
-          val params = parents.filterNot(parent => parentOpt.contains(parent)).flatMap(_.params) ++ selfParams.filterNot(
-            param => parentParamNames.contains(param.term.getName.getIdentifier)
-          )
-          val (requiredTerms, optionalTerms) = sortParams(params)
-          val terms                          = requiredTerms ++ optionalTerms
-
-          val abstractClass = new ClassOrInterfaceDeclaration(util.EnumSet.of(PUBLIC, ABSTRACT), false, className)
-          abstractClass.addAnnotation(
-            new NormalAnnotationExpr(
-              new Name("JsonIgnoreProperties"),
-              new NodeList(
-                new MemberValuePair(
-                  "ignoreUnknown",
-                  new BooleanLiteralExpr(true)
-                )
-              )
-            )
-          )
-          abstractClass.addAnnotation(
-            new NormalAnnotationExpr(
-              new Name("JsonTypeInfo"),
-              new NodeList(
-                new MemberValuePair(
-                  "use",
-                  new FieldAccessExpr(new NameExpr("JsonTypeInfo.Id"), "NAME")
-                ),
-                new MemberValuePair(
-                  "include",
-                  new FieldAccessExpr(new NameExpr("JsonTypeInfo.As"), "PROPERTY")
-                ),
-                new MemberValuePair(
-                  "property",
-                  new StringLiteralExpr(discriminator)
-                )
-              )
-            )
-          )
-          abstractClass.addSingleMemberAnnotation(
-            "JsonSubTypes",
-            new ArrayInitializerExpr(
-              new NodeList(
-                children.map(
-                  child =>
-                    new NormalAnnotationExpr(
-                      new Name("JsonSubTypes.Type"),
-                      new NodeList(
-                        new MemberValuePair("name", new StringLiteralExpr(child)),
-                        new MemberValuePair("value", new ClassExpr(JavaParser.parseType(child)))
-                      )
-                  )
-                ): _*
-              )
-            )
-          )
-
-          addParents(abstractClass, parentOpt)
-
-          terms.foreach({ term =>
-            val field = abstractClass.addField(term.fieldType, term.parameterName, PRIVATE, FINAL)
-            field.addAnnotation(new SingleMemberAnnotationExpr(new Name("JsonProperty"), new StringLiteralExpr(term.propertyName)))
-          })
-
-          val superCall = new MethodCallExpr("super", parentTerms.map(term => new NameExpr(term.parameterName)): _*)
-          abstractClass
-            .addConstructor(PROTECTED)
-            .setParameters(
-              (parentTerms ++ terms)
-                .map(term => new Parameter(util.EnumSet.of(FINAL), term.fieldType, new SimpleName(term.parameterName)))
-                .toNodeList
-            )
-            .setBody(dtoConstructorBody(superCall, requiredTerms ++ optionalTerms))
-
-          terms.foreach(addParameterGetter(abstractClass, _))
-
-          abstractClass
-        }
+        renderSealedTrait(className, selfParams, discriminator, parents, children)
     }
   }
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
@@ -360,342 +360,291 @@ object JacksonGenerator {
         }
 
       case RenderDTOClass(clsName, selfParams, parents) =>
-        val dtoClassType                               = JavaParser.parseClassOrInterfaceType(clsName)
-        val discriminators                             = parents.flatMap(_.discriminators)
-        val parentOpt                                  = parents.headOption
-        val parentParams                               = parents.reverse.flatMap(_.params)
-        val parentParamNames                           = parentParams.map(_.name)
-        val (parentRequiredTerms, parentOptionalTerms) = sortParams(parentParams)
-        val parentTerms                                = parentRequiredTerms ++ parentOptionalTerms
-        val params = selfParams.filterNot(
-          param => discriminators.contains(param.term.getName.getIdentifier) || parentParamNames.contains(param.term.getName.getIdentifier)
-        )
-        val (requiredTerms, optionalTerms) = sortParams(params)
-        val terms                          = requiredTerms ++ optionalTerms
-
-        val dtoClass = new ClassOrInterfaceDeclaration(util.EnumSet.of(PUBLIC), false, clsName)
-        dtoClass.addAnnotation(
-          new NormalAnnotationExpr(
-            new Name("JsonIgnoreProperties"),
-            new NodeList(
-              new MemberValuePair(
-                "ignoreUnknown",
-                new BooleanLiteralExpr(true)
+        val parentsWithDiscriminators = parents.collect({ case p if p.discriminators.nonEmpty => p })
+        for {
+          dtoClassType <- safeParseClassOrInterfaceType(clsName)
+          parentOpt <- (parentsWithDiscriminators, parents) match {
+            case _ if parentsWithDiscriminators.length > 1 =>
+              Target.raiseError[Option[SuperClass[JavaLanguage]]](
+                s"${clsName} requires unsupported multiple inheritance due to multiple parents with discriminators (${parentsWithDiscriminators.map(_.clsName).mkString(", ")})"
               )
-            )
-          )
-        )
-
-        addParents(dtoClass, parentOpt)
-
-        def withoutDiscriminators(terms: List[ParameterTerm]): List[ParameterTerm] =
-          terms.filterNot(term => discriminators.contains(term.propertyName))
-
-        terms.foreach({
-          case ParameterTerm(propertyName, parameterName, fieldType, _, _) =>
-            val field: FieldDeclaration = dtoClass.addField(fieldType, parameterName, PRIVATE, FINAL)
-            field.addSingleMemberAnnotation("JsonProperty", new StringLiteralExpr(propertyName))
-        })
-
-        val primaryConstructor = dtoClass.addConstructor(PROTECTED)
-        primaryConstructor.addMarkerAnnotation("JsonCreator")
-        primaryConstructor.setParameters(
-          new NodeList(
-            withoutDiscriminators(parentTerms ++ terms).map({
-              case ParameterTerm(propertyName, parameterName, fieldType, _, _) =>
-                new Parameter(util.EnumSet.of(FINAL), fieldType, new SimpleName(parameterName))
-                  .addAnnotation(new SingleMemberAnnotationExpr(new Name("JsonProperty"), new StringLiteralExpr(propertyName)))
-            }): _*
-          )
-        )
-        val superCall = new MethodCallExpr(
-          "super",
-          parentTerms.map({ term =>
-            if (discriminators.contains(term.propertyName)) {
-              new StringLiteralExpr(clsName)
-            } else {
-              new NameExpr(term.parameterName)
-            }
-          }): _*
-        )
-        primaryConstructor.setBody(dtoConstructorBody(superCall, terms))
-
-        terms.foreach(addParameterGetter(dtoClass, _))
-
-        def parameterGetterCall(term: ParameterTerm, scope: Option[String] = None): MethodCallExpr = {
-          val methodName = s"get${term.parameterName.unescapeIdentifier.capitalize}"
-          scope.fold(new MethodCallExpr(methodName))(s => new MethodCallExpr(new NameExpr(s), methodName))
-        }
-
-        val toStringFieldExprs = NonEmptyList
-          .fromList(parentTerms ++ terms)
-          .toList
-          .flatMap(
-            l =>
-              (new StringLiteralExpr(s"${l.head.parameterName}="), parameterGetterCall(l.head)) +:
-                l.tail.map(
-                term =>
-                  (
-                    new StringLiteralExpr(s", ${term.parameterName}="),
-                    parameterGetterCall(term)
-                )
-            )
-          )
-
-        val toStringMethod = dtoClass
-          .addMethod("toString", PUBLIC)
-          .setType(STRING_TYPE)
-          .addMarkerAnnotation("Override")
-        toStringMethod.setBody(
-          new BlockStmt(
-            new NodeList(
-              new ReturnStmt(
-                new BinaryExpr(
-                  toStringFieldExprs.foldLeft[Expression](new StringLiteralExpr(s"${clsName}{"))({
-                    case (prevExpr, (strExpr, fieldExpr)) =>
-                      new BinaryExpr(
-                        new BinaryExpr(prevExpr, strExpr, BinaryExpr.Operator.PLUS),
-                        fieldExpr,
-                        BinaryExpr.Operator.PLUS
-                      )
-                  }),
-                  new StringLiteralExpr("}"),
-                  BinaryExpr.Operator.PLUS
-                )
-              )
-            )
-          )
-        )
-
-        val equalsConditions: List[Expression] = terms.map(
-          term =>
-            term.fieldType match {
-              case _: PrimitiveType =>
-                new BinaryExpr(
-                  parameterGetterCall(term),
-                  parameterGetterCall(term, Some("other")),
-                  BinaryExpr.Operator.EQUALS
-                )
-              case _ =>
-                new MethodCallExpr(
-                  parameterGetterCall(term),
-                  "equals",
-                  new NodeList[Expression](parameterGetterCall(term, Some("other")))
-                )
+            case _ if parentsWithDiscriminators.length == 1 => Target.pure(parentsWithDiscriminators.headOption)
+            case _ if parents.length == 1                   => Target.pure(parents.headOption)
+            case _                                          => Target.pure(None)
           }
-        )
-        val returnExpr = NonEmptyList
-          .fromList(equalsConditions)
-          .map(
-            _.reduceLeft(
-              (prevExpr, condExpr) => new BinaryExpr(prevExpr, condExpr, BinaryExpr.Operator.AND)
-            )
+        } yield {
+          val discriminators                             = parents.flatMap(_.discriminators)
+          val parentParams                               = parentOpt.toList.flatMap(_.params)
+          val parentParamNames                           = parentParams.map(_.name)
+          val (parentRequiredTerms, parentOptionalTerms) = sortParams(parentParams)
+          val parentTerms                                = parentRequiredTerms ++ parentOptionalTerms
+          val params = parents.filterNot(parent => parentOpt.contains(parent)).flatMap(_.params) ++ selfParams.filterNot(
+            param => discriminators.contains(param.term.getName.getIdentifier) || parentParamNames.contains(param.term.getName.getIdentifier)
           )
-          .getOrElse(new BooleanLiteralExpr(true))
+          val (requiredTerms, optionalTerms) = sortParams(params)
+          val terms                          = requiredTerms ++ optionalTerms
 
-        val equalsMethod = dtoClass
-          .addMethod("equals", PUBLIC)
-          .setType(PrimitiveType.booleanType)
-          .addMarkerAnnotation("Override")
-          .addParameter(new Parameter(util.EnumSet.of(FINAL), OBJECT_TYPE, new SimpleName("o")))
-        equalsMethod.setBody(
-          new BlockStmt(
-            new NodeList(
-              new IfStmt(
-                new BinaryExpr(new ThisExpr, new NameExpr("o"), BinaryExpr.Operator.EQUALS),
-                new BlockStmt(new NodeList(new ReturnStmt(new BooleanLiteralExpr(true)))),
-                null
-              ),
-              new IfStmt(
-                new BinaryExpr(
-                  new BinaryExpr(new NameExpr("o"), new NullLiteralExpr, BinaryExpr.Operator.EQUALS),
-                  new BinaryExpr(new MethodCallExpr("getClass"), new MethodCallExpr(new NameExpr("o"), "getClass"), BinaryExpr.Operator.NOT_EQUALS),
-                  BinaryExpr.Operator.OR
-                ),
-                new BlockStmt(new NodeList(new ReturnStmt(new BooleanLiteralExpr(false)))),
-                null
-              ),
-              new ExpressionStmt(
-                new VariableDeclarationExpr(new VariableDeclarator(
-                                              dtoClassType,
-                                              "other",
-                                              new CastExpr(dtoClassType, new NameExpr("o"))
-                                            ),
-                                            FINAL)
-              ),
-              new ReturnStmt(returnExpr)
-            )
-          )
-        )
-
-        val hashCodeMethod = dtoClass
-          .addMethod("hashCode", PUBLIC)
-          .setType(PrimitiveType.intType)
-          .addMarkerAnnotation("Override")
-        hashCodeMethod.setBody(
-          new BlockStmt(
-            new NodeList(
-              new ReturnStmt(
-                new MethodCallExpr(
-                  new NameExpr("java.util.Objects"),
-                  "hash",
-                  new NodeList[Expression]((parentTerms ++ terms).map(parameterGetterCall(_, None)): _*)
-                )
-              )
-            )
-          )
-        )
-
-        val builderMethod = dtoClass.addMethod("builder", PUBLIC, STATIC)
-        builderMethod.setType(BUILDER_TYPE)
-        builderMethod.setParameters(
-          new NodeList(
-            withoutDiscriminators(parentRequiredTerms ++ requiredTerms).map({
-              case ParameterTerm(_, parameterName, _, parameterType, _) =>
-                new Parameter(util.EnumSet.of(FINAL), parameterType, new SimpleName(parameterName))
-            }): _*
-          )
-        )
-        builderMethod.setBody(
-          new BlockStmt(
-            new NodeList(
-              new ReturnStmt(
-                new ObjectCreationExpr(
-                  null,
-                  BUILDER_TYPE,
-                  new NodeList(
-                    withoutDiscriminators(parentRequiredTerms ++ requiredTerms).map({
-                      case ParameterTerm(_, parameterName, _, _, _) => new NameExpr(parameterName)
-                    }): _*
-                  )
-                )
-              )
-            )
-          )
-        )
-
-        dtoClass
-          .addMethod("builder", PUBLIC, STATIC)
-          .setType(BUILDER_TYPE)
-          .setParameters(new NodeList(new Parameter(util.EnumSet.of(FINAL), dtoClassType, new SimpleName("template"))))
-          .setBody(
-            new BlockStmt(
+          val dtoClass = new ClassOrInterfaceDeclaration(util.EnumSet.of(PUBLIC), false, clsName)
+          dtoClass.addAnnotation(
+            new NormalAnnotationExpr(
+              new Name("JsonIgnoreProperties"),
               new NodeList(
-                new ReturnStmt(
-                  new ObjectCreationExpr(null, BUILDER_TYPE, new NodeList(new NameExpr("template")))
+                new MemberValuePair(
+                  "ignoreUnknown",
+                  new BooleanLiteralExpr(true)
                 )
               )
             )
           )
 
-        val builderClass = new ClassOrInterfaceDeclaration(util.EnumSet.of(PUBLIC, STATIC), false, "Builder")
+          addParents(dtoClass, parentOpt)
 
-        withoutDiscriminators(parentRequiredTerms ++ requiredTerms).foreach({
-          case ParameterTerm(_, parameterName, fieldType, _, _) =>
-            builderClass.addField(fieldType, parameterName, PRIVATE, FINAL)
-        })
-        withoutDiscriminators(parentOptionalTerms ++ optionalTerms).foreach({
-          case ParameterTerm(_, parameterName, fieldType, _, defaultValue) =>
-            val initializer = defaultValue.fold[Expression](
-              new MethodCallExpr(new NameExpr("java.util.Optional"), "empty")
-            )(
-              dv =>
-                if (fieldType.isOptional) {
-                  new MethodCallExpr(new NameExpr("java.util.Optional"), "of", new NodeList[Expression](dv))
-                } else {
-                  dv
-              }
-            )
-            builderClass.addFieldWithInitializer(fieldType, parameterName, initializer, PRIVATE)
-        })
+          def withoutDiscriminators(terms: List[ParameterTerm]): List[ParameterTerm] =
+            terms.filterNot(term => discriminators.contains(term.propertyName))
 
-        val builderConstructor = builderClass.addConstructor(PRIVATE)
-        builderConstructor.setParameters(
-          new NodeList(
-            withoutDiscriminators(parentRequiredTerms ++ requiredTerms).map({
-              case ParameterTerm(_, parameterName, _, parameterType, _) =>
-                new Parameter(util.EnumSet.of(FINAL), parameterType, new SimpleName(parameterName))
-            }): _*
-          )
-        )
-        builderConstructor.setBody(
-          new BlockStmt(
+          terms.foreach({
+            case ParameterTerm(propertyName, parameterName, fieldType, _, _) =>
+              val field: FieldDeclaration = dtoClass.addField(fieldType, parameterName, PRIVATE, FINAL)
+              field.addSingleMemberAnnotation("JsonProperty", new StringLiteralExpr(propertyName))
+          })
+
+          val primaryConstructor = dtoClass.addConstructor(PROTECTED)
+          primaryConstructor.addMarkerAnnotation("JsonCreator")
+          primaryConstructor.setParameters(
             new NodeList(
-              withoutDiscriminators(parentRequiredTerms ++ requiredTerms).map({
-                case ParameterTerm(_, parameterName, fieldType, _, _) =>
-                  new ExpressionStmt(
-                    new AssignExpr(
-                      new FieldAccessExpr(new ThisExpr, parameterName),
-                      fieldType match {
-                        case _: PrimitiveType => new NameExpr(parameterName)
-                        case _                => new MethodCallExpr("requireNonNull", new NameExpr(parameterName))
-                      },
-                      AssignExpr.Operator.ASSIGN
-                    )
-                  )
+              withoutDiscriminators(parentTerms ++ terms).map({
+                case ParameterTerm(propertyName, parameterName, fieldType, _, _) =>
+                  new Parameter(util.EnumSet.of(FINAL), fieldType, new SimpleName(parameterName))
+                    .addAnnotation(new SingleMemberAnnotationExpr(new Name("JsonProperty"), new StringLiteralExpr(propertyName)))
               }): _*
             )
           )
-        )
+          val superCall = new MethodCallExpr(
+            "super",
+            parentTerms.map({ term =>
+              if (discriminators.contains(term.propertyName)) {
+                new StringLiteralExpr(clsName)
+              } else {
+                new NameExpr(term.parameterName)
+              }
+            }): _*
+          )
+          primaryConstructor.setBody(dtoConstructorBody(superCall, terms))
 
-        builderClass
-          .addConstructor(PRIVATE)
-          .setParameters(new NodeList(new Parameter(util.EnumSet.of(FINAL), dtoClassType, new SimpleName("template"))))
-          .setBody(
+          terms.foreach(addParameterGetter(dtoClass, _))
+
+          def parameterGetterCall(term: ParameterTerm, scope: Option[String] = None): MethodCallExpr = {
+            val methodName = s"get${term.parameterName.unescapeIdentifier.capitalize}"
+            scope.fold(new MethodCallExpr(methodName))(s => new MethodCallExpr(new NameExpr(s), methodName))
+          }
+
+          val toStringFieldExprs = NonEmptyList
+            .fromList(parentTerms ++ terms)
+            .toList
+            .flatMap(
+              l =>
+                (new StringLiteralExpr(s"${l.head.parameterName}="), parameterGetterCall(l.head)) +:
+                  l.tail.map(
+                  term =>
+                    (
+                      new StringLiteralExpr(s", ${term.parameterName}="),
+                      parameterGetterCall(term)
+                  )
+              )
+            )
+
+          val toStringMethod = dtoClass
+            .addMethod("toString", PUBLIC)
+            .setType(STRING_TYPE)
+            .addMarkerAnnotation("Override")
+          toStringMethod.setBody(
             new BlockStmt(
-              withoutDiscriminators(parentTerms ++ terms)
-                .map({
-                  case term @ ParameterTerm(_, parameterName, _, _, _) =>
-                    new ExpressionStmt(
-                      new AssignExpr(
-                        new FieldAccessExpr(new ThisExpr, parameterName),
-                        parameterGetterCall(term, Some("template")),
-                        AssignExpr.Operator.ASSIGN
-                      )
-                    ): Statement
-                })
-                .toNodeList
+              new NodeList(
+                new ReturnStmt(
+                  new BinaryExpr(
+                    toStringFieldExprs.foldLeft[Expression](new StringLiteralExpr(s"${clsName}{"))({
+                      case (prevExpr, (strExpr, fieldExpr)) =>
+                        new BinaryExpr(
+                          new BinaryExpr(prevExpr, strExpr, BinaryExpr.Operator.PLUS),
+                          fieldExpr,
+                          BinaryExpr.Operator.PLUS
+                        )
+                    }),
+                    new StringLiteralExpr("}"),
+                    BinaryExpr.Operator.PLUS
+                  )
+                )
+              )
             )
           )
 
-        // TODO: leave out with${name}() if readOnlyKey?
-        withoutDiscriminators(parentOptionalTerms ++ optionalTerms).foreach({
-          case ParameterTerm(_, parameterName, fieldType, parameterType, _) =>
-            builderClass
-              .addMethod(s"with${parameterName.unescapeIdentifier.capitalize}", PUBLIC)
-              .setType(BUILDER_TYPE)
-              .addParameter(new Parameter(util.EnumSet.of(FINAL), parameterType, new SimpleName(parameterName)))
-              .setBody(
-                new BlockStmt(
-                  new NodeList(
+          val equalsConditions: List[Expression] = terms.map(
+            term =>
+              term.fieldType match {
+                case _: PrimitiveType =>
+                  new BinaryExpr(
+                    parameterGetterCall(term),
+                    parameterGetterCall(term, Some("other")),
+                    BinaryExpr.Operator.EQUALS
+                  )
+                case _ =>
+                  new MethodCallExpr(
+                    parameterGetterCall(term),
+                    "equals",
+                    new NodeList[Expression](parameterGetterCall(term, Some("other")))
+                  )
+            }
+          )
+          val returnExpr = NonEmptyList
+            .fromList(equalsConditions)
+            .map(
+              _.reduceLeft(
+                (prevExpr, condExpr) => new BinaryExpr(prevExpr, condExpr, BinaryExpr.Operator.AND)
+              )
+            )
+            .getOrElse(new BooleanLiteralExpr(true))
+
+          val equalsMethod = dtoClass
+            .addMethod("equals", PUBLIC)
+            .setType(PrimitiveType.booleanType)
+            .addMarkerAnnotation("Override")
+            .addParameter(new Parameter(util.EnumSet.of(FINAL), OBJECT_TYPE, new SimpleName("o")))
+          equalsMethod.setBody(
+            new BlockStmt(
+              new NodeList(
+                new IfStmt(
+                  new BinaryExpr(new ThisExpr, new NameExpr("o"), BinaryExpr.Operator.EQUALS),
+                  new BlockStmt(new NodeList(new ReturnStmt(new BooleanLiteralExpr(true)))),
+                  null
+                ),
+                new IfStmt(
+                  new BinaryExpr(
+                    new BinaryExpr(new NameExpr("o"), new NullLiteralExpr, BinaryExpr.Operator.EQUALS),
+                    new BinaryExpr(new MethodCallExpr("getClass"), new MethodCallExpr(new NameExpr("o"), "getClass"), BinaryExpr.Operator.NOT_EQUALS),
+                    BinaryExpr.Operator.OR
+                  ),
+                  new BlockStmt(new NodeList(new ReturnStmt(new BooleanLiteralExpr(false)))),
+                  null
+                ),
+                new ExpressionStmt(
+                  new VariableDeclarationExpr(new VariableDeclarator(
+                                                dtoClassType,
+                                                "other",
+                                                new CastExpr(dtoClassType, new NameExpr("o"))
+                                              ),
+                                              FINAL)
+                ),
+                new ReturnStmt(returnExpr)
+              )
+            )
+          )
+
+          val hashCodeMethod = dtoClass
+            .addMethod("hashCode", PUBLIC)
+            .setType(PrimitiveType.intType)
+            .addMarkerAnnotation("Override")
+          hashCodeMethod.setBody(
+            new BlockStmt(
+              new NodeList(
+                new ReturnStmt(
+                  new MethodCallExpr(
+                    new NameExpr("java.util.Objects"),
+                    "hash",
+                    new NodeList[Expression]((parentTerms ++ terms).map(parameterGetterCall(_, None)): _*)
+                  )
+                )
+              )
+            )
+          )
+
+          val builderClass = new ClassOrInterfaceDeclaration(util.EnumSet.of(PUBLIC, STATIC), false, "Builder")
+
+          withoutDiscriminators(parentRequiredTerms ++ requiredTerms).foreach({
+            case ParameterTerm(_, parameterName, fieldType, _, _) =>
+              builderClass.addField(fieldType, parameterName, PRIVATE, FINAL)
+          })
+          withoutDiscriminators(parentOptionalTerms ++ optionalTerms).foreach({
+            case ParameterTerm(_, parameterName, fieldType, _, defaultValue) =>
+              val initializer = defaultValue.fold[Expression](
+                new MethodCallExpr(new NameExpr("java.util.Optional"), "empty")
+              )(
+                dv =>
+                  if (fieldType.isOptional) {
+                    new MethodCallExpr(new NameExpr("java.util.Optional"), "of", new NodeList[Expression](dv))
+                  } else {
+                    dv
+                }
+              )
+              builderClass.addFieldWithInitializer(fieldType, parameterName, initializer, PRIVATE)
+          })
+
+          val builderConstructor = builderClass.addConstructor(PUBLIC)
+          builderConstructor.setParameters(
+            new NodeList(
+              withoutDiscriminators(parentRequiredTerms ++ requiredTerms).map({
+                case ParameterTerm(_, parameterName, _, parameterType, _) =>
+                  new Parameter(util.EnumSet.of(FINAL), parameterType, new SimpleName(parameterName))
+              }): _*
+            )
+          )
+          builderConstructor.setBody(
+            new BlockStmt(
+              new NodeList(
+                withoutDiscriminators(parentRequiredTerms ++ requiredTerms).map({
+                  case ParameterTerm(_, parameterName, fieldType, _, _) =>
                     new ExpressionStmt(
                       new AssignExpr(
                         new FieldAccessExpr(new ThisExpr, parameterName),
                         fieldType match {
-                          case _: PrimitiveType    => new NameExpr(parameterName)
-                          case ft if ft.isOptional => new MethodCallExpr("java.util.Optional.of", new NameExpr(parameterName))
-                          case _                   => new MethodCallExpr("requireNonNull", new NameExpr(parameterName))
+                          case _: PrimitiveType => new NameExpr(parameterName)
+                          case _                => new MethodCallExpr("requireNonNull", new NameExpr(parameterName))
                         },
                         AssignExpr.Operator.ASSIGN
                       )
-                    ),
-                    new ReturnStmt(new ThisExpr)
-                  )
-                )
+                    )
+                }): _*
               )
+            )
+          )
 
-            if (fieldType.isOptional && !parameterType.isOptional) {
+          builderClass
+            .addConstructor(PUBLIC)
+            .setParameters(new NodeList(new Parameter(util.EnumSet.of(FINAL), dtoClassType, new SimpleName("template"))))
+            .setBody(
+              new BlockStmt(
+                withoutDiscriminators(parentTerms ++ terms)
+                  .map({
+                    case term @ ParameterTerm(_, parameterName, _, _, _) =>
+                      new ExpressionStmt(
+                        new AssignExpr(
+                          new FieldAccessExpr(new ThisExpr, parameterName),
+                          parameterGetterCall(term, Some("template")),
+                          AssignExpr.Operator.ASSIGN
+                        )
+                      ): Statement
+                  })
+                  .toNodeList
+              )
+            )
+
+          // TODO: leave out with${name}() if readOnlyKey?
+          withoutDiscriminators(parentOptionalTerms ++ optionalTerms).foreach({
+            case ParameterTerm(_, parameterName, fieldType, parameterType, _) =>
               builderClass
                 .addMethod(s"with${parameterName.unescapeIdentifier.capitalize}", PUBLIC)
                 .setType(BUILDER_TYPE)
-                .addParameter(new Parameter(util.EnumSet.of(FINAL), fieldType, new SimpleName(parameterName)))
+                .addParameter(new Parameter(util.EnumSet.of(FINAL), parameterType, new SimpleName(parameterName)))
                 .setBody(
                   new BlockStmt(
                     new NodeList(
                       new ExpressionStmt(
                         new AssignExpr(
                           new FieldAccessExpr(new ThisExpr, parameterName),
-                          new MethodCallExpr("requireNonNull", new NameExpr(parameterName)),
+                          fieldType match {
+                            case _: PrimitiveType    => new NameExpr(parameterName)
+                            case ft if ft.isOptional => new MethodCallExpr("java.util.Optional.of", new NameExpr(parameterName))
+                            case _                   => new MethodCallExpr("requireNonNull", new NameExpr(parameterName))
+                          },
                           AssignExpr.Operator.ASSIGN
                         )
                       ),
@@ -703,30 +652,51 @@ object JacksonGenerator {
                     )
                   )
                 )
-            }
-        })
 
-        val buildMethod = builderClass.addMethod("build", PUBLIC)
-        buildMethod.setType(clsName)
-        buildMethod.setBody(
-          new BlockStmt(
-            new NodeList(
-              new ReturnStmt(
-                new ObjectCreationExpr(
-                  null,
-                  JavaParser.parseClassOrInterfaceType(clsName),
-                  new NodeList(
-                    withoutDiscriminators(parentTerms ++ terms).map(param => new FieldAccessExpr(new ThisExpr, param.parameterName)): _*
+              if (fieldType.isOptional && !parameterType.isOptional) {
+                builderClass
+                  .addMethod(s"with${parameterName.unescapeIdentifier.capitalize}", PUBLIC)
+                  .setType(BUILDER_TYPE)
+                  .addParameter(new Parameter(util.EnumSet.of(FINAL), fieldType, new SimpleName(parameterName)))
+                  .setBody(
+                    new BlockStmt(
+                      new NodeList(
+                        new ExpressionStmt(
+                          new AssignExpr(
+                            new FieldAccessExpr(new ThisExpr, parameterName),
+                            new MethodCallExpr("requireNonNull", new NameExpr(parameterName)),
+                            AssignExpr.Operator.ASSIGN
+                          )
+                        ),
+                        new ReturnStmt(new ThisExpr)
+                      )
+                    )
+                  )
+              }
+          })
+
+          val buildMethod = builderClass.addMethod("build", PUBLIC)
+          buildMethod.setType(clsName)
+          buildMethod.setBody(
+            new BlockStmt(
+              new NodeList(
+                new ReturnStmt(
+                  new ObjectCreationExpr(
+                    null,
+                    JavaParser.parseClassOrInterfaceType(clsName),
+                    new NodeList(
+                      withoutDiscriminators(parentTerms ++ terms).map(param => new FieldAccessExpr(new ThisExpr, param.parameterName)): _*
+                    )
                   )
                 )
               )
             )
           )
-        )
 
-        dtoClass.addMember(builderClass)
+          dtoClass.addMember(builderClass)
 
-        Target.pure(dtoClass)
+          dtoClass
+        }
 
       case EncodeModel(clsName, needCamelSnakeConversion, selfParams, parents) =>
         Target.pure(None)
@@ -785,17 +755,18 @@ object JacksonGenerator {
       case ExtractSuperClass(swagger, definitions) =>
         def allParents(model: Schema[_]): List[(String, Schema[_], List[Schema[_]])] =
           model match {
-            case elem: ComposedSchema =>
-              Option(elem.getAllOf).map(_.asScala.toList).getOrElse(List.empty) match {
-                case head :: tail =>
+            case schema: ComposedSchema =>
+              Option(schema.getAllOf)
+                .map(_.asScala.toList)
+                .getOrElse(List.empty)
+                .flatMap({ elem =>
                   definitions
                     .collectFirst({
-                      case (clsName, e) if Option(head.get$ref).exists(_.endsWith(s"/$clsName")) =>
-                        (clsName, e, tail.toList) :: allParents(e)
+                      case (clsName, e) if Option(elem.get$ref).exists(_.endsWith(s"/$clsName")) =>
+                        (clsName, e, List.empty) :: allParents(e)
                     })
                     .getOrElse(List.empty)
-                case _ => List.empty
-              }
+                })
             case _ => List.empty
           }
 
@@ -822,84 +793,98 @@ object JacksonGenerator {
         Target.pure(None)
 
       case RenderSealedTrait(className, selfParams, discriminator, parents, children) =>
-        val parentOpt                                  = parents.headOption
-        val parentParams                               = parents.reverse.flatMap(_.params)
-        val parentParamNames                           = parentParams.map(_.name)
-        val params                                     = selfParams.filterNot(param => parentParamNames.contains(param.name))
-        val (parentRequiredTerms, parentOptionalTerms) = sortParams(parentParams)
-        val parentTerms                                = parentRequiredTerms ++ parentOptionalTerms
-        val (requiredTerms, optionalTerms)             = sortParams(params)
-        val terms                                      = requiredTerms ++ optionalTerms
+        val parentsWithDiscriminators = parents.collect({ case p if p.discriminators.nonEmpty => p })
+        for {
+          parentOpt <- (parentsWithDiscriminators, parents) match {
+            case _ if parentsWithDiscriminators.length > 1 =>
+              Target.raiseError[Option[SuperClass[JavaLanguage]]](
+                s"${className} requires unsupported multiple inheritance due to multiple parents with discriminators (${parentsWithDiscriminators.map(_.clsName).mkString(", ")})"
+              )
+            case _ if parentsWithDiscriminators.length == 1 => Target.pure(parentsWithDiscriminators.headOption)
+            case _ if parents.length == 1                   => Target.pure(parents.headOption)
+            case _                                          => Target.pure(None)
+          }
+        } yield {
+          val parentParams                               = parentOpt.toList.flatMap(_.params)
+          val parentParamNames                           = parentParams.map(_.name)
+          val (parentRequiredTerms, parentOptionalTerms) = sortParams(parentParams)
+          val parentTerms                                = parentRequiredTerms ++ parentOptionalTerms
+          val params = parents.filterNot(parent => parentOpt.contains(parent)).flatMap(_.params) ++ selfParams.filterNot(
+            param => parentParamNames.contains(param.term.getName.getIdentifier)
+          )
+          val (requiredTerms, optionalTerms) = sortParams(params)
+          val terms                          = requiredTerms ++ optionalTerms
 
-        val abstractClass = new ClassOrInterfaceDeclaration(util.EnumSet.of(PUBLIC, ABSTRACT), false, className)
-        abstractClass.addAnnotation(
-          new NormalAnnotationExpr(
-            new Name("JsonIgnoreProperties"),
-            new NodeList(
-              new MemberValuePair(
-                "ignoreUnknown",
-                new BooleanLiteralExpr(true)
-              )
-            )
-          )
-        )
-        abstractClass.addAnnotation(
-          new NormalAnnotationExpr(
-            new Name("JsonTypeInfo"),
-            new NodeList(
-              new MemberValuePair(
-                "use",
-                new FieldAccessExpr(new NameExpr("JsonTypeInfo.Id"), "NAME")
-              ),
-              new MemberValuePair(
-                "include",
-                new FieldAccessExpr(new NameExpr("JsonTypeInfo.As"), "PROPERTY")
-              ),
-              new MemberValuePair(
-                "property",
-                new StringLiteralExpr(discriminator)
-              )
-            )
-          )
-        )
-        abstractClass.addSingleMemberAnnotation(
-          "JsonSubTypes",
-          new ArrayInitializerExpr(
-            new NodeList(
-              children.map(
-                child =>
-                  new NormalAnnotationExpr(
-                    new Name("JsonSubTypes.Type"),
-                    new NodeList(
-                      new MemberValuePair("name", new StringLiteralExpr(child)),
-                      new MemberValuePair("value", new ClassExpr(JavaParser.parseType(child)))
-                    )
+          val abstractClass = new ClassOrInterfaceDeclaration(util.EnumSet.of(PUBLIC, ABSTRACT), false, className)
+          abstractClass.addAnnotation(
+            new NormalAnnotationExpr(
+              new Name("JsonIgnoreProperties"),
+              new NodeList(
+                new MemberValuePair(
+                  "ignoreUnknown",
+                  new BooleanLiteralExpr(true)
                 )
-              ): _*
+              )
             )
           )
-        )
-
-        addParents(abstractClass, parentOpt)
-
-        terms.foreach({ term =>
-          val field = abstractClass.addField(term.fieldType, term.parameterName, PRIVATE, FINAL)
-          field.addAnnotation(new SingleMemberAnnotationExpr(new Name("JsonProperty"), new StringLiteralExpr(term.propertyName)))
-        })
-
-        val superCall = new MethodCallExpr("super", parentTerms.map(term => new NameExpr(term.parameterName)): _*)
-        abstractClass
-          .addConstructor(PROTECTED)
-          .setParameters(
-            (parentTerms ++ terms)
-              .map(term => new Parameter(util.EnumSet.of(FINAL), term.fieldType, new SimpleName(term.parameterName)))
-              .toNodeList
+          abstractClass.addAnnotation(
+            new NormalAnnotationExpr(
+              new Name("JsonTypeInfo"),
+              new NodeList(
+                new MemberValuePair(
+                  "use",
+                  new FieldAccessExpr(new NameExpr("JsonTypeInfo.Id"), "NAME")
+                ),
+                new MemberValuePair(
+                  "include",
+                  new FieldAccessExpr(new NameExpr("JsonTypeInfo.As"), "PROPERTY")
+                ),
+                new MemberValuePair(
+                  "property",
+                  new StringLiteralExpr(discriminator)
+                )
+              )
+            )
           )
-          .setBody(dtoConstructorBody(superCall, requiredTerms ++ optionalTerms))
+          abstractClass.addSingleMemberAnnotation(
+            "JsonSubTypes",
+            new ArrayInitializerExpr(
+              new NodeList(
+                children.map(
+                  child =>
+                    new NormalAnnotationExpr(
+                      new Name("JsonSubTypes.Type"),
+                      new NodeList(
+                        new MemberValuePair("name", new StringLiteralExpr(child)),
+                        new MemberValuePair("value", new ClassExpr(JavaParser.parseType(child)))
+                      )
+                  )
+                ): _*
+              )
+            )
+          )
 
-        terms.foreach(addParameterGetter(abstractClass, _))
+          addParents(abstractClass, parentOpt)
 
-        Target.pure(abstractClass)
+          terms.foreach({ term =>
+            val field = abstractClass.addField(term.fieldType, term.parameterName, PRIVATE, FINAL)
+            field.addAnnotation(new SingleMemberAnnotationExpr(new Name("JsonProperty"), new StringLiteralExpr(term.propertyName)))
+          })
+
+          val superCall = new MethodCallExpr("super", parentTerms.map(term => new NameExpr(term.parameterName)): _*)
+          abstractClass
+            .addConstructor(PROTECTED)
+            .setParameters(
+              (parentTerms ++ terms)
+                .map(term => new Parameter(util.EnumSet.of(FINAL), term.fieldType, new SimpleName(term.parameterName)))
+                .toNodeList
+            )
+            .setBody(dtoConstructorBody(superCall, requiredTerms ++ optionalTerms))
+
+          terms.foreach(addParameterGetter(abstractClass, _))
+
+          abstractClass
+        }
     }
   }
 }

--- a/modules/sample-dropwizard/src/test/java/core/Dropwizard/DropwizardMultiPartTest.java
+++ b/modules/sample-dropwizard/src/test/java/core/Dropwizard/DropwizardMultiPartTest.java
@@ -29,9 +29,10 @@ public class DropwizardMultiPartTest {
     private static final FooHandler fooHandler = new FooHandler() {
         @Override
         public CompletionStage<DoFooResponse> doFoo(long id, OffsetDateTime date, Optional<OffsetDateTime> optionalDate) {
-            final Foo.Builder builder = Foo.builder(id, date);
-            optionalDate.ifPresent(builder::withOptionalDate);
-            return CompletableFuture.completedFuture(FooHandler.DoFooResponse.Created(builder.build()));
+            final Foo foo = new Foo.Builder(id, date)
+                    .withOptionalDate(optionalDate)
+                    .build();
+            return CompletableFuture.completedFuture(FooHandler.DoFooResponse.Created(foo));
         }
     };
 

--- a/modules/sample-dropwizard/src/test/java/core/Dropwizard/DropwizardResourceTest.java
+++ b/modules/sample-dropwizard/src/test/java/core/Dropwizard/DropwizardResourceTest.java
@@ -33,7 +33,7 @@ public class DropwizardResourceTest {
     private static final String USERNAME = "foobar";
     private static final String PASSWORD = "sekrit";
     private static final String TOKEN = "abc123";
-    private static final User USER = User.builder()
+    private static final User USER = new User.Builder()
             .withId(1)
             .withUsername(USERNAME)
             .withPassword(PASSWORD)

--- a/modules/sample-dropwizard/src/test/scala/core/Dropwizard/DropwizardRoundTripTest.scala
+++ b/modules/sample-dropwizard/src/test/scala/core/Dropwizard/DropwizardRoundTripTest.scala
@@ -36,7 +36,7 @@ class DropwizardRoundTripTest extends FreeSpec with Matchers with Waiters with M
       override def getUserByName(username: String): CompletionStage[GetUserByNameResponse] = {
         username match {
           case USERNAME =>
-            serverFuture.complete(GetUserByNameResponse.Ok(User.builder()
+            serverFuture.complete(GetUserByNameResponse.Ok(new User.Builder()
               .withEmail("foo@bar.com")
               .withFirstName("Foo")
               .withLastName("Bar")


### PR DESCRIPTION
This is to prevent us from generating uncompileable multiple-inheritance hierarchies.  It works like this:

1. If there's more than one parent class that has a discriminator, we throw an error.
2. If there's a single parent that has a discriminator, we extend from that parent class.  If there are other parents, we flatten them so the generated class has the properties of all those other parents.
3. If there's just a single parent, we extend from that parent class.
4. Otherwise there's no composition or polymorphism going on, so we just emit a class that extends from nothing.

Unfortunately this necessitated removing the static `builder()` method from the POJO class, because you can't have a static method in a subclass with the same arg list that has a different return type.  (Which is an odd restriction since Java doesn't support static method overriding, but perhaps they did it for future-proofing.)  To compensate, the builder constructors are now public.

I'm _not_ including a test spec with this PR as it causes the Scala build to fail, which should hopefully be fixed when https://github.com/twilio/guardrail/pull/234 lands.

Note that the vast majority of this PR is only whitespace change as the indentation level changed for a bunch of code.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
