### PR TITLE
Use InputStream instead of File for file/binary types in Dropwizard

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
@@ -120,7 +120,7 @@ object AsyncHttpClientClientGenerator {
       if (param.isFile) {
         new NodeList[Expression](
           new ObjectCreationExpr(null,
-                                 FILE_PART_TYPE,
+                                 INPUT_STREAM_PART_TYPE,
                                  new NodeList(
                                    new StringLiteralExpr(param.argName.value),
                                    new NameExpr(name)
@@ -163,7 +163,7 @@ object AsyncHttpClientClientGenerator {
         new ExpressionStmt(
           wrapSetBody(
             new ObjectCreationExpr(null,
-                                   FILE_PART_TYPE,
+                                   INPUT_STREAM_PART_TYPE,
                                    new NodeList(
                                      new StringLiteralExpr(param.argName.value),
                                      new NameExpr(param.paramName.asString)
@@ -860,7 +860,6 @@ object AsyncHttpClientClientGenerator {
             "org.asynchttpclient.Request",
             "org.asynchttpclient.RequestBuilder",
             "org.asynchttpclient.Response",
-            "org.asynchttpclient.request.body.multipart.FilePart",
             "org.asynchttpclient.request.body.multipart.StringPart"
           ).map(safeParseRawImport) ++ List(
             "java.util.Objects.requireNonNull"
@@ -986,7 +985,8 @@ object AsyncHttpClientClientGenerator {
           (ahcSupportImports, ahcSupportClass) = ahcSupport
           jacksonSupport <- generateJacksonSupportClass()
           (jacksonSupportImports, jacksonSupportClass) = jacksonSupport
-          shower <- SerializationHelpers.showerSupportDef
+          inputStreamPart <- inputStreamPartDef
+          shower          <- SerializationHelpers.showerSupportDef
         } yield {
           exceptionClasses.map({
             case (imports, cls) =>
@@ -994,6 +994,7 @@ object AsyncHttpClientClientGenerator {
           }) ++ List(
             SupportDefinition[JavaLanguage](new Name(ahcSupportClass.getNameAsString), ahcSupportImports, ahcSupportClass),
             SupportDefinition[JavaLanguage](new Name(jacksonSupportClass.getNameAsString), jacksonSupportImports, jacksonSupportClass),
+            inputStreamPart,
             shower
           )
         }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientHelpers.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientHelpers.scala
@@ -2,6 +2,9 @@ package com.twilio.guardrail.generators.Java
 
 import com.github.javaparser.JavaParser
 import com.github.javaparser.ast.`type`.ClassOrInterfaceType
+import com.twilio.guardrail.{ SupportDefinition, Target }
+import com.twilio.guardrail.languages.JavaLanguage
+import com.twilio.guardrail.generators.syntax.Java.loadSupportDefinitionFromString
 
 object AsyncHttpClientHelpers {
   val DEFAULT_ASYNC_HTTP_CLIENT_CONFIG_BUILDER_TYPE: ClassOrInterfaceType = JavaParser.parseClassOrInterfaceType("DefaultAsyncHttpClientConfig.Builder")
@@ -12,5 +15,97 @@ object AsyncHttpClientHelpers {
   val REQUEST_TYPE: ClassOrInterfaceType                                  = JavaParser.parseClassOrInterfaceType("Request")
   val RESPONSE_TYPE: ClassOrInterfaceType                                 = JavaParser.parseClassOrInterfaceType("Response")
   val FILE_PART_TYPE: ClassOrInterfaceType                                = JavaParser.parseClassOrInterfaceType("FilePart")
+  val INPUT_STREAM_PART_TYPE: ClassOrInterfaceType                        = JavaParser.parseClassOrInterfaceType("InputStreamPart")
   val STRING_PART_TYPE: ClassOrInterfaceType                              = JavaParser.parseClassOrInterfaceType("StringPart")
+
+  def inputStreamPartDef: Target[SupportDefinition[JavaLanguage]] = loadSupportDefinitionFromString(
+    "InputStreamPart",
+    """
+      import java.io.ByteArrayOutputStream;
+      import java.io.FileInputStream;
+      import java.io.IOException;
+      import java.io.InputStream;
+      import java.nio.charset.Charset;
+      import java.util.Arrays;
+      import org.asynchttpclient.request.body.multipart.ByteArrayPart;
+
+      /**
+       * An AsyncHttpClient multipart part that takes an input stream.
+       *
+       * Unfortunately, AHC doesn't let us register custom part types, so we have
+       * to base this on ByteArrayPart, which means we don't actually stream the
+       * part; it has to be completely buffered into memory before sending.
+       *
+       * Unfortunately, this also means that the constructor can block the calling
+       * thread if the passed InputStream can block on read.
+       */
+      public class InputStreamPart extends ByteArrayPart {
+          private static final int BUFFER_SIZE = 1024 * 1024;
+          private static final int BUFFER_SIZE_MAX = BUFFER_SIZE * 50;
+
+          private static byte[] streamToBytes(final InputStream stream) {
+              try {
+                  if (stream instanceof FileInputStream) {
+                      final long length = ((FileInputStream) stream).getChannel().size();
+                      if (length > 0 && length <= Integer.MAX_VALUE) {
+                          final byte[] buf = new byte[(int) length];
+                          final int actualLength = stream.read(buf);
+                          if (actualLength != length) {
+                              return Arrays.copyOf(buf, actualLength);
+                          } else {
+                              return buf;
+                          }
+                      }
+                  }
+
+                  final ByteArrayOutputStream accum = new ByteArrayOutputStream();
+
+                  final int bufferSize;
+                  if (stream.available() > BUFFER_SIZE) {
+                      bufferSize = Math.min(BUFFER_SIZE_MAX, stream.available());
+                  } else {
+                      bufferSize = BUFFER_SIZE;
+                  }
+                  final byte[] buf = new byte[bufferSize];
+
+                  while (true) {
+                      final int read = stream.read(buf);
+                      if (read == -1) {
+                          break;
+                      }
+                      accum.write(buf, 0, read);
+                  }
+
+                  return accum.toByteArray();
+              } catch (final IOException e) {
+                  throw new IllegalArgumentException("Unable to read from input stream: " + e.getMessage(), e);
+              }
+          }
+
+          public InputStreamPart(final String name, final InputStream stream) {
+              super(name, streamToBytes(stream));
+          }
+
+          public InputStreamPart(final String name, final InputStream stream, final String contentType) {
+              super(name, streamToBytes(stream), contentType);
+          }
+
+          public InputStreamPart(final String name, final InputStream stream, final String contentType, final Charset charset) {
+              super(name, streamToBytes(stream), contentType, charset);
+          }
+
+          public InputStreamPart(final String name, final InputStream stream, final String contentType, final Charset charset, final String fileName) {
+              super(name, streamToBytes(stream), contentType, charset, fileName);
+          }
+
+          public InputStreamPart(final String name, final InputStream stream, final String contentType, final Charset charset, final String fileName, final String contentId) {
+              super(name, streamToBytes(stream), contentType, charset, fileName, contentId);
+          }
+
+          public InputStreamPart(final String name, final InputStream stream, final String contentType, final Charset charset, final String fileName, final String contentId, final String transferEncoding) {
+              super(name, streamToBytes(stream), contentType, charset, fileName, contentId, transferEncoding);
+          }
+      }
+     """
+  )
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardGenerator.scala
@@ -10,7 +10,7 @@ import com.twilio.guardrail.terms.framework._
 object DropwizardGenerator {
   object FrameworkInterp extends (FrameworkTerm[JavaLanguage, ?] ~> Target) {
     def apply[T](term: FrameworkTerm[JavaLanguage, T]): Target[T] = term match {
-      case FileType(format)   => safeParseType(format.getOrElse("java.io.File"))
+      case FileType(format)   => safeParseType(format.getOrElse("java.io.InputStream"))
       case ObjectType(format) => safeParseType("com.fasterxml.jackson.databind.JsonNode")
 
       case GetFrameworkImports(tracing) =>


### PR DESCRIPTION
DW natively supports `InputStream`, but I had to write a shim for AsyncHttpClient.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
