### PR TITLE
Generate definition classes for inlined objects

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
@@ -182,6 +182,9 @@ object JavaGenerator {
       case ExtractTermName(term) =>
         Target.pure(term.asString)
 
+      case SelectType(typeNames) =>
+        safeParseType(typeNames.toList.mkString("."))
+
       case AlterMethodParameterName(param, name) =>
         safeParseSimpleName(name.asString.escapeIdentifier).map(
           new Parameter(
@@ -209,8 +212,10 @@ object JavaGenerator {
       case ArrayType(format)         => safeParseClassOrInterfaceType("java.util.List").map(_.setTypeArguments(new NodeList[Type](STRING_TYPE)))
       case FallbackType(tpe, format) => safeParseType(tpe)
 
-      case WidenTypeName(tpe)     => safeParseType(tpe.asString)
-      case WidenTermSelect(value) => Target.pure(value)
+      case WidenTypeName(tpe)           => safeParseType(tpe.asString)
+      case WidenTermSelect(value)       => Target.pure(value)
+      case WidenClassDefinition(value)  => Target.pure(value)
+      case WidenObjectDefinition(value) => Target.pure(value)
 
       case RenderImplicits(pkgPath, pkgName, frameworkImports, jsonImports, customImports) =>
         Target.pure(None)
@@ -322,6 +327,9 @@ object JavaGenerator {
           handlerTree <- writeServerTree(pkgPath, pkg, pkgDecl, allImports, handlerDefinition)
           serverTrees <- serverDefinitions.traverse(writeServerTree(pkgPath, pkg, pkgDecl, allImports, _))
         } yield handlerTree +: serverTrees
+
+      case WrapToObject(_, _, _) =>
+        Target.raiseError("Currently not supported for Java")
     }
   }
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerm.scala
@@ -5,6 +5,8 @@ import com.twilio.guardrail.SwaggerUtil.LazyResolvedType
 import com.twilio.guardrail.languages.LA
 import java.nio.file.Path
 
+import cats.data.NonEmptyList
+
 sealed trait ScalaTerm[L <: LA, T]
 
 case class VendorPrefixes[L <: LA]() extends ScalaTerm[L, List[String]]
@@ -39,6 +41,7 @@ case class TypeNamesEqual[L <: LA](a: L#TypeName, b: L#TypeName)                
 case class TypesEqual[L <: LA](a: L#Type, b: L#Type)                                            extends ScalaTerm[L, Boolean]
 case class ExtractTypeName[L <: LA](tpe: L#Type)                                                extends ScalaTerm[L, Option[L#TypeName]]
 case class ExtractTermName[L <: LA](term: L#TermName)                                           extends ScalaTerm[L, String]
+case class SelectType[L <: LA](typeNames: NonEmptyList[String])                                 extends ScalaTerm[L, L#Type]
 case class AlterMethodParameterName[L <: LA](param: L#MethodParameter, name: L#TermName)        extends ScalaTerm[L, L#MethodParameter]
 
 case class UUIDType[L <: LA]()                                        extends ScalaTerm[L, L#Type]
@@ -55,8 +58,10 @@ case class BooleanType[L <: LA](format: Option[String])               extends Sc
 case class ArrayType[L <: LA](format: Option[String])                 extends ScalaTerm[L, L#Type]
 case class FallbackType[L <: LA](tpe: String, format: Option[String]) extends ScalaTerm[L, L#Type]
 
-case class WidenTypeName[L <: LA](tpe: L#TypeName)       extends ScalaTerm[L, L#Type]
-case class WidenTermSelect[L <: LA](value: L#TermSelect) extends ScalaTerm[L, L#Term]
+case class WidenTypeName[L <: LA](tpe: L#TypeName)                   extends ScalaTerm[L, L#Type]
+case class WidenTermSelect[L <: LA](value: L#TermSelect)             extends ScalaTerm[L, L#Term]
+case class WidenClassDefinition[L <: LA](value: L#ClassDefinition)   extends ScalaTerm[L, L#Definition]
+case class WidenObjectDefinition[L <: LA](value: L#ObjectDefinition) extends ScalaTerm[L, L#Definition]
 
 case class RenderImplicits[L <: LA](pkgPath: Path,
                                     pkgName: List[String],
@@ -106,3 +111,5 @@ case class WriteServer[L <: LA](pkgPath: Path,
                                 dtoComponents: List[String],
                                 server: Server[L])
     extends ScalaTerm[L, List[WriteTree]]
+
+case class WrapToObject[L <: LA](name: L#TermName, imports: List[L#Import], definitions: List[L#Definition]) extends ScalaTerm[L, L#ObjectDefinition]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerms.scala
@@ -7,6 +7,8 @@ import com.twilio.guardrail.SwaggerUtil.LazyResolvedType
 import com.twilio.guardrail.languages.LA
 import java.nio.file.Path
 
+import cats.data.NonEmptyList
+
 class ScalaTerms[L <: LA, F[_]](implicit I: InjectK[ScalaTerm[L, ?], F]) {
   def vendorPrefixes(): Free[F, List[String]] = Free.inject[ScalaTerm[L, ?], F](VendorPrefixes[L]())
 
@@ -41,6 +43,7 @@ class ScalaTerms[L <: LA, F[_]](implicit I: InjectK[ScalaTerm[L, ?], F]) {
   def typesEqual(a: L#Type, b: L#Type): Free[F, Boolean]             = Free.inject[ScalaTerm[L, ?], F](TypesEqual(a, b))
   def extractTypeName(tpe: L#Type): Free[F, Option[L#TypeName]]      = Free.inject[ScalaTerm[L, ?], F](ExtractTypeName(tpe))
   def extractTermName(term: L#TermName): Free[F, String]             = Free.inject[ScalaTerm[L, ?], F](ExtractTermName(term))
+  def selectType(typeNames: NonEmptyList[String]): Free[F, L#Type]   = Free.inject[ScalaTerm[L, ?], F](SelectType(typeNames))
   def alterMethodParameterName(param: L#MethodParameter, name: L#TermName): Free[F, L#MethodParameter] =
     Free.inject[ScalaTerm[L, ?], F](AlterMethodParameterName(param, name))
 
@@ -58,8 +61,10 @@ class ScalaTerms[L <: LA, F[_]](implicit I: InjectK[ScalaTerm[L, ?], F]) {
   def arrayType(format: Option[String]): Free[F, L#Type]                 = Free.inject[ScalaTerm[L, ?], F](ArrayType(format))
   def fallbackType(tpe: String, format: Option[String]): Free[F, L#Type] = Free.inject[ScalaTerm[L, ?], F](FallbackType(tpe, format))
 
-  def widenTypeName(tpe: L#TypeName): Free[F, L#Type]       = Free.inject[ScalaTerm[L, ?], F](WidenTypeName(tpe))
-  def widenTermSelect(value: L#TermSelect): Free[F, L#Term] = Free.inject[ScalaTerm[L, ?], F](WidenTermSelect(value))
+  def widenTypeName(tpe: L#TypeName): Free[F, L#Type]                         = Free.inject[ScalaTerm[L, ?], F](WidenTypeName(tpe))
+  def widenTermSelect(value: L#TermSelect): Free[F, L#Term]                   = Free.inject[ScalaTerm[L, ?], F](WidenTermSelect(value))
+  def widenClassDefinition(value: L#ClassDefinition): Free[F, L#Definition]   = Free.inject[ScalaTerm[L, ?], F](WidenClassDefinition(value))
+  def widenObjectDefinition(value: L#ObjectDefinition): Free[F, L#Definition] = Free.inject[ScalaTerm[L, ?], F](WidenObjectDefinition(value))
 
   def renderImplicits(pkgPath: Path,
                       pkgName: List[String],
@@ -112,6 +117,9 @@ class ScalaTerms[L <: LA, F[_]](implicit I: InjectK[ScalaTerm[L, ?], F]) {
                   dtoComponents: List[String],
                   server: Server[L]): Free[F, List[WriteTree]] =
     Free.inject[ScalaTerm[L, ?], F](WriteServer(pkgPath, pkgName, customImports, frameworkImplicitName, dtoComponents, server))
+
+  def wrapToObject(name: L#TermName, imports: List[L#Import], definitions: List[L#Definition]): Free[F, L#ObjectDefinition] =
+    Free.inject[ScalaTerm[L, ?], F](WrapToObject(name, imports, definitions))
 }
 object ScalaTerms {
   implicit def scalaTerm[L <: LA, F[_]](implicit I: InjectK[ScalaTerm[L, ?], F]): ScalaTerms[L, F] = new ScalaTerms[L, F]

--- a/modules/codegen/src/test/scala/tests/core/TypesTest.scala
+++ b/modules/codegen/src/test/scala/tests/core/TypesTest.scala
@@ -9,63 +9,74 @@ import support.SwaggerSpecRunner
 
 class TypesTest extends FunSuite with Matchers with SwaggerSpecRunner {
 
-  val swagger: String = s"""
-    |swagger: "2.0"
-    |info:
-    |  title: Whatever
-    |  version: 1.0.0
-    |host: localhost:1234
-    |definitions:
-    |  Types:
-    |    type: object
-    |    properties:
-    |      array:
-    |        type: array
-    |        items:
-    |          type: boolean
-    |      map:
-    |        type: objet
-    |        additionalProperties:
-    |          type: boolean
-    |      obj:
-    |        type: object
-    |      bool:
-    |        type: boolean
-    |      string:
-    |        type: string
-    |      date:
-    |        type: string
-    |        format: date
-    |      date_time:
-    |        type: string
-    |        format: date-time
-    |      long:
-    |        type: integer
-    |        format: int64
-    |      int:
-    |        type: integer
-    |        format: int32
-    |      float:
-    |        type: number
-    |        format: float
-    |      double:
-    |        type: number
-    |        format: double
-    |      number:
-    |        type: number
-    |      integer:
-    |        type: integer
-    |      untyped:
-    |        description: Untyped
-    |      custom:
-    |        type: string
-    |        x-scala-type: Foo
-    |      customComplex:
-    |        type: string
-    |        x-scala-type: Foo[Bar]
-    |""".stripMargin
-
   test("Generate no definitions") {
+    val swagger: String = s"""
+      |swagger: "2.0"
+      |info:
+      |  title: Whatever
+      |  version: 1.0.0
+      |host: localhost:1234
+      |definitions:
+      |  Types:
+      |    type: object
+      |    properties:
+      |      array:
+      |        type: array
+      |        items:
+      |          type: boolean
+      |      map:
+      |        type: objet
+      |        additionalProperties:
+      |          type: boolean
+      |      obj:
+      |        type: object
+      |      bool:
+      |        type: boolean
+      |      string:
+      |        type: string
+      |      date:
+      |        type: string
+      |        format: date
+      |      date_time:
+      |        type: string
+      |        format: date-time
+      |      long:
+      |        type: integer
+      |        format: int64
+      |      int:
+      |        type: integer
+      |        format: int32
+      |      float:
+      |        type: number
+      |        format: float
+      |      double:
+      |        type: number
+      |        format: double
+      |      number:
+      |        type: number
+      |      integer:
+      |        type: integer
+      |      untyped:
+      |        description: Untyped
+      |      custom:
+      |        type: string
+      |        x-scala-type: Foo
+      |      customComplex:
+      |        type: string
+      |        x-scala-type: Foo[Bar]
+      |      nested:
+      |        type: object
+      |        properties:
+      |          prop1:
+      |            type: string
+      |      nestedArray:
+      |        type: array
+      |        items:
+      |          type: object
+      |          properties:
+      |            prop1:
+      |              type: string
+      |""".stripMargin
     val (
       ProtocolDefinitions(ClassDefinition(_, _, cls, staticDefns, _) :: Nil, _, _, _),
       _,
@@ -89,7 +100,9 @@ class TypesTest extends FunSuite with Matchers with SwaggerSpecRunner {
         integer: Option[BigInt] = None,
         untyped: Option[io.circe.Json] = None,
         custom: Option[Foo] = None,
-        customComplex: Option[Foo[Bar]] = None
+        customComplex: Option[Foo[Bar]] = None,
+        nested: Option[Types.Nested] = None,
+        nestedArray: Option[IndexedSeq[Types.NestedArray]] = Option(IndexedSeq.empty),
       )
     """
 
@@ -97,10 +110,145 @@ class TypesTest extends FunSuite with Matchers with SwaggerSpecRunner {
       object Types {
         implicit val encodeTypes: ObjectEncoder[Types] = {
           val readOnlyKeys = Set[String]()
-          Encoder.forProduct15("array", "obj", "bool", "string", "date", "date_time", "long", "int", "float", "double", "number", "integer", "untyped", "custom", "customComplex")((o: Types) => (o.array, o.obj, o.bool, o.string, o.date, o.date_time, o.long, o.int, o.float, o.double, o.number, o.integer, o.untyped, o.custom, o.customComplex)).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
+          Encoder.forProduct17("array", "obj", "bool", "string", "date", "date_time", "long", "int", "float", "double", "number", "integer", "untyped", "custom", "customComplex", "nested", "nestedArray")((o: Types) => (o.array, o.obj, o.bool, o.string, o.date, o.date_time, o.long, o.int, o.float, o.double, o.number, o.integer, o.untyped, o.custom, o.customComplex, o.nested, o.nestedArray)).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
         }
-        implicit val decodeTypes: Decoder[Types] = Decoder.forProduct15("array", "obj", "bool", "string", "date", "date_time", "long", "int", "float", "double", "number", "integer", "untyped", "custom", "customComplex")(Types.apply _)
+        implicit val decodeTypes: Decoder[Types] = Decoder.forProduct17("array", "obj", "bool", "string", "date", "date_time", "long", "int", "float", "double", "number", "integer", "untyped", "custom", "customComplex", "nested", "nestedArray")(Types.apply _)
+
+        case class Nested(prop1: Option[String] = None)
+        object Nested {
+          implicit val encodeNested: ObjectEncoder[Nested] = {
+            val readOnlyKeys = Set[String]()
+            Encoder.forProduct1("prop1")((o: Nested) => o.prop1).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
+          }
+          implicit val decodeNested: Decoder[Nested] = Decoder.forProduct1("prop1")(Nested.apply _)
+        }
+
+        case class NestedArray(prop1: Option[String] = None)
+        object NestedArray {
+          implicit val encodeNestedArray: ObjectEncoder[NestedArray] = {
+            val readOnlyKeys = Set[String]()
+            Encoder.forProduct1("prop1")((o: NestedArray) => o.prop1).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
+          }
+          implicit val decodeNestedArray: Decoder[NestedArray] = Decoder.forProduct1("prop1")(NestedArray.apply _)
+        }
       }
+    """
+
+    cls.structure shouldEqual definition.structure
+    cmp.structure shouldEqual companion.structure
+  }
+
+  test("Generates from composed schema") {
+    val swagger: String = s"""
+      |swagger: "2.0"
+      |info:
+      |  title: Whatever
+      |  version: 1.0.0
+      |host: localhost:1234
+      |definitions:
+      |  That:
+      |    type: object
+      |    properties:
+      |      string:
+      |        type: string
+      |  Types:
+      |    type: object
+      |    properties:
+      |      composed:
+      |        allOf:
+      |          - $$ref: '#/definitions/That'
+      |          - type: object
+      |            properties:
+      |              int:
+      |                type: integer
+      |                format: int32
+      |
+      |""".stripMargin
+    val (
+      ProtocolDefinitions(ClassDefinition(_, _, _, _, _) :: ClassDefinition(_, _, cls, staticDefns, _) :: Nil, _, _, _),
+      _,
+      _
+    )       = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    val cmp = companionForStaticDefns(staticDefns)
+
+    val definition = q"""case class Types(composed: Option[Types.Composed] = None)"""
+
+    val companion = q"""
+      object Types {
+        implicit val encodeTypes: ObjectEncoder[Types] = {
+          val readOnlyKeys = Set[String]()
+          Encoder.forProduct1("composed")((o: Types) => o.composed).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
+        }
+        implicit val decodeTypes: Decoder[Types] = Decoder.forProduct1("composed")(Types.apply _)
+        case class Composed(string: Option[String] = None, int: Option[Int] = None)
+        object Composed {
+          implicit val encodeComposed: ObjectEncoder[Composed] = {
+            val readOnlyKeys = Set[String]()
+            Encoder.forProduct2("string", "int")((o: Composed) => (o.string, o.int)).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
+          }
+          implicit val decodeComposed: Decoder[Composed] = Decoder.forProduct2("string", "int")(Composed.apply _)
+        }
+      }
+    """
+
+    cls.structure shouldEqual definition.structure
+    cmp.structure shouldEqual companion.structure
+  }
+
+  test("Deeply nested structure is generated") {
+    val swagger =
+      s"""
+      |swagger: "2.0"
+      |info:
+      |  title: Whatever
+      |  version: 1.0.0
+      |host: localhost:1234
+      |definitions:
+      |  First:
+      |    type: object
+      |    properties:
+      |      Second:
+      |        type: object
+      |        properties:
+      |          Third:
+      |            type: object
+      |            properties:
+      |              Fourth:
+      |                type: string
+      |""".stripMargin
+    val (
+      ProtocolDefinitions(ClassDefinition(_, _, cls, staticDefns, _) :: Nil, _, _, _),
+      _,
+      _
+    )       = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    val cmp = companionForStaticDefns(staticDefns)
+
+    val definition = q"""case class First(Second: Option[First.Second] = None)"""
+
+    val companion = q"""
+       object First {
+         implicit val encodeFirst: ObjectEncoder[First] = {
+           val readOnlyKeys = Set[String]()
+           Encoder.forProduct1("Second")((o: First) => o.Second).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
+         }
+         implicit val decodeFirst: Decoder[First] = Decoder.forProduct1("Second")(First.apply _)
+         case class Second(Third: Option[First.Second.Third] = None)
+         object Second {
+           implicit val encodeSecond: ObjectEncoder[Second] = {
+             val readOnlyKeys = Set[String]()
+             Encoder.forProduct1("Third")((o: Second) => o.Third).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
+           }
+           implicit val decodeSecond: Decoder[Second] = Decoder.forProduct1("Third")(Second.apply _)
+           case class Third(Fourth: Option[String] = None)
+           object Third {
+             implicit val encodeThird: ObjectEncoder[Third] = {
+               val readOnlyKeys = Set[String]()
+               Encoder.forProduct1("Fourth")((o: Third) => o.Fourth).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
+             }
+             implicit val decodeThird: Decoder[Third] = Decoder.forProduct1("Fourth")(Third.apply _)
+           }
+         }
+       }
     """
 
     cls.structure shouldEqual definition.structure


### PR DESCRIPTION
This PR bring support for generation of definition classes for objects that are inlined (they are defined with some other object definition). Current behavior is not to generate any definition class and just just `io.circe.Json` (scala). This PR significantly improves current situation.

Generated definitions for those classes are placed into a companion object. Name of a class is derived from a property for which the class was derived for. Please see a test if this is not clear.

A similar approach can be used for enums that are not defined on their own. Currently we use `String`. I plan to implement this as well, but in a separate PR to keep this one small.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
