### PR TITLE
Add a description to requireNonNull() calls

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
@@ -1079,7 +1079,7 @@ object AsyncHttpClientClientGenerator {
           new Parameter(util.EnumSet.of(FINAL), tpe, new SimpleName(name))
         def createBuilderConstructorAssignment(name: String): Statement =
           new ExpressionStmt(
-            new AssignExpr(new FieldAccessExpr(new ThisExpr, name), new MethodCallExpr("requireNonNull", new NameExpr(name)), AssignExpr.Operator.ASSIGN)
+            new AssignExpr(new FieldAccessExpr(new ThisExpr, name), requireNonNullExpr(name), AssignExpr.Operator.ASSIGN)
           )
         (serverUrl, tracingName) match {
           case (None, None) if tracing =>
@@ -1142,9 +1142,8 @@ object AsyncHttpClientClientGenerator {
                 )
               )
             )
-        val nonNullInitializer: String => Expression = name => new MethodCallExpr(null, "requireNonNull", new NodeList[Expression](new NameExpr(name)))
-        def optionalInitializer(valueArg: String => Expression): String => Expression =
-          name => new MethodCallExpr(new NameExpr("Optional"), "of", new NodeList[Expression](valueArg(name)))
+        val nonNullInitializer: String => Expression                                  = name => requireNonNullExpr(name)
+        def optionalInitializer(valueArg: String => Expression): String => Expression = name => optionalOfExpr(valueArg(name))
 
         val builderSetters = List(
           if (serverUrl.isDefined) Some(createSetter(URI_TYPE, "baseUrl", nonNullInitializer)) else None,


### PR DESCRIPTION
The default exception/error message thrown is next to useless, so use the two-arg variant that takes a description that tells the caller what is missing.

Also adds a `java.util.Optional` import to JacksonGenerator so we don't have to keep using the unsightly fully-qualified name.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
