### PR TITLE
Add scala 2.11.8 and 2.12.3 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: scala
+scala:
+  - 2.11.8
+  - 2.12.3
 script:
-- sbt checkFormatting +testSuite
+- sbt  ++$TRAVIS_SCALA_VERSION checkFormatting +testSuite


### PR DESCRIPTION
I was trying to reproduce a problem of compiling a project using scala 2.11, so I've created a variation in travis. In the end it didn't help in my case, but maybe you'll find it useful to have this travis configuration in guardrail. 

But I'm not sure if there is any value added since guardrail is already cross compiled to both 2.11 and 2.12. 

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
