### PR TITLE
Fix issue 290.

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
@@ -651,7 +651,7 @@ object Http4sServerGenerator {
             }
             if (!List("Unit", "Boolean", "Double", "Float", "Short", "Int", "Long", "Char", "String").contains(elemType.toString())) {
               val queryParamDecoder = q"""
-                implicit val ${Pat.Var(Term.Name(s"${argName.value}QueryParamDecoder"))}: QueryParamDecoder[$elemType] = (value: QueryParameterValue) =>
+                implicit val ${Pat.Var(Term.Name(s"${elemType}QueryParamDecoder"))}: QueryParamDecoder[$elemType] = (value: QueryParameterValue) =>
                     Json.fromString(value.value).as[$elemType]
                       .leftMap(t => ParseFailure("Query decoding failed", t.getMessage))
                       .toValidatedNel

--- a/modules/codegen/src/test/scala/core/issues/Issue290.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue290.scala
@@ -1,0 +1,65 @@
+package core.issues
+
+import com.twilio.guardrail.{Context, Server, Servers}
+import com.twilio.guardrail.generators.Http4s
+import org.scalatest.{FunSpec, Matchers}
+import support.SwaggerSpecRunner
+
+class Issue290 extends FunSpec with Matchers with SwaggerSpecRunner {
+
+  describe("Multiple date query params generate ambiguous implicit values") {
+
+    val specification = """
+      | openapi: "3.0.0"
+      | info:
+      |   title: Generator Error Sample
+      |   version: 1.0.0
+      | paths:
+      |   /events:
+      |     parameters:
+      |       - $ref: '#/components/parameters/FromParam'
+      |       - $ref: '#/components/parameters/ToParam'
+      |     get:
+      |       operationId: getEvents
+      |       responses:
+      |         200:
+      |           description: Requested events
+      | components:
+      |   parameters:
+      |     FromParam:
+      |       name: from
+      |       in: query
+      |       schema:
+      |         type: string
+      |         format: date
+      |     ToParam:
+      |       name: to
+      |       in: query
+      |       schema:
+      |         type: string
+      |         format: date""".stripMargin
+
+    val (
+      _, // ProtocolDefinitions
+      _, // clients
+      Servers(
+        Server(
+          _, // pkg
+          _, // extraImports
+          _, // genHandler
+          serverDefinition :: _
+        ) :: Nil,
+        _ // supportDefinitions
+      )
+    ) = runSwaggerSpec(specification)(Context.empty, Http4s)
+
+    it("Ensures that only one implicit value is generated for the LocalDate param") {
+
+      val pattern = "implicit val .*QueryParamDecoder\\[java.time.LocalDate\\]".r
+
+      val hits = pattern.findAllIn(serverDefinition.toString()).length
+
+      hits shouldBe 1
+    }
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/twilio/guardrail/issues/290

This fix generates implicit query param decoders looking like this:

```scala
implicit val `java.time.LocalDateQueryParamDecoder`: QueryParamDecoder[java.time.LocalDate] = (value: QueryParameterValue) => Json.fromString(value.value).as[java.time.LocalDate].leftMap(t => ParseFailure("Query decoding failed", t.getMessage)).toValidatedNel
```

It's not pretty but it works, then again implicits are not shown to the user and the compiler doesn't care about nice names...

Another option would be to have default `QueryParamDecoder` for types like `java.time.LocalDate` (and `java.time.LocalDateTime` etc.) since they are 'standard' types returned by the Swagger generator. That way only custom types (using `x-scala-type`) would need specific generated implicits. Any ideas on this?

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
