### PR TITLE
Add OpenApi v3 components/requestBodies ref support

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -59,7 +59,8 @@ object Common {
 
       paths                      = swagger.getPathsOpt()
       globalSecurityRequirements = Option(swagger.getSecurity).flatMap(SecurityRequirements(_, SecurityOptional(swagger), SecurityRequirements.Global))
-      routes           <- extractOperations(paths, globalSecurityRequirements)
+      requestBodies    <- extractCommonRequestBodies(Option(swagger.getComponents))
+      routes           <- extractOperations(paths, requestBodies, globalSecurityRequirements)
       prefixes         <- vendorPrefixes()
       securitySchemes  <- SwaggerUtil.extractSecuritySchemes(swagger, prefixes)
       classNamedRoutes <- routes.traverse(route => getClassName(route.operation, prefixes).map(_ -> route))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -80,7 +80,7 @@ object Common {
         case CodegenTarget.Server =>
           for {
             serverMeta <- ServerGenerator
-              .fromSwagger[L, F](context, swagger, frameworkImports)(protocolElems, securitySchemes)
+              .fromSwagger[L, F](context, swagger, frameworkImports)(groupedRoutes)(protocolElems, securitySchemes)
             Servers(servers, supportDefinitions) = serverMeta
           } yield CodegenDefinitions[L](List.empty, servers, supportDefinitions)
         case CodegenTarget.Models =>

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
@@ -4,6 +4,7 @@ import cats.data.NonEmptyList
 import io.swagger.v3.oas.models._
 import io.swagger.v3.oas.models.PathItem._
 import io.swagger.v3.oas.models.media._
+import io.swagger.v3.oas.models.parameters.RequestBody
 import io.swagger.v3.oas.models.responses._
 import io.swagger.v3.oas.models.security.{ SecurityScheme => SwSecurityScheme }
 import cats.{ FlatMap, Foldable }
@@ -429,6 +430,30 @@ object SwaggerUtil {
       })
       .map(_.toMap)
   }
+
+  def copyOperation(operation: Operation): Operation =
+    new Operation()
+      .tags(operation.getTags)
+      .summary(operation.getSummary)
+      .description(operation.getDescription)
+      .externalDocs(operation.getExternalDocs)
+      .operationId(operation.getOperationId)
+      .parameters(operation.getParameters)
+      .requestBody(operation.getRequestBody)
+      .responses(operation.getResponses)
+      .callbacks(operation.getCallbacks)
+      .deprecated(operation.getDeprecated)
+      .security(operation.getSecurity)
+      .servers(operation.getServers)
+      .extensions(operation.getExtensions)
+
+  def copyRequestBody(requestBody: RequestBody): RequestBody =
+    new RequestBody()
+      .description(requestBody.getDescription)
+      .content(requestBody.getContent)
+      .required(requestBody.getRequired)
+      .$ref(requestBody.get$ref())
+      .extensions(requestBody.getExtensions)
 
   object paths {
     import atto._, Atto._

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
@@ -8,7 +8,7 @@ import com.twilio.guardrail.generators.{ ScalaParameter, ScalaParameters }
 import com.twilio.guardrail.languages.LA
 import com.twilio.guardrail.terms.SecurityRequirements.SecurityScopes
 import com.twilio.guardrail.terms.framework.FrameworkTerms
-import io.swagger.v3.oas.models.{ Operation, PathItem }
+import io.swagger.v3.oas.models.{ Components, Operation, PathItem }
 import io.swagger.v3.oas.models.PathItem.HttpMethod
 import io.swagger.v3.oas.models.media.{ ArraySchema, MediaType, Schema }
 import io.swagger.v3.oas.models.parameters.{ Parameter, RequestBody }
@@ -205,7 +205,10 @@ case class OpenIdConnectSecurityScheme[L <: LA](url: URI, tpe: Option[L#Type])  
 case class OAuth2SecurityScheme[L <: LA](flows: OAuthFlows, tpe: Option[L#Type])                     extends SecurityScheme[L]
 
 sealed trait SwaggerTerm[L <: LA, T]
-case class ExtractOperations[L <: LA](paths: List[(String, PathItem)], globalSecurityRequirements: Option[SecurityRequirements])
+case class ExtractCommonRequestBodies[L <: LA](components: Option[Components]) extends SwaggerTerm[L, Map[String, RequestBody]]
+case class ExtractOperations[L <: LA](paths: List[(String, PathItem)],
+                                      commonRequestBodies: Map[String, RequestBody],
+                                      globalSecurityRequirements: Option[SecurityRequirements])
     extends SwaggerTerm[L, List[RouteMeta]]
 case class ExtractApiKeySecurityScheme[L <: LA](schemeName: String, securityScheme: SwSecurityScheme, tpe: Option[L#Type])
     extends SwaggerTerm[L, ApiKeySecurityScheme[L]]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerms.scala
@@ -7,13 +7,18 @@ import cats.implicits._
 import com.twilio.guardrail.languages.LA
 import io.swagger.v3.oas.models._
 import io.swagger.v3.oas.models.media.{ ArraySchema, Schema }
-import io.swagger.v3.oas.models.parameters.Parameter
+import io.swagger.v3.oas.models.parameters.{ Parameter, RequestBody }
 import io.swagger.v3.oas.models.responses.ApiResponse
 import io.swagger.v3.oas.models.security.{ SecurityScheme => SwSecurityScheme }
 
 class SwaggerTerms[L <: LA, F[_]](implicit I: InjectK[SwaggerTerm[L, ?], F]) {
-  def extractOperations(paths: List[(String, PathItem)], globalSecurityRequirements: Option[SecurityRequirements]): Free[F, List[RouteMeta]] =
-    Free.inject[SwaggerTerm[L, ?], F](ExtractOperations(paths, globalSecurityRequirements))
+  def extractCommonRequestBodies(components: Option[Components]): Free[F, Map[String, RequestBody]] =
+    Free.inject[SwaggerTerm[L, ?], F](ExtractCommonRequestBodies(components))
+
+  def extractOperations(paths: List[(String, PathItem)],
+                        commonRequestBodies: Map[String, RequestBody],
+                        globalSecurityRequirements: Option[SecurityRequirements]): Free[F, List[RouteMeta]] =
+    Free.inject[SwaggerTerm[L, ?], F](ExtractOperations(paths, commonRequestBodies, globalSecurityRequirements))
 
   def extractApiKeySecurityScheme(schemeName: String, securityScheme: SwSecurityScheme, tpe: Option[L#Type]): Free[F, ApiKeySecurityScheme[L]] =
     Free.inject[SwaggerTerm[L, ?], F](ExtractApiKeySecurityScheme(schemeName, securityScheme, tpe))

--- a/modules/codegen/src/test/scala/tests/core/RequestBodiesTest.scala
+++ b/modules/codegen/src/test/scala/tests/core/RequestBodiesTest.scala
@@ -1,0 +1,96 @@
+package tests.core
+
+import com.github.javaparser.ast.`type`.PrimitiveType
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration
+import com.twilio.guardrail.generators.Java.Dropwizard
+import com.twilio.guardrail.generators.syntax.Java._
+import com.twilio.guardrail.{Clients, Context}
+import org.scalatest.{FreeSpec, Matchers}
+import scala.collection.JavaConverters._
+import support.SwaggerSpecRunner
+
+class RequestBodiesTest extends FreeSpec with Matchers with SwaggerSpecRunner {
+  val openapi: String =
+    """
+      |openapi: 3.0.2
+      |info:
+      |  version: 1.0.0
+      |paths:
+      |  /foo:
+      |    post:
+      |      x-jvm-package: requestBodies
+      |      operationId: foo
+      |      requestBody:
+      |        $ref: "#/components/requestBodies/SomeRequestBodyForm"
+      |      responses:
+      |        200: {}
+      |  /bar:
+      |    post:
+      |      x-jvm-package: requestBodies
+      |      operationId: bar
+      |      requestBody:
+      |        $ref: "#/components/requestBodies/SomeRequestBodyWithRef"
+      |      responses:
+      |        200: {}
+      |components:
+      |  schemas:
+      |    SomeSchema:
+      |      type: object
+      |      required:
+      |        - a
+      |      properties:
+      |        a:
+      |          type: string
+      |        b:
+      |          type: boolean
+      |  requestBodies:
+      |    SomeRequestBodyForm:
+      |      required: true
+      |      content:
+      |        application/x-www-form-urlencoded:
+      |          schema:
+      |            required:
+      |              - d
+      |            properties:
+      |              c:
+      |                type: integer
+      |                format: int64
+      |              d:
+      |                type: number
+      |                format: double
+      |    SomeRequestBodyWithRef:
+      |      required: true
+      |      content:
+      |        application/json:
+      |          schema:
+      |            $ref: "#/components/schemas/SomeSchema"
+    """.stripMargin
+
+  "References to requestBodies should resolve and generate the proper args/methods" in {
+    val (_, Clients(client :: _, _), _) =
+      runSwaggerSpec(openapi)(Context.empty, Dropwizard)
+
+    val cls = client.client.head.getOrElse(fail("Client does not contain a ClassDefinition"))
+
+    val fooMethod = cls.getMethodsByName("foo").get(0)
+    fooMethod.getParameter(0).getType shouldBe PrimitiveType.doubleType
+
+    val fooCallBuilder = cls.getMembers.toList.collectFirst({
+      case cbClass: ClassOrInterfaceDeclaration if cbClass.getNameAsString == "FooCallBuilder" => cbClass
+    }).get
+    val withCMethods = fooCallBuilder.getMethodsByName("withC").asScala
+    withCMethods.length shouldBe 2
+    withCMethods.foreach({
+      case md if md.getParameter(0).getType.isPrimitiveType =>
+        md.getParameter(0).getType shouldBe PrimitiveType.longType
+      case md =>
+        val paramType = md.getParameter(0).getType.asClassOrInterfaceType
+        paramType.getNameAsString shouldBe "Optional"
+        paramType.getTypeArguments.get.get(0).asClassOrInterfaceType.getNameAsString shouldBe "Long"
+    })
+
+    val barMethod = cls.getMethodsByName("bar").get(0)
+    val barMethodParamType = barMethod.getParameter(0).getType.asClassOrInterfaceType
+    barMethodParamType.getNameAsString shouldBe "SomeSchema"
+  }
+}


### PR DESCRIPTION
The `resolve` option to the parser (which we use) appears to auto-resolve references to parameters, headers, and responses (at least), but for some reason doesn't do the same for requestBodies.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
