### PR TITLE
additionalProperties $ref fixes

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
@@ -140,10 +140,11 @@ object SwaggerUtil {
     } yield CustomTypeName(v, prefixes)
 
   sealed class ModelMetaTypePartiallyApplied[L <: LA, F[_]](val dummy: Boolean = true) {
-    def apply[T <: Schema[_]](model: T)(implicit Sc: ScalaTerms[L, F], Sw: SwaggerTerms[L, F], F: FrameworkTerms[L, F]): Free[F, ResolvedType[L]] =
+    def apply[T <: Schema[_]](model: T)(implicit Sc: ScalaTerms[L, F], Sw: SwaggerTerms[L, F], Fw: FrameworkTerms[L, F]): Free[F, ResolvedType[L]] =
       Sw.log.function("modelMetaType") {
         import Sc._
         import Sw._
+        import Fw._
         log.debug(s"model:\n${log.schemaToString(model)}") >> (model match {
           case ref: Schema[_] if Option(ref.get$ref).isDefined =>
             for {
@@ -161,6 +162,20 @@ object SwaggerUtil {
                 case x: Deferred[L]      => embedArray(x)
                 case x: DeferredArray[L] => embedArray(x)
                 case x: DeferredMap[L]   => embedArray(x)
+              }
+            } yield res
+          case map: MapSchema =>
+            for {
+              rec <- Option(map.getAdditionalProperties)
+                .fold[Free[F, ResolvedType[L]]](objectType(None).map(Resolved[L](_, None, None)))({
+                  case _: java.lang.Boolean => objectType(None).map(Resolved[L](_, None, None))
+                  case s: Schema[_]         => propMeta[L, F](s)
+                })
+              res <- rec match {
+                case Resolved(inner, dep, _) => liftMapType(inner).map(Resolved[L](_, dep, None))
+                case x: DeferredMap[L]       => embedMap(x)
+                case x: DeferredArray[L]     => embedMap(x)
+                case x: Deferred[L]          => embedMap(x)
               }
             } yield res
           case impl: Schema[_] =>

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/CirceProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/CirceProtocolGenerator.scala
@@ -154,9 +154,13 @@ object CirceProtocolGenerator {
               }
               (tpe, Option.empty)
             case SwaggerUtil.DeferredArray(tpeName) =>
-              (t"IndexedSeq[${Type.Name(tpeName)}]", Option.empty)
+              val concreteType = lookupTypeName(tpeName, concreteTypes)(identity)
+              val innerType    = concreteType.getOrElse(Type.Name(tpeName))
+              (t"IndexedSeq[$innerType]", Option.empty)
             case SwaggerUtil.DeferredMap(tpeName) =>
-              (t"Map[String, ${Type.Name(tpeName)}]", Option.empty)
+              val concreteType = lookupTypeName(tpeName, concreteTypes)(identity)
+              val innerType    = concreteType.getOrElse(Type.Name(tpeName))
+              (t"Map[String, $innerType]", Option.empty)
           }
 
           (finalDeclType, finalDefaultValue) = Option(isRequired)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
@@ -748,10 +748,13 @@ object JacksonGenerator {
             case SwaggerUtil.Deferred(tpeName) =>
               Target.fromOption(lookupTypeName(tpeName, concreteTypes)(Target.pure(_)), s"Unresolved reference ${tpeName}").flatten
             case SwaggerUtil.DeferredArray(tpeName) =>
-              Target.fromOption(lookupTypeName(tpeName, concreteTypes)(tpe => safeParseType(s"Array<${tpe}>")), s"Unresolved reference ${tpeName}").flatten
+              Target
+                .fromOption(lookupTypeName(tpeName, concreteTypes)(tpe => safeParseType(s"java.util.List<${tpe}>")), s"Unresolved reference ${tpeName}")
+                .flatten
             case SwaggerUtil.DeferredMap(tpeName) =>
               Target
-                .fromOption(lookupTypeName(tpeName, concreteTypes)(tpe => safeParseType(s"Array<Map<String, ${tpe}>>")), s"Unresolved reference ${tpeName}")
+                .fromOption(lookupTypeName(tpeName, concreteTypes)(tpe => safeParseType(s"java.util.List<java.util.Map<String, ${tpe}>>")),
+                            s"Unresolved reference ${tpeName}")
                 .flatten
           }
         } yield result

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
@@ -693,12 +693,14 @@ object JacksonGenerator {
               case SwaggerUtil.DeferredArray(tpeName) =>
                 for {
                   fqListType <- safeParseClassOrInterfaceType("java.util.List")
-                  innerType  <- safeParseType(tpeName)
+                  concreteType = lookupTypeName(tpeName, concreteTypes)(Target.pure)
+                  innerType <- concreteType.getOrElse(safeParseType(tpeName))
                 } yield (fqListType.setTypeArguments(innerType), Option.empty)
               case SwaggerUtil.DeferredMap(tpeName) =>
                 for {
                   fqMapType <- safeParseClassOrInterfaceType("java.util.Map")
-                  innerType <- safeParseType(tpeName)
+                  concreteType = lookupTypeName(tpeName, concreteTypes)(Target.pure)
+                  innerType <- concreteType.getOrElse(safeParseType(tpeName))
                 } yield (fqMapType.setTypeArguments(STRING_TYPE, innerType), Option.empty)
             }
             (tpe, classDep) = tpeClassDep

--- a/modules/sample/src/main/resources/additional-properties.yaml
+++ b/modules/sample/src/main/resources/additional-properties.yaml
@@ -37,3 +37,12 @@ components:
       properties:
         stuff:
           $ref: "#/components/schemas/BarMap"
+    BarMapOfMap:
+      type: object
+      required:
+        - stuff
+      properties:
+        stuff:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/BarMap"

--- a/modules/sample/src/main/resources/additional-properties.yaml
+++ b/modules/sample/src/main/resources/additional-properties.yaml
@@ -25,4 +25,15 @@ components:
           type: object
           additionalProperties:
             $ref: "#/components/schemas/FooMapValues"
-
+    BarMap:
+      type: object
+      additionalProperties:
+        type: integer
+        format: int64
+    Bar:
+      type: object
+      required:
+        - stuff
+      properties:
+        stuff:
+          $ref: "#/components/schemas/BarMap"


### PR DESCRIPTION
Fixes properties that are a reference to a map type, or properties that are maps with the value as a reference to another map type.

Previously the type name would just be inlined, but that would fail to compile since it would reference a type that wasn't emitted at all.

Also fixes a weird reference in JacksonGenerator to a java type called `Array` that doesn't exist; assuming that was copypasta from the circe generator.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
