### PR TITLE
Safety and exhaustivity refactors

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpClientGenerator.scala
@@ -155,7 +155,7 @@ object AkkaHttpClientGenerator {
                   formDataParams: Option[Term],
                   headerParams: Term,
                   responses: Responses[ScalaLanguage],
-                  produces: Seq[RouteMeta.ContentType],
+                  produces: NonEmptyList[RouteMeta.ContentType],
                   consumes: Seq[RouteMeta.ContentType],
                   tracing: Boolean)(tracingArgsPre: List[ScalaParameter[ScalaLanguage]],
                                     tracingArgsPost: List[ScalaParameter[ScalaLanguage]],
@@ -259,7 +259,9 @@ object AkkaHttpClientGenerator {
           // Placeholder for when more functions get logging
           _ <- Target.pure(())
 
-          produces = operation.produces.toList.flatMap(RouteMeta.ContentType.unapply(_))
+          produces = NonEmptyList
+            .fromList(operation.produces.toList.flatMap(RouteMeta.ContentType.unapply(_)))
+            .getOrElse(NonEmptyList.one(RouteMeta.ApplicationJson))
           consumes = operation.consumes.toList.flatMap(RouteMeta.ContentType.unapply(_))
 
           headerArgs = parameters.headerParams
@@ -405,10 +407,10 @@ object AkkaHttpClientGenerator {
         Target.pure(NonEmptyList(Right(client), Nil))
     }
 
-    def generateCodecs(methodName: String, responses: Responses[ScalaLanguage], produces: Seq[RouteMeta.ContentType]): List[Defn.Val] =
+    def generateCodecs(methodName: String, responses: Responses[ScalaLanguage], produces: NonEmptyList[RouteMeta.ContentType]): List[Defn.Val] =
       generateDecoders(methodName, responses, produces)
 
-    def generateDecoders(methodName: String, responses: Responses[ScalaLanguage], produces: Seq[RouteMeta.ContentType]): List[Defn.Val] =
+    def generateDecoders(methodName: String, responses: Responses[ScalaLanguage], produces: NonEmptyList[RouteMeta.ContentType]): List[Defn.Val] =
       for {
         resp <- responses.value
         tpe  <- resp.value.map(_._1).toList

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
@@ -580,7 +580,7 @@ object AkkaHttpServerGenerator {
                     if (param.isFile) {
                       q"Future.successful(Option.empty[(File, Option[String], ContentType)])"
                     } else {
-                      val (realType, getFunc, transformResponse: (Term => Term)) = param.argType match {
+                      val (realType, getFunc, transformResponse): (Type, Term.Name, (Term => Term)) = param.argType match {
                         case t"Iterable[$x]"         => (x, q"getAll", (x: Term) => q"${x}.map(Option.apply)")
                         case t"Option[Iterable[$x]]" => (x, q"getAll", (x: Term) => q"${x}.map(Option.apply)")
                         case t"Option[$x]"           => (x, q"get", (x: Term) => x)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
@@ -522,88 +522,100 @@ object AkkaHttpServerGenerator {
           """)
             } else (List.empty[Stat], term => term)
 
-            val (multipartHandlers, multipartUnmarshallerTerm): (List[Stat], Option[Term.Name]) = if (consumes.exists(_ == RouteMeta.MultipartFormData)) {
-              val unmarshallerTerm = q"MultipartFormDataUnmarshaller"
-              (q"""
-            object ${partsTerm} {
-              ..${List(
-                _trait,
-                ignoredPart
-              ) ++ multipartContainers}
-            }
-
-            ..${unmarshallers};
-            val ${Pat.Var(referenceAccumulator)} = new AtomicReference(List.empty[File])
-            implicit val ${Pat.Var(unmarshallerTerm)}: FromRequestUnmarshaller[Either[Throwable, ${optionalTypes}]] =
-              implicitly[FromRequestUnmarshaller[Multipart.FormData]].flatMap { implicit executionContext => implicit mat => formData =>
-                val collectedPartsF: Future[Either[Throwable, ${optionalTypes}]] = for {
-                  results <- formData.parts
-                    .mapConcat({ part =>
-                      if (${fieldNames}.contains(part.name)) part :: Nil
-                      else {
-                        part.entity.discardBytes()
-                        Nil
-                      }
-                    }).mapAsync(1)(${Term.Block(List(Term.Function(List(Term.Param(List.empty, q"part", None, None)), Term.Match(q"part.name", allCases))))})
-                      .toMat(Sink.seq[Either[Throwable, ${Type.Select(partsTerm, Type.Name("Part"))}]])(Keep.right).run()
-                  } yield {
-                    results.toList.sequence.map({ successes =>
-                      ..${grabHeads}
-
-                      ${optionalTermPatterns.map(_.toTerm) match {
-                case term :: Nil => q"Tuple1(${term})"
-                case xs          => q"(..${xs})"
-              }}
-                    })
+            val (handlers, unmarshallerTerms): (List[Stat], NonEmptyList[Term.Name]) = consumes.distinct.flatTraverse({
+              case RouteMeta.MultipartFormData => {
+                val unmarshallerTerm = q"MultipartFormDataUnmarshaller"
+                val fru = q"""
+                  object ${partsTerm} {
+                    ..${List(
+                  _trait,
+                  ignoredPart
+                ) ++ multipartContainers}
                   }
 
-                collectedPartsF
+                  ..${unmarshallers};
+
+                  val ${Pat.Var(referenceAccumulator)} = new AtomicReference(List.empty[File])
+                  implicit val ${Pat.Var(unmarshallerTerm)}: FromRequestUnmarshaller[Either[Throwable, ${optionalTypes}]] =
+                    implicitly[FromRequestUnmarshaller[Multipart.FormData]].flatMap { implicit executionContext => implicit mat => formData =>
+                      val collectedPartsF: Future[Either[Throwable, ${optionalTypes}]] = for {
+                        results <- formData.parts
+                          .mapConcat({ part =>
+                            if (${fieldNames}.contains(part.name)) part :: Nil
+                            else {
+                              part.entity.discardBytes()
+                              Nil
+                            }
+                          }).mapAsync(1)(${Term.Block(
+                  List(Term.Function(List(Term.Param(List.empty, q"part", None, None)), Term.Match(q"part.name", allCases)))
+                )})
+                            .toMat(Sink.seq[Either[Throwable, ${Type.Select(partsTerm, Type.Name("Part"))}]])(Keep.right).run()
+                        } yield {
+                          results.toList.sequence.map({ successes =>
+                            ..${grabHeads}
+
+                            ${optionalTermPatterns.map(_.toTerm) match {
+                  case term :: Nil => q"Tuple1(${term})"
+                  case xs          => q"(..${xs})"
+                }}
+                          })
+                        }
+
+                      collectedPartsF
+                    }
+                  """.stats
+                (fru, NonEmptyList.one(unmarshallerTerm))
               }
 
-          """.stats, Option(unmarshallerTerm))
-            } else (List.empty, None)
+              case RouteMeta.UrlencodedFormData => {
+                val unmarshallerTerm = q"FormDataUnmarshaller"
+                val fru = q"""
+                  implicit val ${Pat.Var(unmarshallerTerm)}: FromRequestUnmarshaller[Either[Throwable, ${optionalTypes}]] =
+                    implicitly[FromRequestUnmarshaller[FormData]].flatMap { implicit executionContext => implicit mat => formData =>
+                      def unmarshalField[A: Decoder](name: String, value: String): Future[A] =
+                        Unmarshaller.firstOf(jsonDecoderUnmarshaller[A]).apply(value).recoverWith({
+                          case ex =>
+                            Future.failed(RejectionError(MalformedFormFieldRejection(name, ex.getMessage, Some(ex))))
+                        })
 
-            val (formfieldHandlers, formfieldUnmarshallerTerm): (List[Stat], Option[Term.Name]) = if (consumes.exists(_ == RouteMeta.UrlencodedFormData)) {
-              val unmarshallerTerm = q"FormDataUnmarshaller"
-              (List(q"""
-            implicit val ${Pat.Var(unmarshallerTerm)}: FromRequestUnmarshaller[Either[Throwable, ${optionalTypes}]] =
-              implicitly[FromRequestUnmarshaller[FormData]].flatMap { implicit executionContext => implicit mat => formData =>
-                def unmarshalField[A: Decoder](name: String, value: String): Future[A] =
-                  Unmarshaller.firstOf(jsonDecoderUnmarshaller[A]).apply(value).recoverWith({
-                    case ex =>
-                      Future.failed(RejectionError(MalformedFormFieldRejection(name, ex.getMessage, Some(ex))))
-                  })
-
-                ${params
-                .map(
-                  param =>
-                    if (param.isFile) {
-                      q"Future.successful(Option.empty[(File, Option[String], ContentType)])"
-                    } else {
-                      val (realType, getFunc, transformResponse): (Type, Term.Name, (Term => Term)) = param.argType match {
-                        case t"Iterable[$x]"         => (x, q"getAll", (x: Term) => q"${x}.map(Option.apply)")
-                        case t"Option[Iterable[$x]]" => (x, q"getAll", (x: Term) => q"${x}.map(Option.apply)")
-                        case t"Option[$x]"           => (x, q"get", (x: Term) => x)
-                        case x                       => (x, q"get", (x: Term) => x)
-                      }
-                      transformResponse(
-                        q"""formData.fields.${getFunc}(${param.argName.toLit}).traverse(unmarshalField[${realType}](${param.argName.toLit}, _))"""
-                      )
-                  }
-                ) match {
-                case NonEmptyList(term, Nil)   => q"${term}.map(v1 => Right(Tuple1(v1)))"
-                case NonEmptyList(term, terms) => q"(..${term +: terms}).mapN(${Term.Name(s"Tuple${terms.length + 1}")}.apply).map(Right.apply)"
-              }}
+                      ${params
+                  .map(
+                    param =>
+                      if (param.isFile) {
+                        q"Future.successful(Option.empty[(File, Option[String], ContentType)])"
+                      } else {
+                        val (realType, getFunc, transformResponse): (Type, Term.Name, (Term => Term)) = param.argType match {
+                          case t"Iterable[$x]"         => (x, q"getAll", (x: Term) => q"${x}.map(Option.apply)")
+                          case t"Option[Iterable[$x]]" => (x, q"getAll", (x: Term) => q"${x}.map(Option.apply)")
+                          case t"Option[$x]"           => (x, q"get", (x: Term) => x)
+                          case x                       => (x, q"get", (x: Term) => x)
+                        }
+                        transformResponse(
+                          q"""formData.fields.${getFunc}(${param.argName.toLit}).traverse(unmarshalField[${realType}](${param.argName.toLit}, _))"""
+                        )
+                    }
+                  ) match {
+                  case NonEmptyList(term, Nil)   => q"${term}.map(v1 => Right(Tuple1(v1)))"
+                  case NonEmptyList(term, terms) => q"(..${term +: terms}).mapN(${Term.Name(s"Tuple${terms.length + 1}")}.apply).map(Right.apply)"
+                }}
+                    }
+                """
+                (List(fru), NonEmptyList.one(unmarshallerTerm))
               }
-          """), Option(unmarshallerTerm))
-            } else (List.empty, None)
+
+              case RouteMeta.ApplicationJson => throw new Exception(s"Unable to generate unmarshaller for application/json")
+
+              case RouteMeta.OctetStream => throw new Exception(s"Unable to generate unmarshaller for application/octet-stream")
+
+              case RouteMeta.TextPlain => throw new Exception(s"Unable to generate unmarshaller for text/plain")
+            })
 
             val directive: Term = (
               q"""
           ({
-            ..${multipartHandlers ++ formfieldHandlers}
+            ..${handlers}
             (
-              ${trackFileStuff(q"entity(as(Unmarshaller.firstOf(..${(multipartUnmarshallerTerm ++ formfieldUnmarshallerTerm).toList})))")}
+              ${trackFileStuff(q"entity(as(Unmarshaller.firstOf(..${unmarshallerTerms.toList})))")}
             ).flatMap(_.fold({
               case RejectionError(rej) => reject(rej)
               case t => throw t

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
@@ -76,11 +76,10 @@ case class RouteMeta(path: String, method: HttpMethod, operation: Operation, sec
     for {
       content <- Option(requestBody.getContent())
       mt      <- content.values().asScala.headOption
-      tpe     <- Option(mt.getSchema.getType())
+      schema  <- Option(mt.getSchema())
+      tpe     <- Option(schema.getType())
     } yield {
       val p = new Parameter
-
-      val schema = mt.getSchema
 
       if (schema.getFormat == "binary") {
         schema.setType("file")
@@ -103,11 +102,10 @@ case class RouteMeta(path: String, method: HttpMethod, operation: Operation, sec
     val content = for {
       content <- Option(requestBody.getContent)
       mt      <- content.values().asScala.headOption
-      ref     <- Option(mt.getSchema.get$ref())
+      schema  <- Option(mt.getSchema)
+      ref     <- Option(schema.get$ref())
     } yield {
       val p = new Parameter
-
-      val schema = mt.getSchema
 
       if (schema.getFormat == "binary") {
         schema.setType("file")

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
@@ -5,7 +5,7 @@ import cats.data.{ NonEmptyList, NonEmptyMap }
 import cats.free.Free
 import cats.data.State
 import cats.implicits._
-import cats.kernel.Order
+import cats.Order
 import com.twilio.guardrail.generators.{ ScalaParameter, ScalaParameters }
 import com.twilio.guardrail.languages.LA
 import com.twilio.guardrail.terms.SecurityRequirements.SecurityScopes
@@ -40,6 +40,7 @@ object RouteMeta {
       case "application/octet-stream"          => Some(OctetStream)
       case _                                   => None
     }
+    implicit val ContentTypeOrder = Order[String].contramap[ContentType](_.value)
   }
 }
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
@@ -223,12 +223,9 @@ case class RouteMeta(path: String, method: HttpMethod, operation: Operation, sec
   def getParameters[L <: LA, F[_]](
       protocolElems: List[StrictProtocolElems[L]]
   )(implicit Fw: FrameworkTerms[L, F], Sc: ScalaTerms[L, F], Sw: SwaggerTerms[L, F]): Free[F, ScalaParameters[L]] =
-    ScalaParameter
-      .fromParameters(protocolElems)
-      .apply(parameters)
-      .map({ a =>
-        new ScalaParameters[L](a)
-      })
+    for {
+      a <- ScalaParameter.fromParameters(protocolElems).apply(parameters)
+    } yield new ScalaParameters[L](a)
 }
 
 sealed trait SecurityScheme[L <: LA] {


### PR DESCRIPTION
This PR largely applies to akka-http, though the intent is as more functionality gets fleshed out, more of the requirements will move to core and trickle out into the rest of the frameworks/languages.

- Starting with changing `consumes` to `NonEmptyList` (flipped for the akka-http client generator)
- Two new exceptions in cases where we don't have either `Free` or `Target` (these will continue to flag as warnings as time goes on, and will be resolved as we go back to reduce the number of warnings in the build, moving towards `-Wall`)
- Removing some NPEs in the 2to3 shim (we were doing stuff like `Option(getSchema.getType)`)

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
