### PR TITLE
Use the actual operation body types in getBestConsumes()

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
@@ -53,7 +53,7 @@ object AsyncHttpClientClientGenerator {
       }
     } else if (parameters.bodyParams.isDefined) {
       val validTypes = Seq(RouteMeta.ApplicationJson, RouteMeta.TextPlain)
-      List(RouteMeta.ApplicationJson.value, RouteMeta.TextPlain.value)
+      operation.consumes
         .collectFirst({ case ContentType(value) if validTypes.contains(value) => value })
         .orElse({
           println(s"WARNING: no supported body param type for operation '${operation.getOperationId}'; falling back to application/json")


### PR DESCRIPTION
So this is embarrassing.  Not sure how the original PR tests passed, since they're failing now...

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
