### PR TITLE
Better content type support for AsyncHttpClient

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -309,6 +309,7 @@ lazy val dropwizardSample = (project in file("modules/sample-dropwizard"))
       "junit"                      %  "junit"                  % "4.12"             % Test,
       "com.novocode"               %  "junit-interface"        % "0.11"             % Test,
       "org.mockito"                %% "mockito-scala"          % "1.2.0"            % Test,
+      "com.github.tomakehurst"     %  "wiremock"               % "1.57"             % Test,
       "io.dropwizard"              %  "dropwizard-testing"     % dropwizardVersion  % Test,
 			"org.glassfish.jersey.test-framework.providers" % "jersey-test-framework-provider-grizzly2" % jerseyVersion % Test
     ),

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
@@ -2,6 +2,7 @@ package com.twilio.guardrail.generators.Java
 
 import cats.data.NonEmptyList
 import cats.instances.list._
+import cats.syntax.foldable._
 import cats.syntax.traverse._
 import cats.~>
 import com.github.javaparser.JavaParser
@@ -12,15 +13,21 @@ import com.github.javaparser.ast.body._
 import com.github.javaparser.ast.expr.{ MethodCallExpr, NameExpr, _ }
 import com.github.javaparser.ast.stmt._
 import com.twilio.guardrail.generators.Java.AsyncHttpClientHelpers._
-import com.twilio.guardrail.generators.ScalaParameter
+import com.twilio.guardrail.generators.{ ScalaParameter, ScalaParameters }
 import com.twilio.guardrail.generators.syntax.Java._
 import com.twilio.guardrail.languages.JavaLanguage
 import com.twilio.guardrail.protocol.terms.Response
 import com.twilio.guardrail.protocol.terms.client._
+import com.twilio.guardrail.shims._
 import com.twilio.guardrail.terms.RouteMeta
+import com.twilio.guardrail.terms.RouteMeta.ContentType
 import com.twilio.guardrail.{ RenderedClientOperation, StaticDefns, SupportDefinition, SwaggerUtil, Target }
+import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.media.MediaType
 import java.net.URI
 import java.util
+import java.util.Locale
+import scala.collection.JavaConverters._
 
 object AsyncHttpClientClientGenerator {
   private val URI_TYPE                       = JavaParser.parseClassOrInterfaceType("URI")
@@ -36,6 +43,51 @@ object AsyncHttpClientClientGenerator {
 
   private def typeReferenceType(typeArg: Type): ClassOrInterfaceType =
     JavaParser.parseClassOrInterfaceType("TypeReference").setTypeArguments(typeArg)
+
+  def getBestConsumes(operation: Operation, parameters: ScalaParameters[JavaLanguage]): Option[ContentType] =
+    if (parameters.formParams.nonEmpty) {
+      if (parameters.formParams.exists(_.isFile)) {
+        Option(RouteMeta.MultipartFormData)
+      } else {
+        Option(RouteMeta.UrlencodedFormData)
+      }
+    } else if (parameters.bodyParams.isDefined) {
+      val validTypes = Seq(RouteMeta.ApplicationJson, RouteMeta.TextPlain)
+      List(RouteMeta.ApplicationJson.value, RouteMeta.TextPlain.value)
+        .collectFirst({ case ContentType(value) if validTypes.contains(value) => value })
+        .orElse({
+          println(s"WARNING: no supported body param type for operation '${operation.getOperationId}'; falling back to application/json")
+          Option(RouteMeta.ApplicationJson)
+        })
+    } else {
+      Option.empty
+    }
+
+  def getBestProduces(operation: Operation, response: Response[JavaLanguage]): Option[ContentType] = {
+    val priorityOrder = NonEmptyList.of(
+      RouteMeta.ApplicationJson,
+      RouteMeta.TextPlain,
+      RouteMeta.OctetStream
+    )
+
+    response.value
+      .map(_._1)
+      .flatMap({ valueType =>
+        val allProduces = operation.getResponses.asScala
+          .get(response.statusCode.toString)
+          .flatMap(resp => Option(resp.getContent))
+          .fold(List.empty[(String, MediaType)])(_.asScala.toList)
+          .collectFirst({ case (ContentType(ct), _) => ct })
+
+        priorityOrder
+          .collectFirstSome(ct => allProduces.find(_ == ct))
+          .orElse({
+            val fallback = if (valueType.isNamed("String")) RouteMeta.TextPlain else RouteMeta.ApplicationJson
+            println(s"WARNING: no supported body param type for operation '${operation.getOperationId}'; falling back to ${fallback.value}")
+            Option(fallback)
+          })
+      })
+  }
 
   private def showParam(param: ScalaParameter[JavaLanguage], overrideParamName: Option[String] = None): Expression = {
     val paramName = overrideParamName.getOrElse(param.paramName.asString)
@@ -102,54 +154,82 @@ object AsyncHttpClientClientGenerator {
     }
   }
 
-  private def generateBodyMethodCall(param: ScalaParameter[JavaLanguage]): Statement = {
+  private def generateBodyMethodCall(param: ScalaParameter[JavaLanguage], contentType: Option[ContentType]): Option[Statement] = {
     def wrapSetBody(expr: Expression): MethodCallExpr =
       new MethodCallExpr(new NameExpr("builder"), "setBody", new NodeList[Expression](expr))
 
     if (param.isFile) {
-      new ExpressionStmt(
-        wrapSetBody(
-          new ObjectCreationExpr(null,
-                                 FILE_PART_TYPE,
-                                 new NodeList(
-                                   new StringLiteralExpr(param.argName.value),
-                                   new NameExpr(param.paramName.asString)
-                                 ))
+      Option(
+        new ExpressionStmt(
+          wrapSetBody(
+            new ObjectCreationExpr(null,
+                                   FILE_PART_TYPE,
+                                   new NodeList(
+                                     new StringLiteralExpr(param.argName.value),
+                                     new NameExpr(param.paramName.asString)
+                                   ))
+          )
         )
       )
     } else {
-      new TryStmt(
-        new BlockStmt(
-          new NodeList(
+      contentType match {
+        case Some(RouteMeta.ApplicationJson) =>
+          Option(
+            new TryStmt(
+              new BlockStmt(
+                new NodeList(
+                  new ExpressionStmt(
+                    wrapSetBody(
+                      new MethodCallExpr(
+                        new FieldAccessExpr(new ThisExpr, "objectMapper"),
+                        "writeValueAsString",
+                        new NodeList[Expression](new NameExpr(param.paramName.asString))
+                      )
+                    )
+                  )
+                )
+              ),
+              new NodeList(
+                new CatchClause(
+                  new Parameter(util.EnumSet.of(FINAL), JSON_PROCESSING_EXCEPTION_TYPE, new SimpleName("e")),
+                  new BlockStmt(
+                    new NodeList(
+                      new ThrowStmt(
+                        new ObjectCreationExpr(
+                          null,
+                          MARSHALLING_EXCEPTION_TYPE,
+                          new NodeList(new MethodCallExpr(new NameExpr("e"), "getMessage"), new NameExpr("e"))
+                        )
+                      )
+                    )
+                  )
+                )
+              ),
+              null
+            )
+          )
+
+        case Some(RouteMeta.TextPlain) =>
+          Option(
             new ExpressionStmt(
               wrapSetBody(
                 new MethodCallExpr(
-                  new FieldAccessExpr(new ThisExpr, "objectMapper"),
-                  "writeValueAsString",
+                  new MethodCallExpr(new NameExpr("Shower"), "getInstance"),
+                  "show",
                   new NodeList[Expression](new NameExpr(param.paramName.asString))
                 )
               )
             )
           )
-        ),
-        new NodeList(
-          new CatchClause(
-            new Parameter(util.EnumSet.of(FINAL), JSON_PROCESSING_EXCEPTION_TYPE, new SimpleName("e")),
-            new BlockStmt(
-              new NodeList(
-                new ThrowStmt(
-                  new ObjectCreationExpr(
-                    null,
-                    MARSHALLING_EXCEPTION_TYPE,
-                    new NodeList(new MethodCallExpr(new NameExpr("e"), "getMessage"), new NameExpr("e"))
-                  )
-                )
-              )
-            )
-          )
-        ),
-        null
-      )
+
+        case Some(RouteMeta.OctetStream) | None =>
+          // FIXME: we're hoping that the type is something that AHC already supports
+          Option(new ExpressionStmt(wrapSetBody(new NameExpr(param.paramName.asString))))
+
+        case Some(RouteMeta.UrlencodedFormData) | Some(RouteMeta.MultipartFormData) =>
+          // We shouldn't be here, since we can't have a body param with these content types
+          None
+      }
     }
   }
 
@@ -436,12 +516,15 @@ object AsyncHttpClientClientGenerator {
             (parameters.headerParams, "addHeader", false)
           )
 
+          val consumes = getBestConsumes(operation, parameters)
+          val produces = responses.value.map(resp => (resp.statusCode, getBestProduces(operation, resp))).toMap
+
           val builderMethodCalls: List[(ScalaParameter[JavaLanguage], Statement)] = builderParamsMethodNames
             .flatMap({
               case (params, name, needsMultipart) =>
                 params.map(param => (param, generateBuilderMethodCall(param, name, needsMultipart)))
             }) ++
-            parameters.bodyParams.map(param => (param, generateBodyMethodCall(param)))
+            parameters.bodyParams.flatMap(param => generateBodyMethodCall(param, consumes).map(stmt => (param, stmt)))
 
           val callBuilderCreation = new ObjectCreationExpr(
             null,
@@ -471,18 +554,50 @@ object AsyncHttpClientClientGenerator {
 
           val callBuilderCls = new ClassOrInterfaceDeclaration(util.EnumSet.of(PUBLIC, STATIC), false, callBuilderName)
           callBuilderFinalFields.foreach({ case (tpe, name) => callBuilderCls.addField(tpe, name, PRIVATE, FINAL) })
+          val callBuilderInitContentType = consumes.map({ ct =>
+            val ctStr = ct match {
+              case RouteMeta.TextPlain => s"${ct.value}; charset=utf-8"
+              case _                   => ct.value
+            }
+            new ExpressionStmt(
+              new MethodCallExpr(
+                "withHeader",
+                new StringLiteralExpr("Content-Type"),
+                new StringLiteralExpr(ctStr)
+              )
+            )
+          })
+          val callBuilderInitAccept = {
+            val acceptHeaderString = produces
+              .flatMap({ case (_, ct) => ct.map(ct => s"${ct.value}; q=1.0") })
+              .mkString(", ")
+            if (acceptHeaderString.nonEmpty) {
+              Option(
+                new ExpressionStmt(
+                  new MethodCallExpr(
+                    "withHeader",
+                    new StringLiteralExpr("Accept"),
+                    new StringLiteralExpr(s"$acceptHeaderString, */*; q=0.1")
+                  )
+                )
+              )
+            } else {
+              Option.empty
+            }
+          }
 
           callBuilderCls
             .addConstructor(PRIVATE)
             .setParameters(callBuilderFinalFields.map({ case (tpe, name) => new Parameter(util.EnumSet.of(FINAL), tpe, new SimpleName(name)) }).toNodeList)
             .setBody(
               new BlockStmt(
-                callBuilderFinalFields
-                  .map[Statement, List[Statement]]({
-                    case (_, name) =>
-                      new ExpressionStmt(new AssignExpr(new FieldAccessExpr(new ThisExpr, name), new NameExpr(name), AssignExpr.Operator.ASSIGN))
-                  })
-                  .toNodeList
+                (
+                  callBuilderFinalFields
+                    .map[Statement, List[Statement]]({
+                      case (_, name) =>
+                        new ExpressionStmt(new AssignExpr(new FieldAccessExpr(new ThisExpr, name), new NameExpr(name), AssignExpr.Operator.ASSIGN))
+                    }) ++ callBuilderInitContentType ++ callBuilderInitAccept
+                ).toNodeList
               )
             )
 
@@ -609,18 +724,52 @@ object AsyncHttpClientClientGenerator {
                                     new BlockStmt(
                                       new NodeList(
                                         new ExpressionStmt(
-                                          new AssignExpr(
-                                            new VariableDeclarationExpr(new VariableDeclarator(valueType, "result"), FINAL),
-                                            new MethodCallExpr(
-                                              new FieldAccessExpr(new ThisExpr, "objectMapper"),
-                                              "readValue",
-                                              new NodeList[Expression](
-                                                new MethodCallExpr(new NameExpr("response"), "getResponseBodyAsStream"),
-                                                jacksonTypeReferenceFor(valueType)
+                                          produces
+                                            .get(response.statusCode)
+                                            .flatten
+                                            .getOrElse({
+                                              println(
+                                                s"WARNING: no supported content type specified for ${operation.getOperationId}'s ${response.statusCode} response; falling back to application/json"
                                               )
-                                            ),
-                                            AssignExpr.Operator.ASSIGN
-                                          )
+                                              RouteMeta.ApplicationJson
+                                            }) match {
+                                            case RouteMeta.ApplicationJson =>
+                                              new AssignExpr(
+                                                new VariableDeclarationExpr(new VariableDeclarator(valueType, "result"), FINAL),
+                                                new MethodCallExpr(
+                                                  new FieldAccessExpr(new ThisExpr, "objectMapper"),
+                                                  "readValue",
+                                                  new NodeList[Expression](
+                                                    new MethodCallExpr(new NameExpr("response"), "getResponseBodyAsStream"),
+                                                    jacksonTypeReferenceFor(valueType)
+                                                  )
+                                                ),
+                                                AssignExpr.Operator.ASSIGN
+                                              )
+
+                                            case RouteMeta.TextPlain =>
+                                              new AssignExpr(
+                                                new VariableDeclarationExpr(new VariableDeclarator(valueType, "result"), FINAL),
+                                                new MethodCallExpr(new NameExpr("response"), "getResponseBody"),
+                                                AssignExpr.Operator.ASSIGN
+                                              )
+
+                                            case RouteMeta.OctetStream =>
+                                              // FIXME: need to standardize on a type for byte streams
+                                              new AssignExpr(
+                                                new VariableDeclarationExpr(new VariableDeclarator(valueType, "result"), FINAL),
+                                                new MethodCallExpr(new NameExpr("response"), "getResponseBodyAsByteBuffer"),
+                                                AssignExpr.Operator.ASSIGN
+                                              )
+
+                                            case RouteMeta.UrlencodedFormData | RouteMeta.MultipartFormData =>
+                                              // This should never happen & would be a bug in Guardrail
+                                              new AssignExpr(
+                                                new VariableDeclarationExpr(new VariableDeclarator(valueType, "result"), FINAL),
+                                                new NullLiteralExpr,
+                                                AssignExpr.Operator.ASSIGN
+                                              )
+                                          }
                                         ),
                                         new IfStmt(
                                           new BinaryExpr(new NameExpr("result"), new NullLiteralExpr, BinaryExpr.Operator.EQUALS),

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
@@ -34,6 +34,7 @@ object DropwizardServerGenerator {
       case RouteMeta.UrlencodedFormData => "APPLICATION_FORM_URLENCODED"
       case RouteMeta.MultipartFormData  => "MULTIPART_FORM_DATA"
       case RouteMeta.TextPlain          => "TEXT_PLAIN"
+      case RouteMeta.OctetStream        => "APPLICATION_OCTET_STREAM"
     }
   }
 
@@ -99,7 +100,8 @@ object DropwizardServerGenerator {
                               protocolElems: List[StrictProtocolElems[JavaLanguage]]): Option[RouteMeta.ContentType] = {
     val priorityOrder = NonEmptyList.of(
       RouteMeta.ApplicationJson,
-      RouteMeta.TextPlain
+      RouteMeta.TextPlain,
+      RouteMeta.OctetStream
     )
 
     priorityOrder

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
@@ -17,17 +17,21 @@ import java.util
 import scala.collection.JavaConverters._
 
 object RouteMeta {
-  sealed abstract class ContentType(value: String)
+  sealed abstract class ContentType(val value: String) {
+    override val toString: String = value
+  }
   case object ApplicationJson    extends ContentType("application/json")
   case object MultipartFormData  extends ContentType("multipart/form-data")
   case object UrlencodedFormData extends ContentType("application/x-www-form-urlencoded")
   case object TextPlain          extends ContentType("text/plain")
+  case object OctetStream        extends ContentType("application/octet-stream")
   object ContentType {
     def unapply(value: String): Option[ContentType] = value match {
       case "application/json"                  => Some(ApplicationJson)
       case "multipart/form-data"               => Some(MultipartFormData)
       case "application/x-www-form-urlencoded" => Some(UrlencodedFormData)
       case "text/plain"                        => Some(TextPlain)
+      case "application/octet-stream"          => Some(OctetStream)
       case _                                   => None
     }
   }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.models.responses.ApiResponse
 import io.swagger.v3.oas.models.security.{ OAuthFlows, SecurityRequirement, SecurityScheme => SwSecurityScheme }
 import java.net.URI
 import java.util
+import java.util.Locale
 import scala.collection.JavaConverters._
 
 object RouteMeta {
@@ -26,7 +27,7 @@ object RouteMeta {
   case object TextPlain          extends ContentType("text/plain")
   case object OctetStream        extends ContentType("application/octet-stream")
   object ContentType {
-    def unapply(value: String): Option[ContentType] = value match {
+    def unapply(value: String): Option[ContentType] = value.toLowerCase(Locale.US) match {
       case "application/json"                  => Some(ApplicationJson)
       case "multipart/form-data"               => Some(MultipartFormData)
       case "application/x-www-form-urlencoded" => Some(UrlencodedFormData)

--- a/modules/sample-dropwizard/src/test/scala/core/Dropwizard/AsyncHttpClientContentHeaderTest.scala
+++ b/modules/sample-dropwizard/src/test/scala/core/Dropwizard/AsyncHttpClientContentHeaderTest.scala
@@ -1,0 +1,51 @@
+package core.Dropwizard
+
+import com.github.tomakehurst.wiremock.client.WireMock._
+import helpers.WireMockSupport
+import org.scalatest.{FreeSpec, Matchers}
+import tests.contentTypes.textPlain.client.dropwizard.foo.FooClient
+
+class AsyncHttpClientContentHeaderTest extends FreeSpec with Matchers with WireMockSupport {
+  private val MOCK_REQUEST_BODY = "abcd"
+  private val MOCK_RESPONSE_BODY = "efgh"
+
+  "AsyncHttpClient with text/plain" - {
+    "in both req/resp bodies has Content-Type and Accept headers set" in {
+      wireMockServer.stubFor(
+        post(urlPathEqualTo("/bar"))
+          .withHeader("Content-Type", equalTo("text/plain; charset=utf-8"))
+          .withHeader("Accept", equalTo("text/plain; q=1.0, */*; q=0.1"))
+          .withRequestBody(equalTo(MOCK_REQUEST_BODY))
+          .willReturn(
+            aResponse()
+              .withStatus(201)
+              .withHeader("Content-Type", "text/plain; charset=utf-8")
+              .withBody(MOCK_RESPONSE_BODY)
+          )
+      )
+
+      val client = new FooClient.Builder().withBaseUrl(wireMockBaseUrl).build()
+      client.doBar().withBody(MOCK_REQUEST_BODY).call().toCompletableFuture.get().fold(
+        { body => body shouldBe MOCK_RESPONSE_BODY; () },
+        { () => fail("Should have gotten 2xx response"); () }
+      )
+    }
+
+    "in req body has Content-Type header set" in {
+      wireMockServer.stubFor(
+        post(urlPathEqualTo("/foo"))
+          .withHeader("Content-Type", equalTo("text/plain; charset=utf-8"))
+          .withRequestBody(equalTo(MOCK_REQUEST_BODY))
+          .willReturn(
+            aResponse()
+              .withStatus(201)
+          )
+      )
+      val client = new FooClient.Builder().withBaseUrl(wireMockBaseUrl).build()
+      client.doFoo(MOCK_REQUEST_BODY).call().toCompletableFuture.get().fold(
+        () => (),
+        { () => fail("Should have gotten 201 response"); () }
+      )
+    }
+  }
+}

--- a/modules/sample-dropwizard/src/test/scala/helpers/WireMockSupport.scala
+++ b/modules/sample-dropwizard/src/test/scala/helpers/WireMockSupport.scala
@@ -1,0 +1,21 @@
+package helpers
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration._
+import java.net.URI
+import org.scalatest.{BeforeAndAfterAll, Suite}
+
+trait WireMockSupport extends BeforeAndAfterAll { self: Suite =>
+  protected val wireMockServer = new WireMockServer(wireMockConfig().bindAddress("localhost").dynamicPort())
+  protected def wireMockBaseUrl: URI = new URI(s"http://localhost:${wireMockServer.port()}")
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    wireMockServer.start()
+  }
+
+  override protected def afterAll(): Unit = {
+    wireMockServer.stop()
+    super.afterAll()
+  }
+}

--- a/modules/sample/src/main/resources/contentType-textPlain.yaml
+++ b/modules/sample/src/main/resources/contentType-textPlain.yaml
@@ -39,5 +39,7 @@ paths:
       responses:
         201:
           description: "Created"
+          schema:
+            type: string
         406:
           description: "Invalid"


### PR DESCRIPTION
Take two of https://github.com/twilio/guardrail/pull/278

Adds text/plain and application/octet-stream support for AHC request and response bodies.

Also improves error reporting from the Java code formatter rather than just dumping a stack trace to console.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
