### PR TITLE
Fix sbt assembly command

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,16 @@ val dropwizardVersion = "1.3.9"
 val jerseyVersion     = "2.25.1"
 
 mainClass in assembly := Some("com.twilio.guardrail.CLI")
+assemblyMergeStrategy in assembly := {
+  case ".api_description" => MergeStrategy.discard
+  case ".options" => MergeStrategy.concat
+  case "plugin.properties" => MergeStrategy.discard
+  case "plugin.xml" => MergeStrategy.concat
+  case "META-INF/eclipse.inf" => MergeStrategy.first
+  case x =>
+    val oldStrategy = (assemblyMergeStrategy in assembly).value
+    oldStrategy(x)
+}
 
 // (filename, prefix, tracing)
 def sampleResource(name: String): java.io.File = file(s"modules/sample/src/main/resources/${name}")


### PR DESCRIPTION
Adding the Eclipse JDT formatter for Java code broke assembly because of a bunch of duplicate files in the Eclipse JARs that need merge strategies.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
