### PR TITLE
Use NonEmptyList/NonEmptyMap for SecurityRequirements

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -58,7 +58,7 @@ object Common {
       basePath = swagger.basePath()
 
       paths                      = swagger.getPathsOpt()
-      globalSecurityRequirements = Option(swagger.getSecurity).map(SecurityRequirements(_, SecurityOptional(swagger), SecurityRequirements.Global))
+      globalSecurityRequirements = Option(swagger.getSecurity).flatMap(SecurityRequirements(_, SecurityOptional(swagger), SecurityRequirements.Global))
       routes           <- extractOperations(paths, globalSecurityRequirements)
       prefixes         <- vendorPrefixes()
       securitySchemes  <- SwaggerUtil.extractSecuritySchemes(swagger, prefixes)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
@@ -42,7 +42,7 @@ object ServerGenerator {
 
     for {
       prefixes <- vendorPrefixes()
-      globalSecurityRequirements = Option(swagger.getSecurity).map(SecurityRequirements(_, SecurityOptional(swagger), SecurityRequirements.Global))
+      globalSecurityRequirements = Option(swagger.getSecurity).flatMap(SecurityRequirements(_, SecurityOptional(swagger), SecurityRequirements.Global))
       routes <- extractOperations(paths, globalSecurityRequirements)
       classNamedRoutes <- routes
         .traverse(route => getClassName(route.operation, prefixes).map(_ -> route))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/SwaggerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/SwaggerGenerator.scala
@@ -38,7 +38,7 @@ object SwaggerGenerator {
                 operationMap.asScala.toList.map {
                   case (httpMethod, operation) =>
                     val securityRequirements = Option(operation.getSecurity)
-                      .map(SecurityRequirements(_, SecurityOptional(operation), SecurityRequirements.Local))
+                      .flatMap(SecurityRequirements(_, SecurityOptional(operation), SecurityRequirements.Local))
                       .orElse(globalSecurityRequirements)
                     RouteMeta(pathStr, httpMethod, operation, securityRequirements)
                 }


### PR DESCRIPTION
We give an `Option[SecurityRequirements]` to terms that might need to do stuff with security.  The `SecurityRequirements` case class contains a list of requirements.  If that list is empty, there's no point in having ` SecurityRequirements` instance at all, so we guarantee that there will be at least one item in the list, and also guarantee that the item in the list is a non-empty map, since it's pointless for it to be empty.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
