### PR TITLE
Add an extra operation to the text/plain test

### DIFF
--- a/modules/sample-dropwizard/src/test/scala/core/Dropwizard/AsyncHttpClientContentHeaderTest.scala
+++ b/modules/sample-dropwizard/src/test/scala/core/Dropwizard/AsyncHttpClientContentHeaderTest.scala
@@ -12,7 +12,7 @@ class AsyncHttpClientContentHeaderTest extends FreeSpec with Matchers with WireM
   "AsyncHttpClient with text/plain" - {
     "in both req/resp bodies has Content-Type and Accept headers set" in {
       wireMockServer.stubFor(
-        post(urlPathEqualTo("/bar"))
+        post(urlPathEqualTo("/baz"))
           .withHeader("Content-Type", equalTo("text/plain; charset=utf-8"))
           .withHeader("Accept", equalTo("text/plain; q=1.0, */*; q=0.1"))
           .withRequestBody(equalTo(MOCK_REQUEST_BODY))
@@ -25,7 +25,7 @@ class AsyncHttpClientContentHeaderTest extends FreeSpec with Matchers with WireM
       )
 
       val client = new FooClient.Builder().withBaseUrl(wireMockBaseUrl).build()
-      client.doBar().withBody(MOCK_REQUEST_BODY).call().toCompletableFuture.get().fold(
+      client.doBaz().withBody(MOCK_REQUEST_BODY).call().toCompletableFuture.get().fold(
         { body => body shouldBe MOCK_RESPONSE_BODY; () },
         { () => fail("Should have gotten 2xx response"); () }
       )

--- a/modules/sample/src/main/resources/contentType-textPlain.yaml
+++ b/modules/sample/src/main/resources/contentType-textPlain.yaml
@@ -39,6 +39,24 @@ paths:
       responses:
         201:
           description: "Created"
+        406:
+          description: "Invalid"
+  /baz:
+    post:
+      operationId: doBaz
+      x-jvm-package: foo
+      consumes:
+        - text/plain
+      produces:
+        - text/plain
+      parameters:
+        - in: body
+          name: body
+          schema:
+            type: string
+      responses:
+        201:
+          description: "Created"
           schema:
             type: string
         406:


### PR DESCRIPTION
The akka-http server generator doesn't properly support text/plain response bodies yet, so avoid conflicting with other tests in the DW test.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
