### PR TITLE
Allow models to be generated from CLI

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
@@ -71,6 +71,8 @@ case class CoreTermInterp[L <: LA](defaultFramework: String,
                 Continue((empty :: sofar :: already, xs))
               case (sofar :: already, "--server" :: xs) =>
                 Continue((empty.copy(kind = CodegenTarget.Server) :: sofar :: already, xs))
+              case (sofar :: already, "--models" :: xs) =>
+                Continue((empty.copy(kind = CodegenTarget.Models) :: sofar :: already, xs))
               case (sofar :: already, "--framework" :: value :: xs) =>
                 Continue((sofar.copy(context = sofar.context.copy(framework = Some(value))) :: already, xs))
               case (sofar :: already, "--help" :: xs) =>


### PR DESCRIPTION
There is a support to generate only models already, it's just not exposed over CLI. This PR fixes it.

We use swagger not only for HTTP API definition, but also for definition of events schema. So it makes no sense for us to generate any kind of client/server code.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x ] I acknowledge that all my contributions will be made under the project's license.
