### PR TITLE
Fix copypasta in JacksonGenerator causing maps to be lists

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,6 +28,7 @@ mainClass in assembly := Some("com.twilio.guardrail.CLI")
 // (filename, prefix, tracing)
 def sampleResource(name: String): java.io.File = file(s"modules/sample/src/main/resources/${name}")
 val exampleCases: List[(java.io.File, String, Boolean, List[String])] = List(
+  (sampleResource("additional-properties.yaml"), "additionalProperties", false, List.empty),
   (sampleResource("alias.yaml"), "alias", false, List.empty),
   (sampleResource("contentType-textPlain.yaml"), "tests.contentTypes.textPlain", false, List.empty),
   (sampleResource("custom-header-type.yaml"), "tests.customTypes.customHeader", false, List.empty),

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
@@ -673,9 +673,15 @@ object JacksonGenerator {
                 }
                 tpe.map((_, Option.empty))
               case SwaggerUtil.DeferredArray(tpeName) =>
-                safeParseType(s"java.util.List<${tpeName}>").map((_, Option.empty))
+                for {
+                  fqListType <- safeParseClassOrInterfaceType("java.util.List")
+                  innerType  <- safeParseType(tpeName)
+                } yield (fqListType.setTypeArguments(innerType), Option.empty)
               case SwaggerUtil.DeferredMap(tpeName) =>
-                safeParseType(s"java.util.List<${tpeName}>").map((_, Option.empty))
+                for {
+                  fqMapType <- safeParseClassOrInterfaceType("java.util.Map")
+                  innerType <- safeParseType(tpeName)
+                } yield (fqMapType.setTypeArguments(STRING_TYPE, innerType), Option.empty)
             }
             (tpe, classDep) = tpeClassDep
 

--- a/modules/sample-dropwizard/src/test/scala/core/Jackson/Issue263.scala
+++ b/modules/sample-dropwizard/src/test/scala/core/Jackson/Issue263.scala
@@ -1,0 +1,14 @@
+package core.Jackson
+
+import additionalProperties.client.dropwizard.definitions.{Foo, FooMapValues}
+import java.util
+import org.scalatest.{FreeSpec, Matchers}
+
+class Issue263 extends FreeSpec with Matchers {
+  "additionalProperties with a $ref should emit a Map" in {
+    val stuff = new util.HashMap[String, FooMapValues]
+    stuff.put("yeah", new FooMapValues.Builder("no", 42).build())
+    val foo = new Foo.Builder().withStuff(stuff).build()
+    assert(classOf[util.Map[String, FooMapValues]].isAssignableFrom(foo.getStuff.getClass))
+  }
+}

--- a/modules/sample/src/main/resources/additional-properties.yaml
+++ b/modules/sample/src/main/resources/additional-properties.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.1
+info:
+  title: Whatever
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    FooMapValues:
+      type: object
+      required:
+        - foo
+        - bar
+      properties:
+        foo:
+          type: string
+        bar:
+          type: integer
+          format: int32
+    Foo:
+      type: object
+      required:
+        - stuff
+      properties:
+        stuff:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/FooMapValues"
+


### PR DESCRIPTION
Also parse both in a safer way that makes it more clear where errors lie.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
