### PR TITLE
Fix discriminator filter in circe protocol trait generation

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
@@ -8,7 +8,7 @@ import com.twilio.guardrail.extract.VendorExtension.VendorExtensible._
 import com.twilio.guardrail.languages.LA
 import com.twilio.guardrail.protocol.terms.protocol._
 import com.twilio.guardrail.terms.framework.FrameworkTerms
-import com.twilio.guardrail.terms.{ScalaTerms, SwaggerTerms}
+import com.twilio.guardrail.terms.{ ScalaTerms, SwaggerTerms }
 import java.util.Locale
 import scala.collection.JavaConverters._
 import scala.language.higherKinds

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/CirceProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/CirceProtocolGenerator.scala
@@ -440,7 +440,7 @@ object CirceProtocolGenerator {
           testTerms <- (
             params
               .map(_.term)
-              .filter(_.name.value != discriminator)
+              .filter(_.name.value != discriminator.propertyName)
               .traverse { t =>
                 for {
                   tpe <- Target.fromOption(

--- a/modules/sample-akkaHttp/src/test/scala/generators/AkkaHttp/Client/contentType/AkkaHttpTextPlainTest.scala
+++ b/modules/sample-akkaHttp/src/test/scala/generators/AkkaHttp/Client/contentType/AkkaHttpTextPlainTest.scala
@@ -60,6 +60,9 @@ class AkkaHttpTextPlainTest extends FunSuite with Matchers with EitherValues wit
       def doBar(respond: tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.doBarResponse.type)(
           body: Option[String]
       ): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.doBarResponse] = ???
+      def doBaz(respond: FooResource.doBazResponse.type)(
+          body: Option[String]
+      ): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.doBazResponse] = ???
     })
 
     val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
@@ -80,6 +83,9 @@ class AkkaHttpTextPlainTest extends FunSuite with Matchers with EitherValues wit
         } else {
           Future.successful(respond.NotAcceptable)
         }
+      def doBaz(respond: FooResource.doBazResponse.type)(
+          body: Option[String]
+      ): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.doBazResponse] = ???
     })
 
     val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
@@ -100,6 +106,9 @@ class AkkaHttpTextPlainTest extends FunSuite with Matchers with EitherValues wit
         } else {
           Future.successful(respond.NotAcceptable)
         }
+      def doBaz(respond: FooResource.doBazResponse.type)(
+          body: Option[String]
+      ): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.doBazResponse] = ???
     })
 
     val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)

--- a/modules/sample-http4s/src/test/scala/generators/Http4s/Client/contentType/Http4sTextPlainTest.scala
+++ b/modules/sample-http4s/src/test/scala/generators/Http4s/Client/contentType/Http4sTextPlainTest.scala
@@ -2,12 +2,11 @@ package generators.Http4s.Client.contentType
 
 import _root_.tests.contentTypes.textPlain.client.http4s.foo.FooClient
 import _root_.tests.contentTypes.textPlain.client.{ http4s => cdefs }
-import _root_.tests.contentTypes.textPlain.server.http4s.foo.{ DoBarResponse, DoFooResponse, FooHandler, FooResource }
+import _root_.tests.contentTypes.textPlain.server.http4s.foo.{ DoBarResponse, DoBazResponse, DoFooResponse, FooHandler, FooResource }
 import _root_.tests.contentTypes.textPlain.server.{ http4s => sdefs }
 import org.scalatest.{ EitherValues, FunSuite, Matchers }
 import org.http4s.dsl.io._
 import org.http4s.headers._
-
 import cats.effect.IO
 import org.http4s.client.Client
 import org.http4s.{ Charset, HttpRoutes, MediaType }
@@ -53,6 +52,7 @@ class Http4sTextPlainTest extends FunSuite with Matchers with EitherValues {
           IO.pure(respond.NotAcceptable)
         }
       def doBar(respond: DoBarResponse.type)(body: Option[String]): IO[sdefs.foo.DoBarResponse] = ???
+      def doBaz(respond: DoBazResponse.type)(body: Option[String]): IO[sdefs.foo.DoBazResponse] = ???
     })
 
     val client: Client[IO] = Client.fromHttpApp(route.orNotFound)
@@ -69,6 +69,7 @@ class Http4sTextPlainTest extends FunSuite with Matchers with EitherValues {
         } else {
           IO.pure(respond.NotAcceptable)
         }
+      def doBaz(respond: DoBazResponse.type)(body: Option[String]): IO[sdefs.foo.DoBazResponse] = ???
     })
 
     val client: Client[IO] = Client.fromHttpApp(route.orNotFound)
@@ -85,6 +86,7 @@ class Http4sTextPlainTest extends FunSuite with Matchers with EitherValues {
         } else {
           IO.pure(respond.NotAcceptable)
         }
+      def doBaz(respond: DoBazResponse.type)(body: Option[String]): IO[sdefs.foo.DoBazResponse] = ???
     })
 
     val client: Client[IO] = Client.fromHttpApp(route.orNotFound)


### PR DESCRIPTION
Not sure why PR validation didn't catch this.  (And I bet this showed up as a warning, but I missed it :( ).

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
