### PR TITLE
Support BinarySchema for param/property types

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,6 +39,7 @@ def sampleResource(name: String): java.io.File = file(s"modules/sample/src/main/
 val exampleCases: List[(java.io.File, String, Boolean, List[String])] = List(
   (sampleResource("additional-properties.yaml"), "additionalProperties", false, List.empty),
   (sampleResource("alias.yaml"), "alias", false, List.empty),
+  (sampleResource("binary.yaml"), "binary", false, List.empty),
   (sampleResource("contentType-textPlain.yaml"), "tests.contentTypes.textPlain", false, List.empty),
   (sampleResource("custom-header-type.yaml"), "tests.customTypes.customHeader", false, List.empty),
   (sampleResource("edgecases/defaults.yaml"), "edgecases.defaults", false, List.empty),

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
@@ -234,19 +234,19 @@ object SwaggerUtil {
         customTpe <- customType.flatTraverse(liftCustomType _)
         result <- customTpe.fold({
           (typeName, format) match {
-            case ("string", Some("password"))     => stringType(None)
-            case ("string", Some("date"))         => dateType()
-            case ("string", Some("date-time"))    => dateTimeType()
-            case ("string", fmt @ Some("binary")) => fileType(None).map(log(fmt, _))
-            case ("string", fmt)                  => stringType(fmt).map(log(fmt, _))
-            case ("number", Some("float"))        => floatType()
-            case ("number", Some("double"))       => doubleType()
-            case ("number", fmt)                  => numberType(fmt).map(log(fmt, _))
-            case ("integer", Some("int32"))       => intType()
-            case ("integer", Some("int64"))       => longType()
-            case ("integer", fmt)                 => integerType(fmt).map(log(fmt, _))
-            case ("boolean", fmt)                 => booleanType(fmt).map(log(fmt, _))
-            case ("array", fmt)                   => arrayType(fmt).map(log(fmt, _))
+            case ("string", Some("password"))  => stringType(None)
+            case ("string", Some("date"))      => dateType()
+            case ("string", Some("date-time")) => dateTimeType()
+            case ("string", Some("binary"))    => fileType(None)
+            case ("string", fmt)               => stringType(fmt).map(log(fmt, _))
+            case ("number", Some("float"))     => floatType()
+            case ("number", Some("double"))    => doubleType()
+            case ("number", fmt)               => numberType(fmt).map(log(fmt, _))
+            case ("integer", Some("int32"))    => intType()
+            case ("integer", Some("int64"))    => longType()
+            case ("integer", fmt)              => integerType(fmt).map(log(fmt, _))
+            case ("boolean", fmt)              => booleanType(fmt).map(log(fmt, _))
+            case ("array", fmt)                => arrayType(fmt).map(log(fmt, _))
             case ("file", fmt) =>
               fileType(None).map(log(fmt, _))
             case ("binary", fmt) =>
@@ -346,6 +346,12 @@ object SwaggerUtil {
           for {
             customTpeName <- customTypeName(f)
             res           <- typeName[L, F]("file", Option(f.getFormat), customTpeName).map(Resolved[L](_, None, None))
+          } yield res
+
+        case b: BinarySchema =>
+          for {
+            customTpeName <- customTypeName(b)
+            res           <- typeName[L, F]("string", Option(b.getFormat), customTpeName).map(Resolved[L](_, None, None))
           } yield res
 
         case x =>

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpGenerator.scala
@@ -9,7 +9,7 @@ import com.twilio.guardrail.languages.ScalaLanguage
 object AkkaHttpGenerator {
   object FrameworkInterp extends FunctionK[FrameworkTerm[ScalaLanguage, ?], Target] {
     def apply[T](term: FrameworkTerm[ScalaLanguage, T]): Target[T] = term match {
-      case FileType(format)   => Target.pure(format.fold[Type](t"BodyPartEntity")(Type.Name(_)))
+      case FileType(format)   => Target.pure(format.fold[Type](t"akka.http.scaladsl.model.BodyPartEntity")(Type.Name(_)))
       case ObjectType(format) => Target.pure(t"io.circe.Json")
 
       case GetFrameworkImports(tracing) =>

--- a/modules/sample/src/main/resources/binary.yaml
+++ b/modules/sample/src/main/resources/binary.yaml
@@ -1,0 +1,49 @@
+openapi: 3.0.1
+info:
+  version: 1.0.0
+paths:
+  /binary-inline:
+    post:
+      x-jvm-package: binary
+      operationId: postBinaryInline
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              required:
+                - file
+              properties:
+                file:
+                  type: string
+                  format: binary
+                optionalFile:
+                  type: string
+                  format: binary
+      responses:
+        200: {}
+  /binary-ref:
+    post:
+      x-jvm-package: binary
+      operationId: postBinaryRef
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/Files"
+      responses:
+        200: {}
+components:
+  schemas:
+    Files:
+      type: object
+      required:
+        - file
+      properties:
+        file:
+          type: string
+          format: binary
+        optionalFile:
+          type: string
+          format: binary


### PR DESCRIPTION
This makes OpenAPI v3 binary support work for the case where you have a request body that uses a `$ref` to reference a defined schema.

This also removes the warning logging for `type: string`, `format: binary`; not sure why that was there in the first place since it's a perfectly valid combination, and, in OpenAPI v3, is the only correct way to declare stream of bytes (since they removed `type: file`).

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
