### PR TITLE
Don't generate an inline object for objects with no properties

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
@@ -300,11 +300,13 @@ object SwaggerUtil {
       Sw: SwaggerTerms[L, F],
       Fw: FrameworkTerms[L, F]
   ): Free[F, ResolvedType[L]] = {
-    import Sc._
+    import Fw._
     val action: Free[F, ResolvedType[L]] = Free.pure(Resolved[L](tpe, None, None, None, None))
     propMetaImpl(property) {
-      case _: ObjectSchema =>
+      case schema: ObjectSchema if Option(schema.getProperties).exists(p => !p.isEmpty) =>
         action
+      case _: ObjectSchema =>
+        objectType(None).map(Resolved[L](_, None, None, None, None))
       case _: ComposedSchema =>
         action
     }

--- a/modules/codegen/src/test/scala/tests/core/TypesTest.scala
+++ b/modules/codegen/src/test/scala/tests/core/TypesTest.scala
@@ -25,7 +25,7 @@ class TypesTest extends FunSuite with Matchers with SwaggerSpecRunner {
       |        items:
       |          type: boolean
       |      map:
-      |        type: objet
+      |        type: object
       |        additionalProperties:
       |          type: boolean
       |      obj:
@@ -87,6 +87,7 @@ class TypesTest extends FunSuite with Matchers with SwaggerSpecRunner {
     val definition = q"""
       case class Types(
         array: Option[IndexedSeq[Boolean]] = Option(IndexedSeq.empty),
+        map: Option[Map[String, Boolean]] = Option(Map.empty),
         obj: Option[io.circe.Json] = None,
         bool: Option[Boolean] = None,
         string: Option[String] = None,
@@ -110,9 +111,9 @@ class TypesTest extends FunSuite with Matchers with SwaggerSpecRunner {
       object Types {
         implicit val encodeTypes: ObjectEncoder[Types] = {
           val readOnlyKeys = Set[String]()
-          Encoder.forProduct17("array", "obj", "bool", "string", "date", "date_time", "long", "int", "float", "double", "number", "integer", "untyped", "custom", "customComplex", "nested", "nestedArray")((o: Types) => (o.array, o.obj, o.bool, o.string, o.date, o.date_time, o.long, o.int, o.float, o.double, o.number, o.integer, o.untyped, o.custom, o.customComplex, o.nested, o.nestedArray)).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
+          Encoder.forProduct18("array", "map", "obj", "bool", "string", "date", "date_time", "long", "int", "float", "double", "number", "integer", "untyped", "custom", "customComplex", "nested", "nestedArray")((o: Types) => (o.array, o.map, o.obj, o.bool, o.string, o.date, o.date_time, o.long, o.int, o.float, o.double, o.number, o.integer, o.untyped, o.custom, o.customComplex, o.nested, o.nestedArray)).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
         }
-        implicit val decodeTypes: Decoder[Types] = Decoder.forProduct17("array", "obj", "bool", "string", "date", "date_time", "long", "int", "float", "double", "number", "integer", "untyped", "custom", "customComplex", "nested", "nestedArray")(Types.apply _)
+        implicit val decodeTypes: Decoder[Types] = Decoder.forProduct18("array", "map", "obj", "bool", "string", "date", "date_time", "long", "int", "float", "double", "number", "integer", "untyped", "custom", "customComplex", "nested", "nestedArray")(Types.apply _)
 
         case class Nested(prop1: Option[String] = None)
         object Nested {

--- a/modules/sample/src/main/resources/additional-properties.yaml
+++ b/modules/sample/src/main/resources/additional-properties.yaml
@@ -5,6 +5,22 @@ info:
 paths: {}
 components:
   schemas:
+    SimpleMap:
+      type: object
+      required:
+        - simple_obj
+        - simple_str
+      properties:
+        simple_obj:
+          type: object
+          additionalProperties:
+            type: object
+        simple_str:
+          type: object
+          additionalProperties:
+            type: string
+        just_obj:
+          type: object
     FooMapValues:
       type: object
       required:


### PR DESCRIPTION
The core doesn't really know how to emit objects like that (so it doesn't, and we end up with a compile error when building the generated classes).  At any rate, if there's a bare `object` type without any
properties, our assumption is that the user is expected to populate it with whatever data is applicable: arbitrary key/value pairs, primitive types, whatever; so in this case we should just use `objectType()` (`io.cire.Json` or Jackson `JsonNode`).

Issue introduced in https://github.com/twilio/guardrail/pull/356 -- unfortunately at the time we didn't have a specific test for this, so no surprise we didn't catch it.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
