### PR TITLE
fix: Remove extra apply in generated multiple query parameters

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
@@ -713,7 +713,9 @@ object AkkaHttpServerGenerator {
                         acc(Term.Apply(directive, List(next)))
                     case xs =>
                       next =>
-                        acc(Term.Apply(directive, List(Term.Function(xs.map(x => Term.Param(List.empty, x, None, None)), next))))
+                        acc(
+                          Term.Apply(Term.Select(directive, Term.Name("apply")), List(Term.Function(xs.map(x => Term.Param(List.empty, x, None, None)), next)))
+                        )
                   }
               }))
           val methodMatcher  = bindParams(List((akkaMethod, List.empty)))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
@@ -316,7 +316,7 @@ object AkkaHttpServerGenerator {
       directivesFromParams(
         arg => tpe => um => Target.pure(q"parameter(${param(um)(arg)(tpe)})"),
         arg => tpe => um => Target.pure(q"parameter(${param(um)(arg)(tpe)}.*)"),
-        arg => tpe => um => Target.pure(q"parameter(${param(um)(arg)(tpe)}.*).map(xs => Option(xs).filterNot(_.isEmpty)).apply"),
+        arg => tpe => um => Target.pure(q"parameter(${param(um)(arg)(tpe)}.*).map(xs => Option(xs).filterNot(_.isEmpty))"),
         arg => tpe => um => Target.pure(q"parameter(${param(um)(arg)(tpe)}.?)")
       ) _
     }

--- a/modules/codegen/src/test/scala/core/issues/Issue127.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue127.scala
@@ -149,7 +149,7 @@ class Issue127 extends FunSuite with Matchers with SwaggerSpecRunner {
                   }
                   maybe.fold(reject(_), tprovide(_))
               }))
-            }: Directive[Tuple1[(File, Option[String], ContentType)]])(file => complete(handler.uploadFile(uploadFileResponse)(file)))))
+            }: Directive[Tuple1[(File, Option[String], ContentType)]]).apply(file => complete(handler.uploadFile(uploadFileResponse)(file)))))
           }
         }
         sealed abstract class uploadFileResponse(val statusCode: StatusCode)

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/AkkaHttpServerTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/AkkaHttpServerTest.scala
@@ -151,13 +151,13 @@ class AkkaHttpServerTest extends FunSuite with Matchers with SwaggerSpecRunner {
           {
             get(pathEndOrSingleSlash(discardEntity(complete(handler.getRoot(getRootResponse)()))))
           } ~ {
-            put(path("bar")(parameter(Symbol("bar").as[Long])(bar => discardEntity(complete(handler.putBar(putBarResponse)(bar))))))
+            put(path("bar")(parameter(Symbol("bar").as[Long]).apply(bar => discardEntity(complete(handler.putBar(putBarResponse)(bar))))))
           } ~ {
             get((pathPrefix("foo") & pathEndOrSingleSlash)(discardEntity(complete(handler.getFoo(getFooResponse)()))))
           } ~ {
-            get(path("foo" / LongNumber)(bar => discardEntity(complete(handler.getFooBar(getFooBarResponse)(bar)))))
+            get(path("foo" / LongNumber).apply(bar => discardEntity(complete(handler.getFooBar(getFooBarResponse)(bar)))))
           } ~ {
-            get(path("store" / "order" / LongNumber)(orderId => parameter(Symbol("status").as[OrderStatus](stringyJsonUnmarshaller.andThen(unmarshallJson[OrderStatus])))(status => discardEntity(complete(handler.getOrderById(getOrderByIdResponse)(orderId, status))))))
+            get(path("store" / "order" / LongNumber).apply(orderId => parameter(Symbol("status").as[OrderStatus](stringyJsonUnmarshaller.andThen(unmarshallJson[OrderStatus]))).apply(status => discardEntity(complete(handler.getOrderById(getOrderByIdResponse)(orderId, status))))))
           }
         }
         sealed abstract class getRootResponse(val statusCode: StatusCode)
@@ -292,15 +292,15 @@ class AkkaHttpServerTest extends FunSuite with Matchers with SwaggerSpecRunner {
         }
         def routes(handler: StoreHandler, trace: String => Directive1[TraceBuilder])(implicit mat: akka.stream.Materializer): Route = {
           {
-            get(pathEndOrSingleSlash(trace("store:getRoot")(traceBuilder => discardEntity(complete(handler.getRoot(getRootResponse)()(traceBuilder))))))
+            get(pathEndOrSingleSlash(trace("store:getRoot").apply(traceBuilder => discardEntity(complete(handler.getRoot(getRootResponse)()(traceBuilder))))))
           } ~ {
-            put(path("bar")(parameter(Symbol("bar").as[Long])(bar => trace("store:putBar")(traceBuilder => discardEntity(complete(handler.putBar(putBarResponse)(bar)(traceBuilder)))))))
+            put(path("bar")(parameter(Symbol("bar").as[Long]).apply(bar => trace("store:putBar").apply(traceBuilder => discardEntity(complete(handler.putBar(putBarResponse)(bar)(traceBuilder)))))))
           } ~ {
-            get((pathPrefix("foo") & pathEndOrSingleSlash)(trace("store:getFoo")(traceBuilder => discardEntity(complete(handler.getFoo(getFooResponse)()(traceBuilder))))))
+            get((pathPrefix("foo") & pathEndOrSingleSlash)(trace("store:getFoo").apply(traceBuilder => discardEntity(complete(handler.getFoo(getFooResponse)()(traceBuilder))))))
           } ~ {
-            get(path("foo" / LongNumber)(bar => trace("completely-custom-label")(traceBuilder => discardEntity(complete(handler.getFooBar(getFooBarResponse)(bar)(traceBuilder))))))
+            get(path("foo" / LongNumber).apply(bar => trace("completely-custom-label").apply(traceBuilder => discardEntity(complete(handler.getFooBar(getFooBarResponse)(bar)(traceBuilder))))))
           } ~ {
-            get(path("store" / "order" / LongNumber)(orderId => parameter(Symbol("status").as[OrderStatus](stringyJsonUnmarshaller.andThen(unmarshallJson[OrderStatus])))(status => trace("store:getOrderById")(traceBuilder => discardEntity(complete(handler.getOrderById(getOrderByIdResponse)(orderId, status)(traceBuilder)))))))
+            get(path("store" / "order" / LongNumber).apply(orderId => parameter(Symbol("status").as[OrderStatus](stringyJsonUnmarshaller.andThen(unmarshallJson[OrderStatus]))).apply(status => trace("store:getOrderById").apply(traceBuilder => discardEntity(complete(handler.getOrderById(getOrderByIdResponse)(orderId, status)(traceBuilder)))))))
           }
         }
         sealed abstract class getRootResponse(val statusCode: StatusCode)

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/CustomHeaderTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/CustomHeaderTest.scala
@@ -60,7 +60,7 @@ class CustomHeaderTest extends FunSuite with Matchers with SwaggerSpecRunner {
                 reject(MalformedHeaderRejection("CustomHeader", e.getMessage, Some(e)))
               case Success(x) =>
                 provide(x)
-            }))(customHeader => discardEntity(complete(handler.getFoo(getFooResponse)(customHeader))))))
+            })).apply(customHeader => discardEntity(complete(handler.getFoo(getFooResponse)(customHeader))))))
           }
         }
         sealed abstract class getFooResponse(val statusCode: StatusCode)

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
@@ -182,7 +182,7 @@ class FormFieldsServerTest extends FunSuite with Matchers with SwaggerSpecRunner
                   }
                   maybe.fold(reject(_), tprovide(_))
               }))
-            }: Directive[(String, Long, (File, Option[String], ContentType, String))])((foo, bar, baz) => complete(handler.putFoo(putFooResponse)(foo, bar, baz)))))
+            }: Directive[(String, Long, (File, Option[String], ContentType, String))]).apply((foo, bar, baz) => complete(handler.putFoo(putFooResponse)(foo, bar, baz)))))
           }
         }
         sealed abstract class putFooResponse(val statusCode: StatusCode)


### PR DESCRIPTION
Trying to fix codegen in #210 

When generating the akka code it does not compile. After removing it and compiling just the akka part it compiles in my tests. But seems like the tests in this repo fail. Any ideas?

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
