### PR TITLE
Better content type support for AsyncHttpClient

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
@@ -34,6 +34,7 @@ object DropwizardServerGenerator {
       case RouteMeta.UrlencodedFormData => "APPLICATION_FORM_URLENCODED"
       case RouteMeta.MultipartFormData  => "MULTIPART_FORM_DATA"
       case RouteMeta.TextPlain          => "TEXT_PLAIN"
+      case RouteMeta.OctetStream        => "APPLICATION_OCTET_STREAM"
     }
   }
 
@@ -99,7 +100,8 @@ object DropwizardServerGenerator {
                               protocolElems: List[StrictProtocolElems[JavaLanguage]]): Option[RouteMeta.ContentType] = {
     val priorityOrder = NonEmptyList.of(
       RouteMeta.ApplicationJson,
-      RouteMeta.TextPlain
+      RouteMeta.TextPlain,
+      RouteMeta.OctetStream
     )
 
     priorityOrder

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
@@ -17,17 +17,21 @@ import java.util
 import scala.collection.JavaConverters._
 
 object RouteMeta {
-  sealed abstract class ContentType(value: String)
+  sealed abstract class ContentType(val value: String) {
+    override val toString: String = value
+  }
   case object ApplicationJson    extends ContentType("application/json")
   case object MultipartFormData  extends ContentType("multipart/form-data")
   case object UrlencodedFormData extends ContentType("application/x-www-form-urlencoded")
   case object TextPlain          extends ContentType("text/plain")
+  case object OctetStream        extends ContentType("application/octet-stream")
   object ContentType {
     def unapply(value: String): Option[ContentType] = value match {
       case "application/json"                  => Some(ApplicationJson)
       case "multipart/form-data"               => Some(MultipartFormData)
       case "application/x-www-form-urlencoded" => Some(UrlencodedFormData)
       case "text/plain"                        => Some(TextPlain)
+      case "application/octet-stream"          => Some(OctetStream)
       case _                                   => None
     }
   }

--- a/modules/sample/src/main/resources/petstore.json
+++ b/modules/sample/src/main/resources/petstore.json
@@ -788,8 +788,7 @@
         "description": "",
         "operationId": "loginUser",
         "produces": [
-          "application/xml",
-          "application/json"
+          "text/plain"
         ],
         "parameters": [
           {


### PR DESCRIPTION
Adds text/plain and application/octet-stream support for AHC request and response bodies.

Also improves error reporting from the Java code formatter rather than just dumping a stack trace to console.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
