### PR TITLE
Do not generate framework implicits when generating model only

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
@@ -13,7 +13,10 @@ import com.twilio.guardrail.terms.{ ScalaTerm, SwaggerTerm }
 import com.twilio.swagger.core.StructuredLogger
 
 package guardrail {
-  case class CodegenDefinitions[L <: LA](clients: List[Client[L]], servers: List[Server[L]], supportDefinitions: List[SupportDefinition[L]])
+  case class CodegenDefinitions[L <: LA](clients: List[Client[L]],
+                                         servers: List[Server[L]],
+                                         supportDefinitions: List[SupportDefinition[L]],
+                                         frameworksImplicits: Option[(L#TermName, L#ObjectDefinition)])
 
   sealed trait LogAbstraction {
     type F[_]

--- a/modules/codegen/src/test/scala/core/issues/Issue166.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue166.scala
@@ -54,7 +54,7 @@ class Issue166 extends FunSuite with Matchers with SwaggerSpecRunner {
     )
 
     val ProtocolDefinitions(ClassDefinition(_, _, cls, _, _) :: Nil, _, _, _) = proto
-    val CodegenDefinitions(Nil, Nil, Nil)                                     = codegen
+    val CodegenDefinitions(Nil, Nil, Nil, None)                               = codegen
 
     val definition = q"""
       case class Blix(map: String)

--- a/modules/codegen/src/test/scala/support/SwaggerSpecRunner.scala
+++ b/modules/codegen/src/test/scala/support/SwaggerSpecRunner.scala
@@ -29,7 +29,7 @@ trait SwaggerSpecRunner {
     import F._
     import Sw._
 
-    val (proto, CodegenDefinitions(clients, Nil, clientSupportDefs)) = Target.unsafeExtract(
+    val (proto, CodegenDefinitions(clients, Nil, clientSupportDefs, _)) = Target.unsafeExtract(
       Common
         .prepareDefinitions[L, CodegenApplication[L, ?]](
           CodegenTarget.Client,
@@ -39,7 +39,7 @@ trait SwaggerSpecRunner {
         .foldMap(framework)
     )
 
-    val (_, CodegenDefinitions(Nil, servers, serverSupportDefs)) = Target.unsafeExtract(
+    val (_, CodegenDefinitions(Nil, servers, serverSupportDefs, _)) = Target.unsafeExtract(
       Common
         .prepareDefinitions[L, CodegenApplication[L, ?]](
           CodegenTarget.Server,


### PR DESCRIPTION
When generating only model classes, current behavior is to generate also a file with implicits for given framework. This effectively means that generated code has a build dependency on http4s/akka-http/... even though it's not needed.

This PR changes that such that no file with framework specific implicits is generated when generating model classes only.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
