### PR TITLE
Traversing Free structure to inject term logging

### DIFF
--- a/modules/codegen/src/main/scala/cats/free/Hacks.scala
+++ b/modules/codegen/src/main/scala/cats/free/Hacks.scala
@@ -67,7 +67,7 @@ object GuardrailFreeHacks {
           term.getClass.getSimpleName,
           term
             .toString()
-            .lines
+            .linesIterator
             .filterNot(_.contains(": null"))
             .mkString("; ")
         )

--- a/modules/codegen/src/main/scala/cats/free/Hacks.scala
+++ b/modules/codegen/src/main/scala/cats/free/Hacks.scala
@@ -4,6 +4,57 @@ import cats.data.EitherK
 import cats.free.Free.{ FlatMapped, Pure, Suspend }
 import cats.implicits._
 
+/* GuardrailFreeHacks
+ *
+ *  Motivation:
+ *    Due to the complex nature of code generation codebases,
+ *    combined with the inherent complexity of Free monads,
+ *    it proved necessary to attempt to inject additional logging
+ *    information into the Free-monadic call graph.
+ *
+ *    This may end up being the wrong approach to take in the end,
+ *    at which point it can be safely removed, though for the time
+ *    being the expected benefit is expressing a direct relationship between
+ *    logs (via SwaggerTerms.log, Target.log, or anything else that uses
+ *    StructuredLogger) and the functions that actually did the logging.
+ *
+ *  Implementation:
+ *    By putting ourselves in the cats.free package, we can directly match
+ *    on individual members of Free.
+ *
+ *    This lets us guess (with some confidence) when we're making some a
+ *    function call vs simply the next line in a for comprehension.
+ *
+ *    By exposing the push/pop terms from StructuredLogger as parameters,
+ *    we can influence the final interpreted tree by propagating through all
+ *    other suspended functions throughout the Free members, without
+ *    polluting the implementation with guardrail specifics.
+ *
+ *    Finally, as we're operating from inside the Free implementation,
+ *    we can actually reflect on the name of the GADT in order to inject
+ *    those as elements of structure in the StructuredLogger for free,
+ *    including logging their parameters if the toString representation
+ *    is shorter than the name threshold.
+ *
+ *  Limitations:
+ *    - As mentioned earlier, reflecting on the GADT names means we're
+ *      unable to differentiate identically named terms from different
+ *      algebras. This turns out to not be that big of an issue, as we're
+ *      only explicitly ignoring a handful, which are likely to not conflict
+ *      with other algebras.
+ *
+ *    - Pure Scala functions that return Free are completely invisible to this
+ *      technique, and must be explicitly marked with
+ *      log.function("functionName").
+ *      It will add a lot of noise in the codebase, but I currently don't see
+ *      an alternate approach that gives us the level of debuggability that
+ *      we are able to achieve with this approach.
+ *      If it does turn out that there's a better approach, it would be much
+ *      easier to remove than to write, as those function calls are simply
+ *      wrappers and can be removed without altering anything about the
+ *      actual execution.
+ *
+ */
 object GuardrailFreeHacks {
   val limit: Int = 80
 

--- a/modules/codegen/src/main/scala/cats/free/Hacks.scala
+++ b/modules/codegen/src/main/scala/cats/free/Hacks.scala
@@ -1,0 +1,60 @@
+package cats.free
+
+import cats.data.EitherK
+import cats.free.Free.{ FlatMapped, Pure, Suspend }
+import cats.implicits._
+
+object GuardrailFreeHacks {
+  val limit: Int = 80
+
+  trait TermName[F[_]] { def extract[A](term: F[A]): (String, String) }
+
+  trait LowPriorityTermName {
+    implicit def baseTermName[F[_]]: TermName[F] = new TermName[F] {
+      def extract[A](term: F[A]) =
+        (
+          term.getClass.getSimpleName,
+          term
+            .toString()
+            .lines
+            .filterNot(_.contains(": null"))
+            .mkString("; ")
+        )
+    }
+  }
+
+  trait HighPriorityTermName extends LowPriorityTermName {
+    implicit def extractEitherT[F[_], G[_]](implicit evF: TermName[F], evG: TermName[G]): TermName[EitherK[F, G, ?]] = new TermName[EitherK[F, G, ?]] {
+      def extract[A](term: EitherK[F, G, A]) = term.run.fold(evF.extract _, evG.extract _)
+    }
+  }
+
+  object TermName extends HighPriorityTermName {
+    def apply[F[_], A](value: F[A])(implicit ev: TermName[F]): String = {
+      val (name, full) = ev.extract(value)
+      if (full.length > limit) name else full
+    }
+    def full[F[_], A](value: F[A])(implicit ev: TermName[F]): String     = ev.extract(value)._2
+    def nameOnly[F[_], A](value: F[A])(implicit ev: TermName[F]): String = ev.extract(value)._1
+  }
+
+  def injectLogs[F[_]: TermName, A](value: Free[F, A],
+                                    ignore: Set[String],
+                                    push: String => Free[F, Unit],
+                                    pop: Free[F, Unit],
+                                    emit: Free[F, Unit]): Free[F, A] = {
+    def next[B]: Free[F, B] => Free[F, B] = injectLogs(_, ignore, push, pop, emit)
+    value match {
+      case Pure(a) =>
+        Pure(a)
+      case Suspend(a) =>
+        Suspend(a)
+      case term @ FlatMapped(Suspend(a), _) if ignore contains TermName.nameOnly(a) =>
+        term
+      case FlatMapped(Suspend(a), f) =>
+        push(TermName(a)) *> FlatMapped(Suspend(a), f.map(x => next(x) <* emit <* pop))
+      case FlatMapped(c, f) =>
+        FlatMapped(next(c), f.map(next))
+    }
+  }
+}

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -38,7 +38,7 @@ object Common {
     import Sc._
     import Sw._
 
-    for {
+    Sw.log.function("prepareDefinitions")(for {
       proto @ ProtocolDefinitions(protocolElems, protocolImports, packageObjectImports, packageObjectContents) <- ProtocolGenerator
         .fromSwagger[L, F](swagger, dtoPackage)
 
@@ -102,7 +102,7 @@ object Common {
         case CodegenTarget.Models =>
           Free.pure[F, CodegenDefinitions[L]](CodegenDefinitions[L](List.empty, List.empty, List.empty, Option.empty))
       }
-    } yield (proto, codegen)
+    } yield (proto, codegen))
   }
 
   def writePackage[L <: LA, F[_]](proto: ProtocolDefinitions[L], codegen: CodegenDefinitions[L], context: Context)(

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
@@ -227,7 +227,7 @@ object SwaggerUtil {
       format: Tracker[Option[String]],
       customType: Option[String]
   )(implicit Sc: ScalaTerms[L, F], Sw: SwaggerTerms[L, F], Fw: FrameworkTerms[L, F]): Free[F, L#Type] =
-    Sw.log.function(s"typeName(${typeName}, ${format}, ${customType})") {
+    Sw.log.function(s"typeName(${typeName.unwrapTracker}, ${format.unwrapTracker}, ${customType})") {
       import Sc._
       import Fw._
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
@@ -140,14 +140,15 @@ case class CoreTermInterp[L <: LA](defaultFramework: String,
           Paths.get(specPath), {
             swagger =>
               try {
+                val Sw = SwaggerTerms.swaggerTerm[L, CodegenApplication[L, ?]]
                 val program = for {
+                  _                  <- Sw.log.debug("Running guardrail codegen")
                   definitionsPkgName <- ScalaTerms.scalaTerm[L, CodegenApplication[L, ?]].fullyQualifyPackageName(pkgName)
                   (proto, codegen) <- Common
                     .prepareDefinitions[L, CodegenApplication[L, ?]](kind, context, Tracker(swagger), definitionsPkgName ++ ("definitions" :: dtoPackage))
                   result <- Common
                     .writePackage[L, CodegenApplication[L, ?]](proto, codegen, context)(Paths.get(outputPath), pkgName, dtoPackage, customImports)
                 } yield result
-                val Sw = SwaggerTerms.swaggerTerm[L, CodegenApplication[L, ?]]
                 GuardrailFreeHacks
                   .injectLogs(program, Set("LogPush", "LogPop", "LogDebug", "LogInfo", "LogWarning", "LogError"), Sw.log.push, Sw.log.pop, Free.pure(()))
                   .foldMap(targetInterpreter)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
@@ -2,6 +2,7 @@ package com.twilio.guardrail
 package core
 
 import cats.data.{ NonEmptyList, State }
+import cats.free.{ Free, GuardrailFreeHacks }
 import cats.implicits._
 import cats.{ FlatMap, ~> }
 import com.twilio.guardrail.languages.LA
@@ -139,14 +140,17 @@ case class CoreTermInterp[L <: LA](defaultFramework: String,
           Paths.get(specPath), {
             swagger =>
               try {
-                (for {
+                val program = for {
                   definitionsPkgName <- ScalaTerms.scalaTerm[L, CodegenApplication[L, ?]].fullyQualifyPackageName(pkgName)
-                  defs <- Common
+                  (proto, codegen) <- Common
                     .prepareDefinitions[L, CodegenApplication[L, ?]](kind, context, Tracker(swagger), definitionsPkgName ++ ("definitions" :: dtoPackage))
-                  (proto, codegen) = defs
                   result <- Common
                     .writePackage[L, CodegenApplication[L, ?]](proto, codegen, context)(Paths.get(outputPath), pkgName, dtoPackage, customImports)
-                } yield result).foldMap(targetInterpreter)
+                } yield result
+                val Sw = SwaggerTerms.swaggerTerm[L, CodegenApplication[L, ?]]
+                GuardrailFreeHacks
+                  .injectLogs(program, Set("LogPush", "LogPop", "LogDebug", "LogInfo", "LogWarning", "LogError"), Sw.log.push, Sw.log.pop, Free.pure(()))
+                  .foldMap(targetInterpreter)
               } catch {
                 case NonFatal(ex) =>
                   val stackTrace =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/core/StructuredLogger.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/core/StructuredLogger.scala
@@ -74,7 +74,7 @@ sealed trait StructuredLoggerInstances extends StructuredLoggerLowPriority {
         ._1
         .foldLeft((List.empty[String], List.empty[String]))({
           case ((lastHistory, messages), (level, history, message)) =>
-            val showFullHistory = false
+            val showFullHistory = true
             def makePrefix(history: List[String]): String =
               history.foldLeft("  ") {
                 case (a, b) =>

--- a/modules/codegen/src/test/scala/core/GuardrailFreeHacksSuite.scala
+++ b/modules/codegen/src/test/scala/core/GuardrailFreeHacksSuite.scala
@@ -1,0 +1,169 @@
+package core
+
+import cats.free.{ Free, GuardrailFreeHacks }
+import cats.implicits._
+import com.twilio.guardrail._
+import com.twilio.swagger.core._
+import com.twilio.guardrail.terms.{ SwaggerTerm, SwaggerTerms }
+
+import org.scalatest.{ FunSuite, Matchers }
+import cats.arrow.FunctionK
+import com.twilio.guardrail.languages.ScalaLanguage
+import cats.data.EitherK
+import com.twilio.guardrail.generators.SwaggerGenerator
+
+sealed trait Algebra[A]
+case class GenName(value: String)     extends Algebra[String]
+case class ToUpper(value: String)     extends Algebra[String]
+case class ToLower(value: String)     extends Algebra[String]
+case class Passthrough(value: String) extends Algebra[String]
+
+class GuardrailFreeHacksSuite extends FunSuite with Matchers {
+  def genLogEntries(): StructuredLogger = {
+    type Program[A] = EitherK[Algebra, SwaggerTerm[ScalaLanguage, ?], A]
+    val Sw = SwaggerTerms.swaggerTerm[ScalaLanguage, Program]
+
+    def passthrough(value: String): Free[Program, String] =
+      Free.inject[Algebra, Program](Passthrough(value + "."))
+
+    def genName(value: String): Free[Program, String] =
+      Sw.log.function("genName")(
+        Free.inject[Algebra, Program](GenName("name 1")) <* Sw.log.info("done")
+      )
+
+    def toUpper(value: String): Free[Program, String] =
+      Sw.log.function("toUpper")(
+        for {
+          a <- Free.inject[Algebra, Program](ToUpper(value))
+          _ <- Sw.log.debug("foo")
+          b <- passthrough(a)
+          c <- passthrough(b)
+          d <- passthrough(c)
+          _ <- Sw.log.warning("toUpper may occasionally fail!")
+        } yield d
+      )
+
+    def toLower(value: String): Free[Program, String] =
+      Sw.log.function("toLower")(
+        Free.inject[Algebra, Program](ToLower(value)) <* Sw.log.debug("bar")
+      )
+
+    def doWork(v1: String, v2: String): Free[Program, String] =
+      Sw.log.function("doWork") {
+        for {
+          _ <- Sw.log.info("work starting")
+          a <- toUpper(v1)
+          b <- toLower(v2)
+          _ <- Sw.log.info("work finished")
+        } yield a + b
+      }
+
+    val program = for {
+      n1 <- genName("name 1")
+      n2 <- genName("name 2")
+      r1 <- doWork(n1, n2)
+      r2 <- doWork(n2, n1)
+    } yield r1 == r2
+
+    val interp = new FunctionK[Algebra, Target] {
+      def apply[A](term: Algebra[A]): Target[A] = term match {
+        case GenName(a)     => Target.pure(a)
+        case ToUpper(a)     => Target.pure(a.toUpperCase)
+        case ToLower(a)     => Target.pure(a.toLowerCase)
+        case Passthrough(a) => Target.log.error("Alert!") *> Target.pure(a)
+      }
+    }
+    val ignoredTerms = Set("LogPush", "LogPop", "LogDebug", "LogInfo", "LogWarning", "LogError")
+    GuardrailFreeHacks
+      .injectLogs(program, ignoredTerms, Sw.log.push, Sw.log.pop, Free.pure(()))
+      .foldMap(interp or SwaggerGenerator.apply[ScalaLanguage])
+      .value
+      .runEmptyS
+  }
+
+  test("Nested function calls work (DEBUG)") {
+    val expected = """
+      |   INFO    genName: done
+      |   INFO    genName: done
+      |   INFO    doWork: work starting
+      |  DEBUG    doWork toUpper: foo
+      |  ERROR    doWork toUpper Passthrough(NAME 1.): Alert!
+      |  ERROR    doWork toUpper Passthrough(NAME 1..): Alert!
+      |  ERROR    doWork toUpper Passthrough(NAME 1...): Alert!
+      |WARNING    doWork toUpper: toUpper may occasionally fail!
+      |  DEBUG    doWork toLower: bar
+      |   INFO    doWork: work finished
+      |   INFO    doWork: work starting
+      |  DEBUG    doWork toUpper: foo
+      |  ERROR    doWork toUpper Passthrough(NAME 1.): Alert!
+      |  ERROR    doWork toUpper Passthrough(NAME 1..): Alert!
+      |  ERROR    doWork toUpper Passthrough(NAME 1...): Alert!
+      |WARNING    doWork toUpper: toUpper may occasionally fail!
+      |  DEBUG    doWork toLower: bar
+      |   INFO    doWork: work finished
+      """.trim.stripMargin
+
+    implicit val logLevel = LogLevels.Debug
+    genLogEntries().show should ===(expected)
+  }
+
+  test("Nested function calls work (INFO)") {
+    val expected = """
+      |   INFO    genName: done
+      |   INFO    genName: done
+      |   INFO    doWork: work starting
+      |  ERROR    doWork toUpper Passthrough(NAME 1.): Alert!
+      |  ERROR    doWork toUpper Passthrough(NAME 1..): Alert!
+      |  ERROR    doWork toUpper Passthrough(NAME 1...): Alert!
+      |WARNING    doWork toUpper: toUpper may occasionally fail!
+      |   INFO    doWork: work finished
+      |   INFO    doWork: work starting
+      |  ERROR    doWork toUpper Passthrough(NAME 1.): Alert!
+      |  ERROR    doWork toUpper Passthrough(NAME 1..): Alert!
+      |  ERROR    doWork toUpper Passthrough(NAME 1...): Alert!
+      |WARNING    doWork toUpper: toUpper may occasionally fail!
+      |   INFO    doWork: work finished
+      """.trim.stripMargin
+
+    implicit val logLevel = LogLevels.Info
+    genLogEntries().show should ===(expected)
+  }
+
+  test("Nested function calls work (WARNING)") {
+    val expected = """
+      |  ERROR    doWork toUpper Passthrough(NAME 1.): Alert!
+      |  ERROR    doWork toUpper Passthrough(NAME 1..): Alert!
+      |  ERROR    doWork toUpper Passthrough(NAME 1...): Alert!
+      |WARNING    doWork toUpper: toUpper may occasionally fail!
+      |  ERROR    doWork toUpper Passthrough(NAME 1.): Alert!
+      |  ERROR    doWork toUpper Passthrough(NAME 1..): Alert!
+      |  ERROR    doWork toUpper Passthrough(NAME 1...): Alert!
+      |WARNING    doWork toUpper: toUpper may occasionally fail!
+      """.trim.stripMargin
+
+    implicit val logLevel = LogLevels.Warning
+    genLogEntries().show should ===(expected)
+  }
+
+  test("Nested function calls work (ERROR)") {
+    val expected = """
+      |  ERROR    doWork toUpper Passthrough(NAME 1.): Alert!
+      |  ERROR    doWork toUpper Passthrough(NAME 1..): Alert!
+      |  ERROR    doWork toUpper Passthrough(NAME 1...): Alert!
+      |  ERROR    doWork toUpper Passthrough(NAME 1.): Alert!
+      |  ERROR    doWork toUpper Passthrough(NAME 1..): Alert!
+      |  ERROR    doWork toUpper Passthrough(NAME 1...): Alert!
+      """.trim.stripMargin
+
+    implicit val logLevel = LogLevels.Error
+    genLogEntries().show should ===(expected)
+  }
+
+  test("Nested function calls work (SILENT)") {
+    val expected = """
+      """.trim.stripMargin
+
+    implicit val logLevel = LogLevels.Silent
+    genLogEntries().show should ===(expected)
+  }
+}

--- a/modules/codegen/src/test/scala/core/GuardrailFreeHacksSuite.scala
+++ b/modules/codegen/src/test/scala/core/GuardrailFreeHacksSuite.scala
@@ -18,6 +18,10 @@ case class ToUpper(value: String)     extends Algebra[String]
 case class ToLower(value: String)     extends Algebra[String]
 case class Passthrough(value: String) extends Algebra[String]
 
+/** GuardrailFreeHacksSuite
+  *
+  *  For documentation, please see GuardrailFreeHacks itself.
+  */
 class GuardrailFreeHacksSuite extends FunSuite with Matchers {
   def genLogEntries(): StructuredLogger = {
     type Program[A] = EitherK[Algebra, SwaggerTerm[ScalaLanguage, ?], A]

--- a/modules/codegen/src/test/scala/core/StructuredLoggerSuite.scala
+++ b/modules/codegen/src/test/scala/core/StructuredLoggerSuite.scala
@@ -20,10 +20,9 @@ class StructuredLoggerSuite extends FunSuite with Matchers {
       }
     val logEntries = structure.value.runEmptyS
     val expected   = """
-      |   INFO    first
-      |   INFO          second: one
-      |   INFO          second: two
-      |   INFO          second: three
+      |   INFO    first second: one
+      |   INFO    first second: two
+      |   INFO    first second: three
       """.trim.stripMargin
 
     {


### PR DESCRIPTION
In an attempt to make it easier to debug either while developing or when running guardrail, this PR abuses the deferred nature of `Free` to dynamically inject logs every time there's a `FlatMapped(Suspend(term), f)`, which is the construct that maps to calling out to a member of a Free algebra.

Abusing package membership is necessary because there are no public functions on `Free` that expose the tree itself, only handling individual terms, like `mapK`.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.