### PR TITLE
Fixes #179

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,7 @@ val exampleCases: List[(java.io.File, String, Boolean, List[String])] = List(
   (sampleResource("issues/issue148.yaml"), "issues.issue148", false, List.empty),
   (sampleResource("issues/issue164.yaml"), "issues.issue164", false, List.empty),
   (sampleResource("issues/issue184.yaml"), "issues.issue184", false, List.empty),
+  (sampleResource("issues/issue179.yaml"), "issues.issue179", false, List.empty),
   (sampleResource("issues/issue215.yaml"), "issues.issue215", false, List.empty),
   (sampleResource("issues/issue218.yaml"), "issues.issue218", false, List.empty),
   (sampleResource("issues/issue222.yaml"), "issues.issue222", false, List.empty),

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sHelper.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sHelper.scala
@@ -95,4 +95,11 @@ object Http4sHelper {
                 """
         case _             => q"EntityEncoder[F, String].contramap[$tpe](_.toString)"
       }
+
+  def generateEntityResponseGenerator(term: Term.Ref): Term =
+    q"""
+       new org.http4s.dsl.impl.EntityResponseGenerator[F,F] {
+          def status = $term
+       }
+     """
 }

--- a/modules/codegen/src/test/scala/core/issues/Issue165.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue165.scala
@@ -55,21 +55,21 @@ class Issue165 extends FunSuite with Matchers with SwaggerSpecRunner {
               mapRoute("getRoot", req, {
                 handler.getRoot(GetRootResponse)() flatMap {
                   case GetRootResponse.Ok =>
-                    Ok()
+                    F.pure(Response[F](status = org.http4s.Status.Ok))
                 }  
               })
             case req @ GET -> Root / "foo" =>
               mapRoute("getFoo", req, {
                 handler.getFoo(GetFooResponse)() flatMap {
                   case GetFooResponse.Ok =>
-                    Ok()
+                    F.pure(Response[F](status = org.http4s.Status.Ok))
                 }
               })
             case req @ GET -> Root / "foo" / "" =>
               mapRoute("getFooDir", req, {
                 handler.getFooDir(GetFooDirResponse)() flatMap {
                   case GetFooDirResponse.Ok =>
-                    Ok()
+                    F.pure(Response[F](status = org.http4s.Status.Ok))
               }
             })
           }

--- a/modules/codegen/src/test/scala/core/issues/Issue225.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue225.scala
@@ -42,7 +42,7 @@ class Issue225 extends FunSuite with Matchers with SwaggerSpecRunner {
               mapRoute("getRoot", req, {
                 handler.getRoot(GetRootResponse)(response) flatMap {
                   case GetRootResponse.Ok =>
-                    Ok()
+                    F.pure(Response[F](status = org.http4s.Status.Ok))
                 } 
               })
           }

--- a/modules/sample/src/main/resources/issues/issue179.yaml
+++ b/modules/sample/src/main/resources/issues/issue179.yaml
@@ -1,0 +1,13 @@
+swagger: '2.0'
+info:
+  title: https://github.com/twilio/guardrail/issues/179
+host: localhost:1234
+schemes:
+- http
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      responses:
+        '401':
+          description: No content


### PR DESCRIPTION
This PR fixes #179 

In summary, we don't use Http4sDsl for response construction, but we build `Response` manually instead. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
