### PR TITLE
Add basic redaction via new vendor extension 'x-data-redaction'

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,6 +60,7 @@ val exampleCases: List[(java.io.File, String, Boolean, List[String])] = List(
   (sampleResource("polymorphism.yaml"), "polymorphism", false, List.empty),
   (sampleResource("polymorphism-mapped.yaml"), "polymorphismMapped", false, List.empty),
   (sampleResource("raw-response.yaml"), "raw", false, List.empty),
+  (sampleResource("redaction.yaml"), "redaction", false, List.empty),
   (sampleResource("server1.yaml"), "tracer", true, List.empty),
   (sampleResource("server2.yaml"), "tracer", true, List.empty),
   (sampleResource("pathological-parameters.yaml"), "pathological", false, List.empty)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
@@ -21,11 +21,16 @@ sealed trait EmptyToNullBehaviour
 case object EmptyIsNull  extends EmptyToNullBehaviour
 case object EmptyIsEmpty extends EmptyToNullBehaviour
 
+sealed trait RedactionBehaviour
+case object DataVisible  extends RedactionBehaviour
+case object DataRedacted extends RedactionBehaviour
+
 case class ProtocolParameter[L <: LA](term: L#MethodParameter,
                                       name: String,
                                       dep: Option[L#TermName],
                                       readOnlyKey: Option[String],
                                       emptyToNull: EmptyToNullBehaviour,
+                                      dataRedaction: RedactionBehaviour,
                                       defaultValue: Option[L#Term])
 
 case class Discriminator[L <: LA](propertyName: String, mapping: Map[String, ProtocolElems[L]])

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/extract/Extractable.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/extract/Extractable.scala
@@ -1,6 +1,6 @@
 package com.twilio.guardrail.extract
 
-import com.twilio.guardrail.{ EmptyIsEmpty, EmptyIsNull, EmptyToNullBehaviour }
+import com.twilio.guardrail.{ DataRedacted, DataVisible, EmptyIsEmpty, EmptyIsNull, EmptyToNullBehaviour, RedactionBehaviour }
 import scala.util.{ Success, Try }
 import scala.reflect.ClassTag
 import scala.collection.JavaConverters._
@@ -42,6 +42,11 @@ object Extractable {
     build[EmptyToNullBehaviour]({
       case x: Boolean if x  => EmptyIsNull
       case x: Boolean if !x => EmptyIsEmpty
+    })
+  implicit val defaultExtractableRedactionBehaviour: Extractable[RedactionBehaviour] =
+    build[RedactionBehaviour]({
+      case x: Boolean if x  => DataRedacted
+      case x: Boolean if !x => DataVisible
     })
 
   implicit def defaultExtractableList[T: Extractable: ClassTag]: Extractable[List[T]] =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/extract/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/extract/package.scala
@@ -39,4 +39,7 @@ package object extract {
 
   def SecurityOptional[F: VendorExtension.VendorExtensible](v: F): List[String] =
     VendorExtension(v).extract[List[String]]("x-security-optional").toList.flatten
+
+  def DataRedaction[F: VendorExtension.VendorExtensible](v: F): Option[RedactionBehaviour] =
+    VendorExtension(v).extract[RedactionBehaviour]("x-data-redaction")
 }

--- a/modules/sample-akkaHttp/src/test/scala/generators/Circe/CirceRedactionTest.scala
+++ b/modules/sample-akkaHttp/src/test/scala/generators/Circe/CirceRedactionTest.scala
@@ -1,0 +1,11 @@
+package generators.Circe
+
+import org.scalatest.{ FreeSpec, Matchers }
+import redaction.client.akkaHttp.definitions.Redaction
+
+class CirceRedactionTest extends FreeSpec with Matchers {
+  "Redacted fields should get replaced with '[redacted]'" in {
+    val redaction = Redaction("a", "b", Some("c"), Some("d"))
+    redaction.toString shouldBe "Redaction(a,[redacted],Some(c),[redacted])"
+  }
+}

--- a/modules/sample-dropwizard/src/test/scala/core/Jackson/JacksonRedactionTest.scala
+++ b/modules/sample-dropwizard/src/test/scala/core/Jackson/JacksonRedactionTest.scala
@@ -1,0 +1,15 @@
+package core.Jackson
+
+import org.scalatest.{FreeSpec, Matchers}
+import redaction.client.dropwizard.definitions.Redaction
+
+class JacksonRedactionTest extends FreeSpec with Matchers {
+  "Redacted fields should get replaced with '[redacted]'" in {
+    val redaction = new Redaction.Builder("a", "b")
+      .withVisibleOptional("c")
+      .withRedactedOptional("d")
+      .build()
+
+    redaction.toString shouldBe "Redaction{visibleRequired=a, redactedRequired=[redacted], visibleOptional=Optional[c], redactedOptional=[redacted]}"
+  }
+}

--- a/modules/sample/src/main/resources/redaction.yaml
+++ b/modules/sample/src/main/resources/redaction.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.2
+info:
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Redaction:
+      type: object
+      required:
+        - visible_required
+        - redacted_required
+      properties:
+        visible_required:
+          type: string
+        redacted_required:
+          type: string
+          x-data-redaction: true
+        visible_optional:
+          type: string
+        redacted_optional:
+          type: string
+          x-data-redaction: true


### PR DESCRIPTION
Redacts fields in circe- and jackson-generated objects' `toString` methods.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
