### PR TITLE
Cleaning up warnings

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -123,8 +123,8 @@ object Common {
     val CodegenDefinitions(clients, servers, supportDefinitions, frameworkImplicits)                     = codegen
     val frameworkImplicitName                                                                            = frameworkImplicits.map(_._1)
 
-    val dtoComponents: List[String]                 = definitions ++ dtoPackage
-    val filteredDtoComponents: Option[List[String]] = if (protocolElems.nonEmpty) Some(dtoComponents) else None
+    val dtoComponents: List[String]                         = definitions ++ dtoPackage
+    val filteredDtoComponents: Option[NonEmptyList[String]] = if (protocolElems.nonEmpty) NonEmptyList.fromList(dtoComponents) else None
 
     for {
       protoOut <- protocolElems.traverse(writeProtocolDefinition(outputPath, pkgName, definitions, dtoComponents, customImports ++ protocolImports, _))
@@ -142,8 +142,8 @@ object Common {
       frameworkImports     <- getFrameworkImports(context.tracing)
       frameworkDefinitions <- getFrameworkDefinitions(context.tracing)
 
-      files <- (clients.flatTraverse(writeClient(pkgPath, pkgName, customImports, frameworkImplicitName, filteredDtoComponents, _)),
-                servers.flatTraverse(writeServer(pkgPath, pkgName, customImports, frameworkImplicitName, filteredDtoComponents, _))).mapN(_ ++ _)
+      files <- (clients.flatTraverse(writeClient(pkgPath, pkgName, customImports, frameworkImplicitName, filteredDtoComponents.map(_.toList), _)),
+                servers.flatTraverse(writeServer(pkgPath, pkgName, customImports, frameworkImplicitName, filteredDtoComponents.map(_.toList), _))).mapN(_ ++ _)
 
       implicits <- renderImplicits(pkgPath, pkgName, frameworkImports, protocolImports, customImports)
       frameworkImplicitsFile <- frameworkImplicits.fold(Free.pure[F, Option[WriteTree]](None))({

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
@@ -596,6 +596,7 @@ object SwaggerUtil {
               .String(before)} + "(.*)" + ${Lit.String(after)} + ${Lit.String("$")})"""
         )
 
+    @SuppressWarnings(Array("org.wartremover.warts.Throw"))
     object http4sExtractor
         extends Extractors[Pat, Term.Name](
           pathSegmentConverter = {
@@ -631,6 +632,7 @@ object SwaggerUtil {
             throw new UnsupportedOperationException
         )
 
+    @SuppressWarnings(Array("org.wartremover.warts.Throw"))
     object endpointsExtractor
         extends Extractors[Term, Term.Name](
           pathSegmentConverter = {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/extract/Extractable.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/extract/Extractable.scala
@@ -57,6 +57,7 @@ object Extractable {
     case x: util.List[_] => x.asScala.toList
   }
 
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   private[this] def validateListItems[A](implicit cls: ClassTag[A]): PartialFunction[List[_], List[A]] = {
     case xs: List[_] if xs.forall(x => cls.runtimeClass.isAssignableFrom(x.getClass)) => xs.asInstanceOf[List[A]]
   }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/CirceProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/CirceProtocolGenerator.scala
@@ -259,50 +259,56 @@ object CirceProtocolGenerator {
         )
         val needsEmptyToNull: Boolean = params.exists(_.emptyToNull == EmptyIsNull)
         val paramCount                = params.length
-        val decVal = if (paramCount <= 22 && !needsEmptyToNull) {
-          val names: List[Lit] = params.map(_.name).map(Lit.String(_)).to[List]
-          q"""
-            Decoder.${Term.Name(s"forProduct${paramCount}")}(..${names})(${Term
-            .Name(clsName)}.apply _)
-          """
-        } else {
-          val (terms, enumerators): (List[Term.Name], List[Enumerator.Generator]) = params
-            .map({ param =>
-              val tpe: Type = param.term.decltpe
-                .flatMap({
-                  case tpe: Type => Some(tpe)
-                  case x =>
-                    println(s"Unsure how to map ${x.structure}, please report this bug!")
-                    None
-                })
-                .get
-              val term = Term.Name(param.term.name.value)
-              val enum = if (param.emptyToNull == EmptyIsNull) {
-                enumerator"""
-                ${Pat.Var(term)} <- c.downField(${Lit
-                  .String(param.name)}).withFocus(j => j.asString.fold(j)(s => if(s.isEmpty) Json.Null else j)).as[${tpe}]
+        for {
+          decVal <- if (paramCount <= 22 && !needsEmptyToNull) {
+            val names: List[Lit] = params.map(_.name).map(Lit.String(_)).to[List]
+            Target.pure(
+              q"""
+                Decoder.${Term.Name(s"forProduct${paramCount}")}(..${names})(${Term
+                .Name(clsName)}.apply _)
               """
-              } else {
-                enumerator"""
-                ${Pat.Var(term)} <- c.downField(${Lit.String(param.name)}).as[${tpe}]
-              """
+            )
+          } else {
+            params
+              .traverse({ param =>
+                for {
+                  rawTpe <- Target.fromOption(param.term.decltpe, "Missing type")
+                  tpe <- rawTpe match {
+                    case tpe: Type => Target.pure(tpe)
+                    case x         => Target.raiseError(s"Unsure how to map ${x.structure}, please report this bug!")
+                  }
+                } yield {
+                  val term = Term.Name(param.term.name.value)
+                  val enum = if (param.emptyToNull == EmptyIsNull) {
+                    enumerator"""
+                  ${Pat.Var(term)} <- c.downField(${Lit
+                      .String(param.name)}).withFocus(j => j.asString.fold(j)(s => if(s.isEmpty) Json.Null else j)).as[${tpe}]
+                """
+                  } else {
+                    enumerator"""
+                  ${Pat.Var(term)} <- c.downField(${Lit.String(param.name)}).as[${tpe}]
+                """
+                  }
+                  (term, enum)
+                }
+              })
+              .map({ pairs =>
+                val (terms, enumerators) = pairs.unzip
+                q"""
+              new Decoder[${Type.Name(clsName)}] {
+                final def apply(c: HCursor): Decoder.Result[${Type.Name(clsName)}] =
+                  for {
+                    ..${enumerators}
+                  } yield ${Term.Name(clsName)}(..${terms})
               }
-              (term, enum)
-            })
-            .to[List]
-            .unzip
-          q"""
-          new Decoder[${Type.Name(clsName)}] {
-            final def apply(c: HCursor): Decoder.Result[${Type.Name(clsName)}] =
-              for {
-                ..${enumerators}
-              } yield ${Term.Name(clsName)}(..${terms})
+              """
+              })
           }
-          """
+        } yield {
+          Some(q"""
+            implicit val ${suffixClsName("decode", clsName)}: Decoder[${Type.Name(clsName)}] = $decVal
+          """)
         }
-        Target.pure(Some(q"""
-          implicit val ${suffixClsName("decode", clsName)}: Decoder[${Type.Name(clsName)}] = $decVal
-        """))
 
       case RenderDTOStaticDefns(clsName, deps, encoder, decoder) =>
         val extraImports: List[Import] = deps.map { term =>

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
@@ -111,6 +111,7 @@ object AsyncHttpClientClientGenerator {
     doShow(param.argType)
   }
 
+  @SuppressWarnings(Array("org.wartremover.warts.Null"))
   private def generateBuilderMethodCall(param: ScalaParameter[JavaLanguage], builderMethodName: String, needsMultipart: Boolean): Statement = {
     val finalMethodName = if (needsMultipart) "addBodyPart" else builderMethodName
     val argName         = param.paramName.asString
@@ -248,7 +249,7 @@ object AsyncHttpClientClientGenerator {
       ).traverse(safeParseRawImport)
     } yield {
       def addStdConstructors(cls: ClassOrInterfaceDeclaration): Unit = {
-        cls
+        val _1 = cls
           .addConstructor(PUBLIC)
           .addParameter(new Parameter(new NodeList(finalModifier), STRING_TYPE, new SimpleName("message")))
           .setBody(
@@ -259,7 +260,7 @@ object AsyncHttpClientClientGenerator {
             )
           )
 
-        cls
+        val _2 = cls
           .addConstructor(PUBLIC)
           .setParameters(
             new NodeList(
@@ -275,8 +276,10 @@ object AsyncHttpClientClientGenerator {
             )
           )
       }
-      def addNoSerialVersionUuid(cls: ClassOrInterfaceDeclaration): Unit =
-        cls.addSingleMemberAnnotation("SuppressWarnings", new StringLiteralExpr("serial"))
+
+      def addNoSerialVersionUuid(cls: ClassOrInterfaceDeclaration): Unit = {
+        val _ = cls.addSingleMemberAnnotation("SuppressWarnings", new StringLiteralExpr("serial"))
+      }
 
       val clientExceptionClass = new ClassOrInterfaceDeclaration(new NodeList(publicModifier, abstractModifier), false, "ClientException")
         .addExtendedType("RuntimeException")
@@ -291,9 +294,9 @@ object AsyncHttpClientClientGenerator {
       val httpErrorClass = new ClassOrInterfaceDeclaration(new NodeList(publicModifier), false, "HttpError")
         .addExtendedType("ClientException")
       addNoSerialVersionUuid(httpErrorClass)
-      httpErrorClass.addField(RESPONSE_TYPE, "response", PRIVATE, FINAL)
+      val _1 = httpErrorClass.addField(RESPONSE_TYPE, "response", PRIVATE, FINAL)
 
-      httpErrorClass
+      val _2 = httpErrorClass
         .addConstructor(PUBLIC)
         .addParameter(new Parameter(new NodeList(finalModifier), RESPONSE_TYPE, new SimpleName("response")))
         .setBody(
@@ -959,9 +962,10 @@ object AsyncHttpClientClientGenerator {
 
         innerClasses.foreach(abstractResponseClass.addMember)
 
-        val foldMethod = abstractResponseClass.addMethod("fold", PUBLIC)
-        foldMethod.addTypeParameter("T")
-        foldMethod.setType("T")
+        val foldMethod = abstractResponseClass
+          .addMethod("fold", PUBLIC)
+          .addTypeParameter("T")
+          .setType("T")
         foldMethodParameters.foreach(foldMethod.addParameter)
 
         NonEmptyList

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
@@ -127,7 +127,7 @@ object DropwizardServerGenerator {
       )
   }
 
-  def generateResponseSuperClass(name: String): Target[ClassOrInterfaceDeclaration] = {
+  def generateResponseSuperClass(name: String): Target[ClassOrInterfaceDeclaration] =
     Target.log.function("generateResponseSuperClass") {
       for {
         _ <- Target.log.info(s"Name: ${name}")
@@ -158,7 +158,6 @@ object DropwizardServerGenerator {
           )
       } yield cls
     }
-  }
 
   def generateResponseClass(superClassType: ClassOrInterfaceType,
                             response: Response[JavaLanguage],

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
@@ -178,8 +178,7 @@ object JacksonGenerator {
           new NodeList(publicModifier),
           STRING_TYPE,
           "getName"
-        )
-          .addMarkerAnnotation("JsonValue")
+        ).addMarkerAnnotation("JsonValue")
           .setBody(
             new BlockStmt(
               new NodeList(
@@ -192,8 +191,7 @@ object JacksonGenerator {
           new NodeList(publicModifier, staticModifier),
           enumType,
           "parse"
-        )
-          .addMarkerAnnotation("JsonCreator")
+        ).addMarkerAnnotation("JsonCreator")
           .addParameter(new Parameter(new NodeList(finalModifier), STRING_TYPE, new SimpleName("name")))
           .setBody(
             new BlockStmt(

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
@@ -260,7 +260,7 @@ object JavaGenerator {
 
       case WritePackageObject(dtoPackagePath, dtoComponents, customImports, packageObjectImports, protocolImports, packageObjectContents, extraTypes) =>
         for {
-          pkgDecl <- dtoComponents.traverse(buildPkgDecl)
+          pkgDecl <- dtoComponents.traverse(xs => buildPkgDecl(xs.toList))
           bytes   <- pkgDecl.traverse(x => prettyPrintSource(new CompilationUnit().setPackageDeclaration(x)))
         } yield bytes.map(WriteTree(resolveFile(dtoPackagePath)(List.empty).resolve("package-info.java"), _))
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
@@ -49,7 +49,7 @@ object JavaGenerator {
   )
 
   def prettyPrintSource(source: CompilationUnit): Target[Array[Byte]] = {
-    source.getChildNodes.asScala.headOption.fold(source.addOrphanComment _)(_.setComment)(GENERATED_CODE_COMMENT)
+    val _ = source.getChildNodes.asScala.headOption.fold(source.addOrphanComment _)(_.setComment)(GENERATED_CODE_COMMENT)
     val className = Try[TypeDeclaration[_]](source.getType(0)).fold(_ => "(unknown)", _.getNameAsString)
     val sourceStr = source.toString
     Option(formatter.format(CodeFormatter.K_COMPILATION_UNIT, sourceStr, 0, sourceStr.length, 0, "\n"))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
@@ -49,7 +49,7 @@ object JavaGenerator {
   )
 
   def prettyPrintSource(source: CompilationUnit): Target[Array[Byte]] = {
-    val _ = source.getChildNodes.asScala.headOption.fold(source.addOrphanComment _)(_.setComment)(GENERATED_CODE_COMMENT)
+    val _         = source.getChildNodes.asScala.headOption.fold(source.addOrphanComment _)(_.setComment)(GENERATED_CODE_COMMENT)
     val className = Try[TypeDeclaration[_]](source.getType(0)).fold(_ => "(unknown)", _.getNameAsString)
     val sourceStr = source.toString
     Option(formatter.format(CodeFormatter.K_COMPILATION_UNIT, sourceStr, 0, sourceStr.length, 0, "\n"))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
@@ -1,6 +1,7 @@
 package com.twilio.guardrail.generators
 
 import cats.~>
+import cats.data.NonEmptyList
 import cats.implicits._
 import com.twilio.guardrail._
 import com.twilio.guardrail.Common.resolveFile
@@ -268,13 +269,15 @@ object ScalaGenerator {
         Target.pure(WriteTree(pkgPath.resolve(s"${frameworkDefinitionsName.value}.scala"), sourceToBytes(frameworkDefinitionsFile)))
 
       case WritePackageObject(dtoPackagePath, dtoComponents, customImports, packageObjectImports, protocolImports, packageObjectContents, extraTypes) =>
-        dtoComponents.traverse {
-          case dtoComponents @ (dtoHead :: dtoRest) =>
-            val dtoPkg = dtoRest.init
+        dtoComponents.traverse { case dtoComponents@NonEmptyList(dtoHead, dtoRest) =>
+          for {
+            dtoRestNel <- Target.fromOption(NonEmptyList.fromList(dtoRest), "DTO Components not quite long enough")
+          } yield {
+            val dtoPkg = dtoRestNel.init
               .foldLeft[Term.Ref](Term.Name(dtoHead)) {
                 case (acc, next) => Term.Select(acc, Term.Name(next))
               }
-            val companion = Term.Name(s"${dtoComponents.last}$$")
+            val companion = Term.Name(s"${dtoRestNel.last}$$")
 
             val (_, statements) =
               packageObjectContents.partition(partitionImplicits)
@@ -286,24 +289,24 @@ object ScalaGenerator {
                 stat.copy(rhs = q"${companion}.${mirror}")
               })
 
-            Target.pure(
-              WriteTree(
-                dtoPackagePath.resolve("package.scala"),
-                sourceToBytes(source"""
-            package ${dtoPkg}
+            WriteTree(
+              dtoPackagePath.resolve("package.scala"),
+              sourceToBytes(source"""
+                package ${dtoPkg}
 
-            ..${customImports ++ packageObjectImports ++ protocolImports}
+                ..${customImports ++ packageObjectImports ++ protocolImports}
 
-            object ${companion} {
-              ..${implicits.map(_.copy(mods = List.empty))}
-            }
+                object ${companion} {
+                  ..${implicits.map(_.copy(mods = List.empty))}
+                }
 
-            package object ${Term.Name(dtoComponents.last)} {
-              ..${(mirroredImplicits ++ statements ++ extraTypes).to[List]}
-            }
-            """)
+                package object ${Term.Name(dtoComponents.last)} {
+                  ..${(mirroredImplicits ++ statements ++ extraTypes).to[List]}
+                }
+                """
               )
             )
+          }
         }
       case WriteProtocolDefinition(outputPath, pkgName, definitions, dtoComponents, imports, elem) =>
         Target.pure(elem match {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerm.scala
@@ -88,7 +88,7 @@ case class RenderFrameworkDefinitions[L <: LA](pkgPath: Path,
                                                frameworkDefinitionsName: L#TermName)
     extends ScalaTerm[L, WriteTree]
 case class WritePackageObject[L <: LA](dtoPackagePath: Path,
-                                       dtoComponents: Option[List[String]],
+                                       dtoComponents: Option[NonEmptyList[String]],
                                        customImports: List[L#Import],
                                        packageObjectImports: List[L#Import],
                                        protocolImports: List[L#Import],

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerms.scala
@@ -93,7 +93,7 @@ class ScalaTerms[L <: LA, F[_]](implicit I: InjectK[ScalaTerm[L, ?], F]) {
     Free.inject[ScalaTerm[L, ?], F](RenderFrameworkDefinitions(pkgPath, pkgName, frameworkImports, frameworkDefinitions, frameworkDefinitionsName))
 
   def writePackageObject(dtoPackagePath: Path,
-                         dtoComponents: Option[List[String]],
+                         dtoComponents: Option[NonEmptyList[String]],
                          customImports: List[L#Import],
                          packageObjectImports: List[L#Import],
                          protocolImports: List[L#Import],


### PR DESCRIPTION
Some small changes to reduce the number of warnings during any given build

- Replacing `println` with `Target.raiseError`
- Using `@SuppressWarnings` for unavoidable stuff
- Using fluent API for javaparser instead of leaking non-unit statements
- Sinking non-unit statements to `_` in for comprehensions

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
