### PR TITLE
Implement support for OpenAPI v3 schema discriminator mapping

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -58,6 +58,7 @@ val exampleCases: List[(java.io.File, String, Boolean, List[String])] = List(
   (sampleResource("petstore.json"), "examples", false, List("--import", "support.PositiveLong")),
   (sampleResource("plain.json"), "tests.dtos", false, List.empty),
   (sampleResource("polymorphism.yaml"), "polymorphism", false, List.empty),
+  (sampleResource("polymorphism-mapped.yaml"), "polymorphismMapped", false, List.empty),
   (sampleResource("raw-response.yaml"), "raw", false, List.empty),
   (sampleResource("server1.yaml"), "tracer", true, List.empty),
   (sampleResource("server2.yaml"), "tracer", true, List.empty),

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolElems.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolElems.scala
@@ -9,14 +9,14 @@ import com.twilio.guardrail.protocol.terms.protocol.ProtocolSupportTerms
 
 case class StaticDefns[L <: LA](className: String, extraImports: List[L#Import], definitions: List[L#Definition])
 
-sealed trait ProtocolElems[L <: LA]
+sealed trait ProtocolElems[L <: LA] { def name: String }
 
-sealed trait LazyProtocolElems[L <: LA]         extends ProtocolElems[L] { def name: String }
+sealed trait LazyProtocolElems[L <: LA]         extends ProtocolElems[L]
 case class Deferred[L <: LA](name: String)      extends LazyProtocolElems[L]
 case class DeferredArray[L <: LA](name: String) extends LazyProtocolElems[L]
 case class DeferredMap[L <: LA](name: String)   extends LazyProtocolElems[L]
 
-sealed trait StrictProtocolElems[L <: LA]                 extends ProtocolElems[L] { def name: String }
+sealed trait StrictProtocolElems[L <: LA]                 extends ProtocolElems[L]
 case class RandomType[L <: LA](name: String, tpe: L#Type) extends StrictProtocolElems[L]
 case class ClassDefinition[L <: LA](name: String, tpe: L#TypeName, cls: L#ClassDefinition, staticDefns: StaticDefns[L], parents: List[SuperClass[L]] = Nil)
     extends StrictProtocolElems[L]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
@@ -7,6 +7,7 @@ import cats.data.NonEmptyList
 import cats.implicits._
 import cats.~>
 import com.github.javaparser.ast.`type`.{ PrimitiveType, Type }
+import com.twilio.guardrail.Discriminator
 import com.twilio.guardrail.extract.{ Default, EmptyValueIsNull }
 import com.twilio.guardrail.generators.syntax.Java._
 import com.twilio.guardrail.generators.syntax.RichString
@@ -292,12 +293,13 @@ object JacksonGenerator {
       }
     } yield {
       val discriminators                             = parents.flatMap(_.discriminators)
+      val discriminatorNames                         = discriminators.map(_.propertyName).toSet
       val parentParams                               = parentOpt.toList.flatMap(_.params)
       val parentParamNames                           = parentParams.map(_.name)
       val (parentRequiredTerms, parentOptionalTerms) = sortParams(parentParams)
       val parentTerms                                = parentRequiredTerms ++ parentOptionalTerms
       val params = parents.filterNot(parent => parentOpt.contains(parent)).flatMap(_.params) ++ selfParams.filterNot(
-        param => discriminators.contains(param.term.getName.getIdentifier) || parentParamNames.contains(param.term.getName.getIdentifier)
+        param => discriminatorNames.contains(param.term.getName.getIdentifier) || parentParamNames.contains(param.term.getName.getIdentifier)
       )
       val (requiredTerms, optionalTerms) = sortParams(params)
       val terms                          = requiredTerms ++ optionalTerms
@@ -318,7 +320,7 @@ object JacksonGenerator {
       addParents(dtoClass, parentOpt)
 
       def withoutDiscriminators(terms: List[ParameterTerm]): List[ParameterTerm] =
-        terms.filterNot(term => discriminators.contains(term.propertyName))
+        terms.filterNot(term => discriminatorNames.contains(term.propertyName))
 
       terms.foreach({
         case ParameterTerm(propertyName, parameterName, fieldType, _, _) =>
@@ -340,11 +342,16 @@ object JacksonGenerator {
       val superCall = new MethodCallExpr(
         "super",
         parentTerms.map({ term =>
-          if (discriminators.contains(term.propertyName)) {
-            new StringLiteralExpr(clsName)
-          } else {
-            new NameExpr(term.parameterName)
-          }
+          discriminators
+            .find(_.propertyName == term.propertyName)
+            .fold[Expression](new NameExpr(term.parameterName))(
+              discriminator =>
+                new StringLiteralExpr(
+                  discriminator.mapping
+                    .collectFirst({ case (value, elem) if elem.name == clsName => value })
+                    .getOrElse(clsName)
+              )
+            )
         }): _*
       )
       primaryConstructor.setBody(dtoConstructorBody(superCall, terms))
@@ -764,7 +771,7 @@ object JacksonGenerator {
 
   private def renderSealedTrait(className: String,
                                 selfParams: List[ProtocolParameter[JavaLanguage]],
-                                discriminator: String,
+                                discriminator: Discriminator[JavaLanguage],
                                 parents: List[SuperClass[JavaLanguage]],
                                 children: List[String]): Target[ClassOrInterfaceDeclaration] = {
     val parentsWithDiscriminators = parents.collect({ case p if p.discriminators.nonEmpty => p })
@@ -815,7 +822,7 @@ object JacksonGenerator {
             ),
             new MemberValuePair(
               "property",
-              new StringLiteralExpr(discriminator)
+              new StringLiteralExpr(discriminator.propertyName)
             )
           )
         )
@@ -829,7 +836,12 @@ object JacksonGenerator {
                 new NormalAnnotationExpr(
                   new Name("JsonSubTypes.Type"),
                   new NodeList(
-                    new MemberValuePair("name", new StringLiteralExpr(child)),
+                    new MemberValuePair("name",
+                                        new StringLiteralExpr(
+                                          discriminator.mapping
+                                            .collectFirst({ case (value, elem) if elem.name == child => value })
+                                            .getOrElse(child)
+                                        )),
                     new MemberValuePair("value", new ClassExpr(JavaParser.parseType(child)))
                   )
               )
@@ -897,10 +909,10 @@ object JacksonGenerator {
             List.empty
           )
 
-      case DecodeADT(clsName, children) =>
+      case DecodeADT(clsName, discriminator, children) =>
         Target.pure(None)
 
-      case EncodeADT(clsName, children) =>
+      case EncodeADT(clsName, discriminator, children) =>
         Target.pure(None)
 
       case RenderSealedTrait(className, selfParams, discriminator, parents, children) =>

--- a/modules/sample-dropwizard/src/test/scala/core/Jackson/JacksonPolyMappingTest.scala
+++ b/modules/sample-dropwizard/src/test/scala/core/Jackson/JacksonPolyMappingTest.scala
@@ -1,0 +1,36 @@
+package core.Jackson
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.scalatest.{FreeSpec, Matchers}
+import polymorphismMapped.client.dropwizard.definitions.{A, B, Base, C}
+import scala.reflect.ClassTag
+
+class JacksonPolyMappingTest extends FreeSpec with Matchers {
+  private val mapper = new ObjectMapper
+
+  "Polymorphic definitions with discriminator mappings" - {
+    "should have their discriminator initialized properly" in {
+      val a = new A.Builder(42).build()
+      a.getPolytype shouldBe "this_is_a"
+
+      val b = new B.Builder("foo").build()
+      b.getPolytype shouldBe "this_is_b"
+
+      val c = new C.Builder(42.42).build()
+      c.getPolytype shouldBe "C"
+    }
+
+    "should deserialize properly" in {
+      def verify[T](json: String, discriminatorValue: String)(implicit cls: ClassTag[T]): Unit = {
+        val pojo = mapper.readValue(json, classOf[Base])
+        pojo shouldNot be(null)
+        pojo.getClass shouldBe cls.runtimeClass
+        pojo.getPolytype shouldBe discriminatorValue
+      }
+
+      verify[A]("""{"polytype": "this_is_a", "some_a": 42}""", "this_is_a")
+      verify[B]("""{"polytype": "this_is_b", "some_b": "foo"}""", "this_is_b")
+      verify[C]("""{"polytype": "C", "some_c": 42.42}""", "C")
+    }
+  }
+}

--- a/modules/sample/src/main/resources/polymorphism-mapped.yaml
+++ b/modules/sample/src/main/resources/polymorphism-mapped.yaml
@@ -1,0 +1,47 @@
+openapi: 3.0.1
+info:
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Base:
+      type: object
+      required:
+        - polytype
+      properties:
+        polytype:
+          type: string
+      discriminator:
+        propertyName: polytype
+        mapping:
+          this_is_a: A
+          this_is_b: "#/components/schemas/B"
+    A:
+      allOf:
+        - $ref: "#/components/schemas/Base"
+        - type: object
+          required:
+            - some_a
+          properties:
+            some_a:
+              type: integer
+              format: int32
+    B:
+      allOf:
+        - $ref: "#/components/schemas/Base"
+        - type: object
+          required:
+            - some_b
+          properties:
+            some_b:
+              type: string
+    C:
+      allOf:
+        - $ref: "#/components/schemas/Base"
+        - type: object
+          required:
+            - some_c
+          properties:
+            some_c:
+              type: number
+              format: double


### PR DESCRIPTION
Addresses https://github.com/twilio/guardrail/issues/193 (for both Circe and Jackson).

I had to make a little compromise rather than doing a major refactor: I implemented a mini-protocol-elem-resolver (_very_ mini tho) for the discriminator mapping values.  As you probably remember, protocol elements are generated like so:

1. Separate schemas into regular and poly.
2. Render all polymorphic ADTs.
3. Render all regular protocol objects.
4. Resolve all polymorphic ADTs.
5. Resolve all regular protocol objects.

The problem is that there's a semi-circular dependency.  During step 1, the hierarchies for poly ADTs are built.  However, that requires that steps 4 and 5 already be done, because discriminator mapping values can reference other (polymorphic or not) schemas.  And the rendering steps in 2 and 3 require that references be resolved.  But building the hierarchies (in the safest way) in step 1 requires that we already know all possible types that aren't found until step 1 is over (and really, they aren't fully resolved until 5 and 6).

So for now the hierarchy-building bit in step 1 does a naive (but probably always right) resolving to `RandomType` that takes the last component of strings that start with `#/`, or just the bare value if it doesn't.  Apparently mappings can also reference URLs, but we don't support anything like that anyway.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
