### PR TITLE
Allow overriding required POJO properties with builder methods

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/Java.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/Java.scala
@@ -4,7 +4,18 @@ import com.github.javaparser.JavaParser
 import com.github.javaparser.ast.`type`.{ ClassOrInterfaceType, Type }
 import com.github.javaparser.ast.body._
 import com.github.javaparser.ast.comments.{ BlockComment, Comment }
-import com.github.javaparser.ast.expr.{ Expression, LiteralStringValueExpr, MethodCallExpr, Name, NameExpr, SimpleName, StringLiteralExpr }
+import com.github.javaparser.ast.expr.{
+  ClassExpr,
+  Expression,
+  FieldAccessExpr,
+  LiteralStringValueExpr,
+  MethodCallExpr,
+  Name,
+  NameExpr,
+  SimpleName,
+  StringLiteralExpr,
+  ThisExpr
+}
 import com.github.javaparser.ast.nodeTypes.{ NodeWithName, NodeWithSimpleName }
 import com.github.javaparser.ast.{ CompilationUnit, ImportDeclaration, Node, NodeList }
 import com.twilio.guardrail.languages.JavaLanguage
@@ -96,6 +107,9 @@ object Java {
   val ASSERTION_ERROR_TYPE: ClassOrInterfaceType = JavaParser.parseClassOrInterfaceType("AssertionError")
 
   private def nameFromExpr(expr: Expression): String = expr match {
+    case _: ThisExpr                  => "this"
+    case ce: ClassExpr                => s"${ce.getType.toString}.class"
+    case fae: FieldAccessExpr         => s"${nameFromExpr(fae.getScope)}.${fae.getNameAsString}"
     case nwsn: NodeWithSimpleName[_]  => nwsn.getNameAsString
     case nwn: NodeWithName[_]         => nwn.getNameAsString
     case lsve: LiteralStringValueExpr => lsve.getValue


### PR DESCRIPTION
Since required properties are passed to the builder constructor, there's usually no need to be able to call `withSomeProperty(...)` to later set the value (again).  However, since I added the "copy" constructor for the builder, this would mean that you wouldn't be able to use that constructor and then modify the value of a required property, which greatly reduces its usefulness.  So, we remove that restriction and add a few more checks to ensure that the object remains consistent.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
