### PR TITLE
Deduplicate identical parameters across different contentTypes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,6 +54,7 @@ val exampleCases: List[(java.io.File, String, Boolean, List[String])] = List(
   (sampleResource("issues/issue222.yaml"), "issues.issue222", false, List.empty),
   (sampleResource("issues/issue249.yaml"), "issues.issue249", false, List.empty),
   (sampleResource("issues/issue264.yaml"), "issues.issue264", false, List.empty),
+  (sampleResource("issues/issue325.yaml"), "issues.issue325", false, List.empty),
   (sampleResource("multipart-form-data.yaml"), "multipartFormData", false, List.empty),
   (sampleResource("petstore.json"), "examples", false, List("--import", "support.PositiveLong")),
   (sampleResource("plain.json"), "tests.dtos", false, List.empty),

--- a/modules/sample-akkaHttp/src/test/scala/core/issues/Issue325.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/issues/Issue325.scala
@@ -1,0 +1,98 @@
+package core.issues
+
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.server._
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.http.scaladsl.unmarshalling.Unmarshaller
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.SpanSugar._
+import org.scalatest.{ EitherValues, FunSuite, Matchers }
+import scala.concurrent.{ ExecutionContext, Future }
+import io.circe._
+import _root_.jawn.IncompleteParseException
+import cats.implicits._
+import cats.data.OptionT
+
+class Issue325Suite extends FunSuite with Matchers with EitherValues with ScalaFutures with ScalatestRouteTest {
+  override implicit val patienceConfig = PatienceConfig(10 seconds, 1 second)
+
+  test("Ensure that servers can be constructed") {
+    import issues.issue325.server.akkaHttp.{ Handler, Resource }
+    import issues.issue325.server.akkaHttp.definitions._
+    val route = Resource.routes(new Handler {
+      override def testMultipleContentTypes(
+          respond: Resource.testMultipleContentTypesResponse.type
+      )(foo: String, bar: Int, baz: Option[Int]): Future[Resource.testMultipleContentTypesResponse] =
+        Future.successful(
+          if (foo == foo && bar == 5 && baz.forall(_ == 10)) {
+            respond.OK
+          } else {
+            respond.InternalServerError
+          }
+        )
+    })
+
+    Post("/test") ~> route ~> check {
+      rejection match {
+        case MissingFormFieldRejection("foo") => ()
+      }
+    }
+
+    Post("/test")
+      .withEntity(ContentType.apply(MediaTypes.`application/x-www-form-urlencoded`, () => HttpCharsets.`UTF-8`), "".getBytes) ~> route ~> check {
+      rejection match {
+        case MissingFormFieldRejection("foo") => ()
+      }
+    }
+
+    Post("/test")
+      .withEntity(ContentType.apply(MediaTypes.`application/x-www-form-urlencoded`, () => HttpCharsets.`UTF-8`), "foo=foo&bar=5".getBytes) ~> route ~> check {
+      status should equal(StatusCodes.OK)
+    }
+  }
+
+  test("Ensure that clients supply the correct arguments encoded in the expected way") {
+    import akka.stream.scaladsl.Sink
+    import issues.issue325.client.akkaHttp.{ Client, TestMultipleContentTypesResponse }
+    import issues.issue325.client.akkaHttp.definitions._
+
+    def expectResponse(p: (String, List[Multipart.FormData.BodyPart.Strict]) => Boolean)(implicit ec: ExecutionContext): HttpRequest => Future[HttpResponse] = {
+      req =>
+        import scala.concurrent.duration._
+        for {
+          sreq     <- req.toStrict(Duration(5, SECONDS))
+          chunks   <- Unmarshaller.multipartFormDataUnmarshaller.apply(sreq.entity)
+          elements <- chunks.parts.runFold(List.empty[Multipart.FormData.BodyPart])(_ :+ _)
+          res <- elements.groupBy(_.name).toList.traverse {
+            case (name, chunks) =>
+              for {
+                chunks <- chunks.traverse[Future, Multipart.FormData.BodyPart.Strict](_.toStrict(Duration(5, SECONDS)))
+              } yield p(name, chunks)
+          }
+        } yield {
+          if (res.forall(_ == true)) {
+            HttpResponse(200)
+          } else {
+            HttpResponse(500)
+          }
+        }
+    }
+
+    Client
+      .httpClient(
+        expectResponse({
+          case ("foo", chunks) if chunks.length == 1 && chunks.forall(_.entity.data.utf8String == "foo") => true
+          case ("bar", chunks) if chunks.length == 1 && chunks.forall(_.entity.data.utf8String == "5")   => true
+          case _                                                                                         => false
+        }),
+        "http://localhost:80"
+      )
+      .testMultipleContentTypes("foo", 5)
+      .value
+      .futureValue match {
+      case Right(TestMultipleContentTypesResponse.OK) => ()
+      case ex                                         => failTest(s"Unknown: ${ex}")
+    }
+  }
+}

--- a/modules/sample/src/main/resources/issues/issue325.yaml
+++ b/modules/sample/src/main/resources/issues/issue325.yaml
@@ -1,0 +1,31 @@
+swagger: "2.0"
+info:
+  title: "Issue 325 (Swagger)"
+  version: 1.0.0
+host: localhost:1234
+schemes:
+  - http
+paths:
+  /test:
+    post:
+      operationId: testMultipleContentTypes
+      consumes:
+        - multipart/form-data
+        - application/x-www-form-urlencoded
+      parameters:
+      - name: foo
+        in: formData
+        required: true
+        type: string
+      - name: bar
+        in: formData
+        required: true
+        type: integer
+        format: int32
+      - name: baz
+        in: formData
+        type: integer
+        format: int32
+      responses:
+        '200': {}
+        '500': {}

--- a/modules/sample/src/main/resources/petstore.json
+++ b/modules/sample/src/main/resources/petstore.json
@@ -336,7 +336,8 @@
         "description": "",
         "operationId": "updatePetWithForm",
         "consumes": [
-          "application/x-www-form-urlencoded"
+          "application/x-www-form-urlencoded",
+          "multipart/form-data"
         ],
         "produces": [
           "application/xml",


### PR DESCRIPTION
Resolves #324 

When multiple content types are specified in `consumes`, deduplicate the parameters and mark ones that don't explicitly occur across all media types as not required.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
