### PR TITLE
Akka form data consumption

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpGenerator.scala
@@ -20,7 +20,7 @@ object AkkaHttpGenerator {
             q"import akka.http.scaladsl.unmarshalling.{Unmarshal, Unmarshaller, FromEntityUnmarshaller, FromRequestUnmarshaller, FromStringUnmarshaller}",
             q"import akka.http.scaladsl.marshalling.{Marshal, Marshaller, Marshalling, ToEntityMarshaller, ToResponseMarshaller}",
             q"import akka.http.scaladsl.server.Directives._",
-            q"import akka.http.scaladsl.server.{Directive, Directive0, Directive1, ExceptionHandler, MalformedHeaderRejection, MissingFormFieldRejection, Rejection, Route}",
+            q"import akka.http.scaladsl.server.{Directive, Directive0, Directive1, ExceptionHandler, MalformedFormFieldRejection, MalformedHeaderRejection, MissingFormFieldRejection, Rejection, RejectionError, Route}",
             q"import akka.http.scaladsl.util.FastFuture",
             q"import akka.stream.{IOResult, Materializer}",
             q"import akka.stream.scaladsl.{FileIO, Keep, Sink, Source}",

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpGenerator.scala
@@ -20,7 +20,7 @@ object AkkaHttpGenerator {
             q"import akka.http.scaladsl.unmarshalling.{Unmarshal, Unmarshaller, FromEntityUnmarshaller, FromRequestUnmarshaller, FromStringUnmarshaller}",
             q"import akka.http.scaladsl.marshalling.{Marshal, Marshaller, Marshalling, ToEntityMarshaller, ToResponseMarshaller}",
             q"import akka.http.scaladsl.server.Directives._",
-            q"import akka.http.scaladsl.server.{Directive, Directive0, Directive1, ExceptionHandler, MalformedFormFieldRejection, MalformedHeaderRejection, MissingFormFieldRejection, Rejection, RejectionError, Route}",
+            q"import akka.http.scaladsl.server.{Directive, Directive0, Directive1, ExceptionHandler, MalformedFormFieldRejection, MalformedHeaderRejection, MissingFormFieldRejection, MalformedRequestContentRejection, Rejection, RejectionError, Route}",
             q"import akka.http.scaladsl.util.FastFuture",
             q"import akka.stream.{IOResult, Materializer}",
             q"import akka.stream.scaladsl.{FileIO, Keep, Sink, Source}",

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpGenerator.scala
@@ -148,9 +148,8 @@ object AkkaHttpGenerator {
               ev.apply(entity).map[Either[Throwable, U]](Right(_)).recover({ case t => Left(t) })
             }
 
-            def StaticUnmarshaller[T](value: T)(implicit mat: Materializer): Unmarshaller[Multipart.FormData.BodyPart, T] = Unmarshaller { _ => part =>
-              part.entity.discardBytes()
-              Future.successful[T](value)
+            def StaticUnmarshaller[T](value: T)(implicit mat: Materializer): Unmarshaller[Multipart.FormData.BodyPart, T] = Unmarshaller { implicit ec => part =>
+              part.entity.discardBytes().future.map(_ => value)
             }
 
             implicit def UnitUnmarshaller(implicit mat: Materializer): Unmarshaller[Multipart.FormData.BodyPart, Unit] = StaticUnmarshaller(())

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/Scala.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/Scala.scala
@@ -29,13 +29,13 @@ object Scala {
     }
   }
 
-  implicit class ExtendedUnzip[T1, T2, T3, T4, T5, T6, T7](xs: NonEmptyList[(T1, T2, T3, T4, T5, T6, T7)]) {
-    def unzip7: (List[T1], List[T2], List[T3], List[T4], List[T5], List[T6], List[T7]) =
+  implicit class ExtendedUnzip[T1, T2, T3, T4, T5, T6, T7, T8](xs: NonEmptyList[(T1, T2, T3, T4, T5, T6, T7, T8)]) {
+    def unzip8: (List[T1], List[T2], List[T3], List[T4], List[T5], List[T6], List[T7], List[T8]) =
       xs.foldLeft(
-        (List.empty[T1], List.empty[T2], List.empty[T3], List.empty[T4], List.empty[T5], List.empty[T6], List.empty[T7])
+        (List.empty[T1], List.empty[T2], List.empty[T3], List.empty[T4], List.empty[T5], List.empty[T6], List.empty[T7], List.empty[T8])
       ) {
-        case ((v1a, v2a, v3a, v4a, v5a, v6a, v7a), (v1, v2, v3, v4, v5, v6, v7)) =>
-          (v1a :+ v1, v2a :+ v2, v3a :+ v3, v4a :+ v4, v5a :+ v5, v6a :+ v6, v7a :+ v7)
+        case ((v1a, v2a, v3a, v4a, v5a, v6a, v7a, v8a), (v1, v2, v3, v4, v5, v6, v7, v8)) =>
+          (v1a :+ v1, v2a :+ v2, v3a :+ v3, v4a :+ v4, v5a :+ v5, v6a :+ v6, v7a :+ v7, v8a :+ v8)
       }
   }
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
@@ -147,7 +147,8 @@ case class RouteMeta(path: String, method: HttpMethod, operation: Operation, sec
     type HashCode            = Int
     type Count               = Int
     type ParameterCountState = (Count, Map[HashCode, Count])
-    val contentTypes = Option(requestBody.getContent()).toList.flatMap(_.keySet.asScala.toList)
+    val contentTypes: List[RouteMeta.ContentType] =
+      Option(requestBody.getContent()).toList.flatMap(_.keySet.asScala.toList).flatMap(RouteMeta.ContentType.unapply)
     val ((maxCount, instances), ps) = Option(requestBody.getContent())
       .fold(List.empty[MediaType])(x => Option(x.values()).toList.flatMap(_.asScala))
       .flatMap({ mt =>
@@ -175,7 +176,7 @@ case class RouteMeta(path: String, method: HttpMethod, operation: Operation, sec
             p.setRequired(isRequired)
             p.setExtensions(Option(schema.getExtensions).getOrElse(new java.util.HashMap[String, Object]()))
 
-            if (Option(schema.getType()).exists(_ == "file") && contentTypes.contains("application/x-www-form-urlencoded")) {
+            if (Option(schema.getType()).exists(_ == "file") && contentTypes.contains(RouteMeta.UrlencodedFormData)) {
               p.setRequired(false)
             }
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
@@ -147,6 +147,7 @@ case class RouteMeta(path: String, method: HttpMethod, operation: Operation, sec
     type HashCode            = Int
     type Count               = Int
     type ParameterCountState = (Count, Map[HashCode, Count])
+    val contentTypes = Option(requestBody.getContent()).toList.flatMap(_.keySet.asScala.toList)
     val ((maxCount, instances), ps) = Option(requestBody.getContent())
       .fold(List.empty[MediaType])(x => Option(x.values()).toList.flatMap(_.asScala))
       .flatMap({ mt =>
@@ -173,6 +174,11 @@ case class RouteMeta(path: String, method: HttpMethod, operation: Operation, sec
 
             p.setRequired(isRequired)
             p.setExtensions(Option(schema.getExtensions).getOrElse(new java.util.HashMap[String, Object]()))
+
+            if (Option(schema.getType()).exists(_ == "file") && contentTypes.contains("application/x-www-form-urlencoded")) {
+              p.setRequired(false)
+            }
+
             p
         }
       })

--- a/modules/codegen/src/test/scala/core/issues/Issue127.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue127.scala
@@ -88,59 +88,56 @@ class Issue127 extends FunSuite with Matchers with SwaggerSpecRunner {
                 case (v1, v2, v3, v4) =>
                   uploadFileParts.file((v1, v2, v3))
               })
-              extractExecutionContext.flatMap { implicit executionContext =>
-                extractMaterializer.flatMap { implicit mat =>
-                  val fileReferences = new AtomicReference(List.empty[File])
-                  (extractSettings.flatMap {
-                    settings => handleExceptions(ExceptionHandler({
-                      case EntityStreamSizeException(limit, contentLength) =>
-                        fileReferences.get().foreach(_.delete())
-                        val summary = contentLength match {
-                          case Some(cl) =>
-                            s"Request Content-Length of $$cl bytes exceeds the configured limit of $$limit bytes"
-                          case None =>
-                            s"Aggregated data length of request entity exceeds the configured limit of $$limit bytes"
-                        }
-                        val info = new ErrorInfo(summary, "Consider increasing the value of akka.http.server.parsing.max-content-length")
-                        val status = StatusCodes.RequestEntityTooLarge
-                        val msg = if (settings.verboseErrorMessages) info.formatPretty else info.summary
-                        complete(HttpResponse(status, entity = msg))
-                      case e: Throwable =>
-                        fileReferences.get().foreach(_.delete())
-                        throw e
-                    }))
-                  } & handleRejections { (rejections: scala.collection.immutable.Seq[Rejection]) =>
-                    fileReferences.get().foreach(_.delete())
-                    None
-                  } & mapResponse { resp =>
-                    fileReferences.get().foreach(_.delete())
-                    resp
-                  } & entity(as[Multipart.FormData])).flatMap { formData =>
-                    val collectedPartsF: Future[Either[Throwable, Tuple1[Option[(File, Option[String], ContentType)]]]] = for (results <- formData.parts.mapConcat {
-                      part => if (Set[String]("file").contains(part.name)) part :: Nil else {
-                        part.entity.discardBytes()
-                        Nil
-                      }
-                    }.mapAsync(1) {
-                      part => part.name match {
-                        case "file" =>
-                          SafeUnmarshaller(AccumulatingUnmarshaller(fileReferences, UnmarshalfilePart)(_.value._1)).apply(part)
-                        case _ =>
-                          SafeUnmarshaller(implicitly[Unmarshaller[Multipart.FormData.BodyPart, Unit]].map(uploadFileParts.IgnoredPart.apply(_))).apply(part)
-                      }
-                    }.toMat(Sink.seq[Either[Throwable, uploadFileParts.Part]])(Keep.right).run()) yield {
-                      results.toList.sequence.map { successes =>
-                        val fileO = successes.collectFirst({
-                          case uploadFileParts.file((v1, v2, v3)) =>
-                            (v1, v2, v3)
-                        })
-                        Tuple1(fileO)
-                      }
-                    }
-                    onSuccess(collectedPartsF)
+              val fileReferences = new AtomicReference(List.empty[File])
+              implicit val MultipartFormDataUnmarshaller: FromRequestUnmarshaller[Either[Throwable, Tuple1[Option[(File, Option[String], ContentType)]]]] = implicitly[FromRequestUnmarshaller[Multipart.FormData]].flatMap { implicit executionContext => implicit mat => formData =>
+                val collectedPartsF: Future[Either[Throwable, Tuple1[Option[(File, Option[String], ContentType)]]]] = for (results <- formData.parts.mapConcat {
+                  part => if (Set[String]("file").contains(part.name)) part :: Nil else {
+                    part.entity.discardBytes()
+                    Nil
+                  }
+                }.mapAsync(1) {
+                  part => part.name match {
+                    case "file" =>
+                      SafeUnmarshaller(AccumulatingUnmarshaller(fileReferences, UnmarshalfilePart)(_.value._1)).apply(part)
+                    case _ =>
+                      SafeUnmarshaller(implicitly[Unmarshaller[Multipart.FormData.BodyPart, Unit]].map(uploadFileParts.IgnoredPart.apply(_))).apply(part)
+                  }
+                }.toMat(Sink.seq[Either[Throwable, uploadFileParts.Part]])(Keep.right).run()) yield {
+                  results.toList.sequence.map { successes =>
+                    val fileO = successes.collectFirst({
+                      case uploadFileParts.file((v1, v2, v3)) =>
+                        (v1, v2, v3)
+                    })
+                    Tuple1(fileO)
                   }
                 }
-              }.flatMap(_.fold({
+                collectedPartsF
+              }
+              (handleExceptions(ExceptionHandler({
+                case e: Throwable =>
+                  fileReferences.get().foreach(_.delete())
+                  throw e
+              })) & extractSettings.flatMap {
+                settings => handleRejections { (rejections: scala.collection.immutable.Seq[Rejection]) =>
+                  fileReferences.get().foreach(_.delete())
+                  rejections.collectFirst({
+                    case MalformedRequestContentRejection(msg, EntityStreamSizeException(limit, contentLength)) =>
+                      val summary = contentLength match {
+                        case Some(cl) =>
+                          s"Request Content-Length of $$cl bytes exceeds the configured limit of $$limit bytes"
+                        case None =>
+                          s"Aggregated data length of request entity exceeds the configured limit of $$limit bytes"
+                      }
+                      val info = new ErrorInfo(summary, "Consider increasing the value of akka.http.server.parsing.max-content-length")
+                      val status = StatusCodes.RequestEntityTooLarge
+                      val msg = if (settings.verboseErrorMessages) info.formatPretty else info.summary
+                      complete(HttpResponse(status, entity = msg))
+                  })
+                }
+              } & mapResponse { resp =>
+                fileReferences.get().foreach(_.delete())
+                resp
+              } & entity(as(Unmarshaller.firstOf(MultipartFormDataUnmarshaller)))).flatMap(_.fold({
                 case RejectionError(rej) =>
                   reject(rej)
                 case t =>

--- a/modules/codegen/src/test/scala/core/issues/Issue127.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue127.scala
@@ -140,7 +140,12 @@ class Issue127 extends FunSuite with Matchers with SwaggerSpecRunner {
                     onSuccess(collectedPartsF)
                   }
                 }
-              }.flatMap(_.fold(t => throw t, {
+              }.flatMap(_.fold({
+                case RejectionError(rej) =>
+                  reject(rej)
+                case t =>
+                  throw t
+              }, {
                 case Tuple1(fileO) =>
                   val maybe: Either[Rejection, Tuple1[(File, Option[String], ContentType)]] = for (file <- fileO.toRight(MissingFormFieldRejection("file"))) yield {
                     Tuple1(file)

--- a/modules/codegen/src/test/scala/core/issues/Issue260.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue260.scala
@@ -84,8 +84,6 @@ class Issue260 extends FunSpec with Matchers with SwaggerSpecRunner {
 
       val hits = pattern.findAllIn(serverDefinition.toString()).length
 
-      println(serverDefinition.toString())
-
       hits shouldBe 1
     }
   }

--- a/modules/sample-akkaHttp/src/test/scala/core/issues/Issue325.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/issues/Issue325.scala
@@ -24,7 +24,7 @@ class Issue325Suite extends FunSuite with Matchers with EitherValues with ScalaF
     val route = Resource.routes(new Handler {
       override def testMultipleContentTypes(
           respond: Resource.testMultipleContentTypesResponse.type
-      )(foo: String, bar: Int, baz: Option[Int]): Future[Resource.testMultipleContentTypesResponse] =
+      )(foo: String, bar: Int, baz: Option[Int], file: Option[(java.io.File, Option[String], ContentType)]): Future[Resource.testMultipleContentTypesResponse] =
         Future.successful(
           if (foo == foo && bar == 5 && baz.forall(_ == 10)) {
             respond.OK
@@ -32,6 +32,8 @@ class Issue325Suite extends FunSuite with Matchers with EitherValues with ScalaF
             respond.InternalServerError
           }
         )
+      override def testMultipleContentTypesMapFileField(fieldName: String, fileName: Option[String], contentType: ContentType): java.io.File =
+        java.io.File.createTempFile("guardrail-issue-325", "dat")
       override def emptyConsumes(
           respond: Resource.emptyConsumesResponse.type
       )(foo: String): Future[Resource.emptyConsumesResponse] =

--- a/modules/sample-akkaHttp/src/test/scala/core/issues/Issue325.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/issues/Issue325.scala
@@ -5,6 +5,7 @@ import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.server._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.http.scaladsl.unmarshalling.Unmarshaller
+import akka.util.ByteString
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.SpanSugar._
 import org.scalatest.{ EitherValues, FunSuite, Matchers }
@@ -48,6 +49,14 @@ class Issue325Suite extends FunSuite with Matchers with EitherValues with ScalaF
 
     Post("/test")
       .withEntity(ContentType.apply(MediaTypes.`application/x-www-form-urlencoded`, () => HttpCharsets.`UTF-8`), "foo=foo&bar=5".getBytes) ~> route ~> check {
+      status should equal(StatusCodes.OK)
+    }
+
+    Post("/test")
+      .withEntity(Multipart.FormData(
+        Multipart.FormData.BodyPart.Strict("foo", HttpEntity.Strict(ContentType(MediaTypes.`multipart/form-data`, () => HttpCharsets.`UTF-8`), ByteString.fromArray("foo".getBytes))),
+        Multipart.FormData.BodyPart.Strict("bar", HttpEntity.Strict(ContentType(MediaTypes.`multipart/form-data`, () => HttpCharsets.`UTF-8`), ByteString.fromArray("5".getBytes)))
+      ).toEntity) ~> route ~> check {
       status should equal(StatusCodes.OK)
     }
   }

--- a/modules/sample-akkaHttp/src/test/scala/core/issues/Issue325.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/issues/Issue325.scala
@@ -33,7 +33,7 @@ class Issue325Suite extends FunSuite with Matchers with EitherValues with ScalaF
           }
         )
       override def emptyConsumes(
-        respond: Resource.emptyConsumesResponse.type
+          respond: Resource.emptyConsumesResponse.type
       )(foo: String): Future[Resource.emptyConsumesResponse] =
         Future.successful(respond.OK)
     })
@@ -57,10 +57,17 @@ class Issue325Suite extends FunSuite with Matchers with EitherValues with ScalaF
     }
 
     Post("/test")
-      .withEntity(Multipart.FormData(
-        Multipart.FormData.BodyPart.Strict("foo", HttpEntity.Strict(ContentType(MediaTypes.`multipart/form-data`, () => HttpCharsets.`UTF-8`), ByteString.fromArray("foo".getBytes))),
-        Multipart.FormData.BodyPart.Strict("bar", HttpEntity.Strict(ContentType(MediaTypes.`multipart/form-data`, () => HttpCharsets.`UTF-8`), ByteString.fromArray("5".getBytes)))
-      ).toEntity) ~> route ~> check {
+      .withEntity(
+        Multipart
+          .FormData(
+            Multipart.FormData.BodyPart.Strict("foo",
+                                               HttpEntity.Strict(ContentType(MediaTypes.`multipart/form-data`, () => HttpCharsets.`UTF-8`),
+                                                                 ByteString.fromArray("foo".getBytes))),
+            Multipart.FormData.BodyPart
+              .Strict("bar", HttpEntity.Strict(ContentType(MediaTypes.`multipart/form-data`, () => HttpCharsets.`UTF-8`), ByteString.fromArray("5".getBytes)))
+          )
+          .toEntity
+      ) ~> route ~> check {
       status should equal(StatusCodes.OK)
     }
 
@@ -74,9 +81,14 @@ class Issue325Suite extends FunSuite with Matchers with EitherValues with ScalaF
     }
 
     Put("/test")
-      .withEntity(Multipart.FormData(
-        Multipart.FormData.BodyPart.Strict("foo", HttpEntity.Strict(ContentType(MediaTypes.`multipart/form-data`, () => HttpCharsets.`UTF-8`), ByteString.fromArray("foo".getBytes)))
-      ).toEntity) ~> route ~> check {
+      .withEntity(
+        Multipart
+          .FormData(
+            Multipart.FormData.BodyPart
+              .Strict("foo", HttpEntity.Strict(ContentType(MediaTypes.`multipart/form-data`, () => HttpCharsets.`UTF-8`), ByteString.fromArray("foo".getBytes)))
+          )
+          .toEntity
+      ) ~> route ~> check {
       status should equal(StatusCodes.OK)
     }
   }

--- a/modules/sample/src/main/resources/issues/issue325.yaml
+++ b/modules/sample/src/main/resources/issues/issue325.yaml
@@ -29,3 +29,17 @@ paths:
       responses:
         '200': {}
         '500': {}
+    put:
+      operationId: emptyConsumes
+      consumes: []
+      description: >
+        Empty consumes with formData parameters should emit multipart with
+        no urlencoded handler
+      parameters:
+      - name: foo
+        in: formData
+        required: true
+        type: string
+      responses:
+        '200': {}
+        '500': {}

--- a/modules/sample/src/main/resources/issues/issue325.yaml
+++ b/modules/sample/src/main/resources/issues/issue325.yaml
@@ -26,6 +26,10 @@ paths:
         in: formData
         type: integer
         format: int32
+      - name: file
+        in: formData
+        type: file
+        required: true
       responses:
         '200': {}
         '500': {}


### PR DESCRIPTION
Resolves #312 

- Switches to `Unmarshaller`s for `formData` consumption to support both `application/x-www-form-urlencoded` _and_ `multipart/form-data`, depending on what's in `consumes`
- Relies heavily on parameter deduplication (#325)
- If any `consumes` are `application/x-www-form-urlencoded`, all `file` parameters are forced to be optional.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.