### PR TITLE
Unmarshaller shuffle redux

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,6 +59,7 @@ val exampleCases: List[(java.io.File, String, Boolean, List[String])] = List(
   (sampleResource("issues/issue264.yaml"), "issues.issue264", false, List.empty),
   (sampleResource("issues/issue325.yaml"), "issues.issue325", false, List.empty),
   (sampleResource("issues/issue351.yaml"), "issues.issue351", false, List.empty),
+  (sampleResource("issues/issue357.yaml"), "issues.issue357", false, List.empty),
   (sampleResource("multipart-form-data.yaml"), "multipartFormData", false, List.empty),
   (sampleResource("petstore.json"), "examples", false, List("--import", "support.PositiveLong")),
   (sampleResource("plain.json"), "tests.dtos", false, List.empty),

--- a/modules/sample-akkaHttp/src/test/scala/core/issues/Issue357.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/issues/Issue357.scala
@@ -1,0 +1,277 @@
+package core.issues
+
+import _root_.jawn.IncompleteParseException
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.server._
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshal, Unmarshaller }
+import cats.instances.future._
+import io.circe._
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.SpanSugar._
+import org.scalatest.{ EitherValues, FunSpec, Matchers }
+import scala.concurrent.Future
+import scala.concurrent.duration.{ Duration, SECONDS }
+
+class Issue357Suite extends FunSpec with Matchers with EitherValues with ScalaFutures with ScalatestRouteTest {
+  override implicit val patienceConfig = PatienceConfig(10 seconds, 1 second)
+
+  describe("akka-http server should") {
+    import issues.issue357.server.akkaHttp.{ Handler, Resource }
+    import issues.issue357.server.akkaHttp.definitions._
+    val route = Resource.routes(new Handler {
+      def deleteFoo(respond: Resource.deleteFooResponse.type)(path: String, query: String, form: String): Future[Resource.deleteFooResponse] =
+        Future.successful((path, query, form) match {
+          case ("1234", "2345", "3456")             => respond.NoContent
+          case ("foo", "bar", "baz")                => respond.NoContent
+          case ("\"qfoo\"", "\"qbar\"", "\"qbaz\"") => respond.NoContent
+          case _                                    => respond.BadRequest
+        })
+      def patchFoo(respond: Resource.patchFooResponse.type)(path: String, query: String, form: String): Future[Resource.patchFooResponse] =
+        Future.successful((path, query, form) match {
+          case ("1234", "2345", "3456")             => respond.NoContent
+          case ("foo", "bar", "baz")                => respond.NoContent
+          case ("\"qfoo\"", "\"qbar\"", "\"qbaz\"") => respond.NoContent
+          case _                                    => respond.BadRequest
+        })
+      def putFoo(respond: Resource.putFooResponse.type)(path: String, query: String, form: String): Future[Resource.putFooResponse] =
+        Future.successful((path, query, form) match {
+          case ("1234", "2345", "3456")             => respond.NoContent
+          case ("foo", "bar", "baz")                => respond.NoContent
+          case ("\"qfoo\"", "\"qbar\"", "\"qbaz\"") => respond.NoContent
+          case _                                    => respond.BadRequest
+        })
+    })
+
+    describe("correctly navigate difficult JSON/string encodings") {
+      describe("should handle url-encoded forms") {
+        it("numbers") {
+          Delete(Uri("/1234").withQuery(Uri.Query("query" -> "2345")), FormData("form" -> "3456")) ~> route ~> check {
+            val _ = assert(status === StatusCodes.NoContent)
+          }
+        }
+
+        it("strings") {
+          Delete(Uri("/foo").withQuery(Uri.Query("query" -> "bar")), FormData("form" -> "baz")) ~> route ~> check {
+            val _ = assert(status === StatusCodes.NoContent)
+          }
+
+          Delete(Uri("/\"qfoo\"").withQuery(Uri.Query("query" -> "\"qbar\"")), FormData("form" -> "\"qbaz\"")) ~> route ~> check {
+            val _ = assert(status === StatusCodes.NoContent)
+          }
+        }
+      }
+
+      describe("should handle multipart forms") {
+        it("numbers") {
+          Put(Uri("/1234").withQuery(Uri.Query("query" -> "2345")), Multipart.FormData(Multipart.FormData.BodyPart("form", "3456"))) ~> route ~> check {
+            val _ = assert(status === StatusCodes.NoContent)
+          }
+        }
+
+        it("strings") {
+          Put(Uri("/foo").withQuery(Uri.Query("query" -> "bar")), Multipart.FormData(Multipart.FormData.BodyPart("form", "baz"))) ~> route ~> check {
+            val _ = assert(status === StatusCodes.NoContent)
+          }
+
+          Put(Uri("/\"qfoo\"").withQuery(Uri.Query("query" -> "\"qbar\"")), Multipart.FormData(Multipart.FormData.BodyPart("form", "\"qbaz\""))) ~> route ~> check {
+            val _ = assert(status === StatusCodes.NoContent)
+          }
+        }
+      }
+
+      describe("should handle text/plain") {
+        it("numbers") {
+          Patch(Uri("/1234").withQuery(Uri.Query("query" -> "2345")), HttpEntity(ContentTypes.`text/plain(UTF-8)`, "3456")) ~> route ~> check {
+            val _ = assert(status === StatusCodes.NoContent)
+          }
+        }
+
+        it("strings") {
+          Patch(Uri("/foo").withQuery(Uri.Query("query" -> "bar")), HttpEntity(ContentTypes.`text/plain(UTF-8)`, "baz")) ~> route ~> check {
+            val _ = assert(status === StatusCodes.NoContent)
+          }
+
+          Patch(Uri("/\"qfoo\"").withQuery(Uri.Query("query" -> "\"qbar\"")), HttpEntity(ContentTypes.`text/plain(UTF-8)`, "\"qbaz\"")) ~> route ~> check {
+            val _ = assert(status === StatusCodes.NoContent)
+          }
+        }
+      }
+    }
+  }
+
+  describe("akka-http client should") {
+    import issues.issue357.client.akkaHttp.{ Client, DeleteFooResponse, PatchFooResponse, PutFooResponse }
+    import issues.issue357.client.akkaHttp.definitions._
+
+    object pathRE {
+      def unapply(value: Uri.Path): Option[String] =
+        value match {
+          case Uri.Path.Slash(Uri.Path.Segment(head, tail)) => Some(head)
+          case rest                                         => fail("Expected \"/{arg}\" did not match: " + rest.toString())
+        }
+    }
+
+    def strictResponse[A](method: HttpMethod, extract: A => Option[String])(implicit um: FromEntityUnmarshaller[A]): HttpRequest => Future[HttpResponse] =
+      response[A](method, { x =>
+        Future.successful(extract(x))
+      })
+
+    def response[A](method: HttpMethod, extract: A => Future[Option[String]])(implicit um: FromEntityUnmarshaller[A]): HttpRequest => Future[HttpResponse] = {
+      case HttpRequest(`method`, uri, headers, entity, protocol) =>
+        for {
+          entity <- Unmarshal(entity).to[A]
+          res    <- extract(entity)
+        } yield {
+          (uri.path, uri.query().get("query"), res) match {
+            case (pathRE("1234"), Some("2345"), Some("3456"))             => HttpResponse(204)
+            case (pathRE("foo"), Some("bar"), Some("baz"))                => HttpResponse(204)
+            case (pathRE("\"qfoo\""), Some("\"qbar\""), Some("\"qbaz\"")) => HttpResponse(204)
+            case _                                                        => HttpResponse(400)
+          }
+        }
+      case ex => failTest(s"Unknown: ${ex}")
+    }
+
+    describe("correctly navigate difficult JSON/string encodings") {
+      describe("given url-encoded forms containing") {
+        it("numbers") {
+          Client
+            .httpClient(strictResponse[FormData](HttpMethods.DELETE, _.fields.get("form")), "http://localhost:80")
+            .deleteFoo("1234", "2345", "3456")
+            .value
+            .futureValue match {
+            case Right(DeleteFooResponse.NoContent) =>
+            case ex                                 => failTest(s"Unknown: ${ex}")
+          }
+        }
+
+        it("strings") {
+          Client
+            .httpClient(strictResponse[FormData](HttpMethods.DELETE, _.fields.get("form")), "http://localhost:80")
+            .deleteFoo("foo", "bar", "baz")
+            .value
+            .futureValue match {
+            case Right(DeleteFooResponse.NoContent) =>
+            case ex                                 => failTest(s"Unknown: ${ex}")
+          }
+
+          Client
+            .httpClient(strictResponse[FormData](HttpMethods.DELETE, _.fields.get("form")), "http://localhost:80")
+            .deleteFoo("\"qfoo\"", "\"qbar\"", "\"qbaz\"")
+            .value
+            .futureValue match {
+            case Right(DeleteFooResponse.NoContent) =>
+            case ex                                 => failTest(s"Unknown: ${ex}")
+          }
+        }
+      }
+
+      describe("given multipart forms containing") {
+        it("numbers") {
+          Client
+            .httpClient(
+              response[Multipart.FormData](
+                HttpMethods.PUT,
+                _.toStrict(Duration(5, SECONDS))
+                  .map(_.strictParts.find(_.name == "form").map(_.entity.data.utf8String))
+              ),
+              "http://localhost:80"
+            )
+            .putFoo("1234", "2345", "3456")
+            .value
+            .futureValue match {
+            case Right(PutFooResponse.NoContent) =>
+            case ex                              => failTest(s"Unknown: ${ex}")
+          }
+        }
+
+        it("strings") {
+          Client
+            .httpClient(
+              response[Multipart.FormData](
+                HttpMethods.PUT,
+                _.toStrict(Duration(5, SECONDS))
+                  .map(_.strictParts.find(_.name == "form").map(_.entity.data.utf8String))
+              ),
+              "http://localhost:80"
+            )
+            .putFoo("foo", "bar", "baz")
+            .value
+            .futureValue match {
+            case Right(PutFooResponse.NoContent) =>
+            case ex                              => failTest(s"Unknown: ${ex}")
+          }
+
+          Client
+            .httpClient(
+              response[Multipart.FormData](
+                HttpMethods.PUT,
+                _.toStrict(Duration(5, SECONDS))
+                  .map(_.strictParts.find(_.name == "form").map(_.entity.data.utf8String))
+              ),
+              "http://localhost:80"
+            )
+            .putFoo("\"qfoo\"", "\"qbar\"", "\"qbaz\"")
+            .value
+            .futureValue match {
+            case Right(PutFooResponse.NoContent) =>
+            case ex                              => failTest(s"Unknown: ${ex}")
+          }
+        }
+      }
+
+      describe("given text/plain containing") {
+        it("numbers") {
+          Client
+            .httpClient(
+              strictResponse[String](
+                HttpMethods.PATCH,
+                Option.apply
+              ),
+              "http://localhost:80"
+            )
+            .patchFoo("1234", "2345", "3456")
+            .value
+            .futureValue match {
+            case Right(PatchFooResponse.NoContent) =>
+            case ex                                => failTest(s"Unknown: ${ex}")
+          }
+        }
+
+        it("strings") {
+          Client
+            .httpClient(
+              strictResponse[String](
+                HttpMethods.PATCH,
+                Option.apply
+              ),
+              "http://localhost:80"
+            )
+            .patchFoo("foo", "bar", "baz")
+            .value
+            .futureValue match {
+            case Right(PatchFooResponse.NoContent) =>
+            case ex                                => failTest(s"Unknown: ${ex}")
+          }
+
+          Client
+            .httpClient(
+              strictResponse[String](
+                HttpMethods.PATCH,
+                Option.apply
+              ),
+              "http://localhost:80"
+            )
+            .patchFoo("\"qfoo\"", "\"qbar\"", "\"qbaz\"")
+            .value
+            .futureValue match {
+            case Right(PatchFooResponse.NoContent) =>
+            case ex                                => failTest(s"Unknown: ${ex}")
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/sample/src/main/resources/issues/issue357.yaml
+++ b/modules/sample/src/main/resources/issues/issue357.yaml
@@ -1,0 +1,73 @@
+swagger: '2.0'
+host: localhost:1234
+schemes:
+- http
+paths:
+  /{path}:
+    delete:
+      operationId: deleteFoo
+      parameters:
+      - name: path
+        in: path
+        type: string
+        required: true
+      - name: query
+        in: query
+        type: string
+        required: true
+      - name: form
+        in: formData
+        type: string
+        required: true
+      consumes:
+      - application/x-www-form-urlencoded
+      responses:
+        '204':
+          description: No content
+        '400':
+          description: Bad request
+    put:
+      operationId: putFoo
+      parameters:
+      - name: path
+        in: path
+        type: string
+        required: true
+      - name: query
+        in: query
+        type: string
+        required: true
+      - name: form
+        in: formData
+        type: string
+        required: true
+      consumes:
+      - multipart/form-data
+      responses:
+        '204':
+          description: No content
+        '400':
+          description: Bad request
+    patch:
+      operationId: patchFoo
+      parameters:
+      - name: path
+        in: path
+        type: string
+        required: true
+      - name: query
+        in: query
+        type: string
+        required: true
+      - name: body
+        in: body
+        schema:
+          type: string
+        required: true
+      consumes:
+      - text/plain
+      responses:
+        '204':
+          description: No content
+        '400':
+          description: Bad request


### PR DESCRIPTION
Depends on #358 
Resolves #357 

#292 didn't fully resolve the problem, as query string parameters still used the old-style fallback parser.

I've added a test for it now, as well as deleting the dangerous unmarshaller entirely.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
