### PR TITLE
issue-329: binary support for http4s

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,8 @@ val exampleCases: List[ExampleCase] = List(
   ExampleCase(sampleResource("server1.yaml"), "tracer").args("--tracing"),
   ExampleCase(sampleResource("server2.yaml"), "tracer").args("--tracing"),
   ExampleCase(sampleResource("pathological-parameters.yaml"), "pathological"),
-  ExampleCase(sampleResource("response-headers.yaml"), "responseHeaders")
+  ExampleCase(sampleResource("response-headers.yaml"), "responseHeaders"),
+  ExampleCase(sampleResource("binary.yaml"), "binary").frameworks(Set("http4s")),
 )
 
 val exampleFrameworkSuites = Map(
@@ -89,10 +90,11 @@ val exampleFrameworkSuites = Map(
 
 def exampleArgs(language: String): List[List[String]] = exampleCases
   .foldLeft(List[List[String]](List(language)))({
-    case (acc, ExampleCase(path, prefix, extra)) =>
+    case (acc, ExampleCase(path, prefix, extra, onlyFrameworks)) =>
       acc ++ (for {
         frameworkSuite <- exampleFrameworkSuites(language)
         (frameworkName, frameworkPackage, kinds) = frameworkSuite
+        if onlyFrameworks.forall(_.contains(frameworkName))
         kind <- kinds
         filteredExtra = extra.filterNot(if (language == "java") _ == "--tracing" else Function.const(false) _)
       } yield

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/CirceProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/CirceProtocolGenerator.scala
@@ -108,7 +108,7 @@ object CirceProtocolGenerator {
           case _ => Target.pure(None)
         }).map(_.map(_.asScala.toList).toList.flatten)
 
-      case TransformProperty(clsName, name, property, meta, needCamelSnakeConversion, concreteTypes, isRequired) =>
+      case TransformProperty(clsName, name, property, meta, needCamelSnakeConversion, concreteTypes, isRequired, isCustomType) =>
         Target.log.function(s"transformProperty")(for {
           _ <- Target.log.debug(s"Args: (${clsName}, ${name}, ...)")
 
@@ -146,6 +146,9 @@ object CirceProtocolGenerator {
           dataRedaction = DataRedaction(property).getOrElse(DataVisible)
 
           (tpe, classDep) = meta match {
+            case SwaggerUtil.Resolved(declType, classDep, _, Some(rawType), rawFormat) if SwaggerUtil.isFile(rawType, rawFormat) && !isCustomType =>
+              // assume that binary data are represented as a string. allow users to override.
+              (t"String", classDep)
             case SwaggerUtil.Resolved(declType, classDep, _, _, _) =>
               (declType, classDep)
             case SwaggerUtil.Deferred(tpeName) =>

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sHelper.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sHelper.scala
@@ -10,27 +10,34 @@ object Http4sHelper {
   def generateResponseDefinitions(operationId: String,
                                   responses: Responses[ScalaLanguage],
                                   protocolElems: List[StrictProtocolElems[ScalaLanguage]]): List[Defn] = {
+    val isGeneric                         = isDefinitionGeneric(responses)
+    val extraTypes: List[Type]            = if (isGeneric) List(t"F") else Nil
+    val extraTypeParams: List[Type.Param] = if (isGeneric) List(tparam"F[_]") else Nil
+
     val responseSuperType     = Type.Name(s"${operationId.capitalize}Response")
     val responseSuperTerm     = Term.Name(s"${operationId.capitalize}Response")
-    val responseSuperTemplate = template"${Init(responseSuperType, Name(""), List.empty)}"
+    val responseSuperTemplate = template"${Init(if (isGeneric) Type.Apply(responseSuperType, extraTypes) else responseSuperType, Name(""), List.empty)}"
 
     val (terms, foldPair) = responses.value
       .map({
         case Response(statusCodeName, valueType, headers) =>
-          val responseTerm   = Term.Name(s"${statusCodeName.value}")
-          val responseName   = Type.Name(s"${statusCodeName.value}")
+          val responseTerm = Term.Name(s"${statusCodeName.value}")
+          val responseName = Type.Name(s"${statusCodeName.value}")
+
           val foldHandleName = Term.Name(s"handle${statusCodeName.value}")
 
           val allParams = valueType.map(tpe => (tpe, q"value")).toList ++ headers.value.map(h => (h.tpe, h.term))
           allParams match {
-            case Nil =>
+            case Nil if !isGeneric =>
               val foldParameter = param"${foldHandleName}: => A"
               val foldCase      = p"case ${responseSuperTerm}.${responseTerm} => ${foldHandleName}"
               (q"case object $responseTerm extends $responseSuperTemplate", (foldParameter, foldCase))
             case _ =>
-              val foldParameter = param"${foldHandleName}: (..${allParams.map(_._1)}) => A"
-              val foldCase      = p"case x: ${responseSuperTerm}.${responseName} => ${foldHandleName}(..${allParams.map(t => q"x.${t._2}")})"
-              (q"case class  $responseName(..${allParams.map(t => param"${t._2}: ${t._1}")}) extends $responseSuperTemplate", (foldParameter, foldCase))
+              val responseCaseType = if (isGeneric) t"$responseSuperTerm.$responseName[F]" else t"$responseSuperTerm.$responseName"
+              val foldParameter    = param"${foldHandleName}: (..${allParams.map(_._1)}) => A"
+              val foldCase         = p"case x: $responseCaseType => ${foldHandleName}(..${allParams.map(t => q"x.${t._2}")})"
+              (q"case class  $responseName[..$extraTypeParams](..${allParams.map(t => param"${t._2}: ${t._1}")}) extends $responseSuperTemplate",
+               (foldParameter, foldCase))
           }
       })
       .unzip
@@ -43,15 +50,12 @@ object Http4sHelper {
             }
           """
 
-    List[Defn](
-      q"""
-        sealed abstract class ${responseSuperType} {
+    val cls = q"""
+        sealed abstract class ${responseSuperType}[..$extraTypeParams] {
           def fold[A](..${foldParams}): A = ${Term.Match(Term.This(Name("")), foldCases)}
         }
       """
-    ) ++ List[Defn](
-      companion
-    )
+    List[Defn](cls, companion)
   }
 
   def generateDecoder(tpe: Type, consumes: Seq[RouteMeta.ContentType]): Term =
@@ -59,7 +63,6 @@ object Http4sHelper {
       q"jsonOf[F, $tpe]"
     else
       tpe match {
-        case t"String"     => q"EntityDecoder[F, String]"
         case t"Option[$_]" => q"""
                   decodeBy(MediaType.text.plain) { msg =>
                     msg.contentLength.filter(_ > 0).fold[DecodeResult[F, $tpe]](DecodeResult.success(None)){ _ =>
@@ -73,15 +76,7 @@ object Http4sHelper {
                     }
                   }
                 """
-        case _             => q"""
-                  EntityDecoder[F, String].flatMapR[$tpe] { str =>
-                    Json.fromString(str).as[$tpe]
-                      .fold(failure =>
-                        DecodeResult.failure(InvalidMessageBodyFailure(s"Could not decode response: $$str", Some(failure))),
-                        DecodeResult.success(_)
-                      )
-                  }
-                """
+        case _             => q"EntityDecoder[F, $tpe]"
       }
 
   def generateEncoder(tpe: Type, produces: Seq[RouteMeta.ContentType]): Term =
@@ -89,13 +84,12 @@ object Http4sHelper {
       q"jsonEncoderOf[F, $tpe]"
     else
       tpe match {
-        case t"String"     => q"EntityEncoder[F, String]"
         case t"Option[$_]" => q"""
                   encodeBy(`Content-Type`(MediaType.text.plain, Charset.`UTF-8`)) { a: $tpe =>
                     a.fold[Entity[F]](Entity.empty)(e => EntityEncoder[F, String].toEntity(e.toString))
                   }
                 """
-        case _             => q"EntityEncoder[F, String].contramap[$tpe](_.toString)"
+        case _             => q"EntityEncoder[F, $tpe]"
       }
 
   def generateEntityResponseGenerator(term: Term.Ref): Term =
@@ -104,4 +98,15 @@ object Http4sHelper {
           def status = $term
        }
      """
+
+  def isDefinitionGeneric(responses: Responses[ScalaLanguage]): Boolean =
+    responses.value.exists { response =>
+      response.value.exists {
+        case (tpe, _) =>
+          tpe match {
+            case t"fs2.Stream[F,Byte]" => true
+            case _                     => false
+          }
+      }
+    }
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
@@ -738,7 +738,7 @@ object JacksonGenerator {
           case _ => Target.pure(None)
         }).map(_.map(_.asScala.toList).toList.flatten)
 
-      case TransformProperty(clsName, name, property, meta, needCamelSnakeConversion, concreteTypes, isRequired) =>
+      case TransformProperty(clsName, name, property, meta, needCamelSnakeConversion, concreteTypes, isRequired, _) =>
         Target.log.function("transformProperty") {
           for {
             defaultValue <- property match {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerm.scala
@@ -13,7 +13,8 @@ case class TransformProperty[L <: LA](clsName: String,
                                       meta: ResolvedType[L],
                                       needCamelSnakeConversion: Boolean,
                                       concreteTypes: List[PropMeta[L]],
-                                      isRequired: Boolean)
+                                      isRequired: Boolean,
+                                      isCustomType: Boolean)
     extends ModelProtocolTerm[L, ProtocolParameter[L]]
 case class RenderDTOClass[L <: LA](clsName: String, params: List[ProtocolParameter[L]], parents: List[SuperClass[L]] = Nil)
     extends ModelProtocolTerm[L, L#ClassDefinition]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerms.scala
@@ -14,9 +14,10 @@ class ModelProtocolTerms[L <: LA, F[_]](implicit I: InjectK[ModelProtocolTerm[L,
       name: String,
       prop: Schema[_],
       meta: ResolvedType[L],
-      isRequired: Boolean
+      isRequired: Boolean,
+      isCustomType: Boolean
   ): Free[F, ProtocolParameter[L]] =
-    Free.inject[ModelProtocolTerm[L, ?], F](TransformProperty[L](clsName, name, prop, meta, needCamelSnakeConversion, concreteTypes, isRequired))
+    Free.inject[ModelProtocolTerm[L, ?], F](TransformProperty[L](clsName, name, prop, meta, needCamelSnakeConversion, concreteTypes, isRequired, isCustomType))
   def renderDTOClass(clsName: String, terms: List[ProtocolParameter[L]], parents: List[SuperClass[L]] = Nil): Free[F, L#ClassDefinition] =
     Free.inject[ModelProtocolTerm[L, ?], F](RenderDTOClass[L](clsName, terms, parents))
   def encodeModel(clsName: String,

--- a/modules/codegen/src/test/scala/core/issues/Issue255.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue255.scala
@@ -20,6 +20,9 @@ class Issue255 extends FunSuite with Matchers with SwaggerSpecRunner {
                            |  Foo:
                            |    type: object
                            |    properties:
+                           |      someEmail:
+                           |        type: string
+                           |        format: email
                            |      somePassword:
                            |        type: string
                            |        format: password
@@ -28,6 +31,9 @@ class Issue255 extends FunSuite with Matchers with SwaggerSpecRunner {
                            |      someBinary:
                            |        type: string
                            |        format: binary
+                           |      someCustomBinary:
+                           |        type: file
+                           |        x-scala-type: custom.Bytes
                            |""".stripMargin
 
   test("Test password format generation") {
@@ -37,6 +43,14 @@ class Issue255 extends FunSuite with Matchers with SwaggerSpecRunner {
       _
     ) = runSwaggerSpec(swagger)(Context.empty, Http4s)
 
-    c1.structure shouldBe q"case class Foo(somePassword: Option[String] = None, someFile: Option[java.io.File] = None, someBinary: Option[java.io.File] = None)".structure
+    val expected =
+      q"""
+        case class Foo(someEmail: Option[String] = None,
+                       somePassword: Option[String] = None,
+                       someFile: Option[String] = None,
+                       someBinary: Option[String] = None,
+                       someCustomBinary: Option[custom.Bytes] = None)
+       """
+    c1.structure shouldBe expected.structure
   }
 }

--- a/modules/codegen/src/test/scala/swagger/VendorExtensionTest.scala
+++ b/modules/codegen/src/test/scala/swagger/VendorExtensionTest.scala
@@ -15,6 +15,8 @@ class VendorExtensionTest extends FunSuite with Matchers {
   val spec: String = s"""
     |swagger: '2.0'
     |host: petstore.swagger.io
+    |produces:
+    | - application/json
     |x-scala-garbage: io.swagger.models.Swagger
     |paths:
     |  foo:

--- a/modules/codegen/src/test/scala/tests/core/DereferencingAliasesSpec.scala
+++ b/modules/codegen/src/test/scala/tests/core/DereferencingAliasesSpec.scala
@@ -15,6 +15,10 @@ class DereferencingAliasesSpec extends FunSuite with Matchers with SwaggerSpecRu
     |  title: Whatever
     |  version: 1.0.0
     |host: localhost:1234
+    |consumes:
+    | - application/json
+    |produces:
+    | - application/json
     |paths:
     |  /foo:
     |    post:

--- a/modules/codegen/src/test/scala/tests/generators/http4s/BasicTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/http4s/BasicTest.scala
@@ -127,9 +127,7 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
           .get(header.ci)
           .map(_.value).fold[F[String]](F.raiseError(ParseFailure("Missing required header.", s"HTTP header '$$header' is not present.")))(F.pure)
 
-      val getBazOkDecoder = EntityDecoder[F, String].flatMapR[io.circe.Json] {
-        str => Json.fromString(str).as[io.circe.Json].fold(failure => DecodeResult.failure(InvalidMessageBodyFailure(s"Could not decode response: $$str", Some(failure))), DecodeResult.success(_))
-      }
+      private[this] val getBazOkDecoder = EntityDecoder[F, io.circe.Json]
       def getBar(headers: List[Header] = List.empty): F[GetBarResponse] = {
         val allHeaders = headers ++ List[Option[Header]]().flatten
         val req = Request[F](method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/bar"), headers = Headers(allHeaders))
@@ -145,7 +143,7 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
         val req = Request[F](method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/baz"), headers = Headers(allHeaders))
         httpClient.fetch(req)({
           case Ok(resp) =>
-            F.map(getBazOkDecoder.decode(resp, strict = false).value.flatMap(F.fromEither))(GetBazResponse.Ok)
+            F.map(getBazOkDecoder.decode(resp, strict = false).value.flatMap(F.fromEither))(GetBazResponse.Ok.apply)
           case resp =>
             F.raiseError(UnexpectedStatus(resp.status))
         })

--- a/modules/codegen/src/test/scala/tests/generators/http4s/client/DefaultParametersTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/http4s/client/DefaultParametersTest.scala
@@ -144,13 +144,13 @@ class DefaultParametersTest extends FunSuite with Matchers with SwaggerSpecRunne
         response.headers
           .get(header.ci)
           .map(_.value).fold[F[String]](F.raiseError(ParseFailure("Missing required header.", s"HTTP header '$$header' is not present.")))(F.pure)
-      val getOrderByIdOkDecoder = jsonOf[F, Order]
+      private[this] val getOrderByIdOkDecoder = jsonOf[F, Order]
       def getOrderById(orderId: Long, defparmOpt: Option[Int] = Option(1), defparm: Int = 2, headerMeThis: String, headers: List[Header] = List.empty): F[GetOrderByIdResponse] = {
         val allHeaders = headers ++ List[Option[Header]](Some(Header("HeaderMeThis", Formatter.show(headerMeThis)))).flatten
         val req = Request[F](method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/store/order/" + Formatter.addPath(orderId) + "?" + Formatter.addArg("defparm_opt", defparmOpt) + Formatter.addArg("defparm", defparm)), headers = Headers(allHeaders))
         httpClient.fetch(req)({
           case Ok(resp) =>
-            F.map(getOrderByIdOkDecoder.decode(resp, strict = false).value.flatMap(F.fromEither))(GetOrderByIdResponse.Ok)
+            F.map(getOrderByIdOkDecoder.decode(resp, strict = false).value.flatMap(F.fromEither))(GetOrderByIdResponse.Ok.apply)
           case BadRequest(_) =>
             F.pure(GetOrderByIdResponse.BadRequest)
           case NotFound(_) =>

--- a/modules/sample/src/main/resources/alias.yaml
+++ b/modules/sample/src/main/resources/alias.yaml
@@ -8,6 +8,10 @@ paths:
     post:
       operationId: doFoo
       x-jvm-package: foo
+      consumes:
+        - application/json
+      produces:
+        - application/json
       parameters:
       - in: query
         name: long

--- a/modules/sample/src/main/resources/binary.yaml
+++ b/modules/sample/src/main/resources/binary.yaml
@@ -1,0 +1,54 @@
+swagger: "2.0"
+info:
+  title: Whatever
+  version: 1.0.0
+host: localhost:1234
+schemes:
+  - http
+paths:
+  /foo:
+    post:
+      operationId: foo
+      parameters:
+      - name: payload
+        in: body
+        schema:
+          type: string
+          format: binary
+        required: true
+      responses:
+        '200':
+          schema:
+            type: file
+  /fooArray:
+    post:
+      operationId: fooArray
+      parameters:
+        - name: payload
+          in: body
+          schema:
+            type: string
+            format: binary
+            x-scala-type: Array[Byte]
+          required: true
+      responses:
+        '200':
+          schema:
+            type: file
+            x-scala-type: Array[Byte]
+  /fooChunk:
+    post:
+      operationId: fooChunk
+      parameters:
+        - name: payload
+          in: body
+          schema:
+            type: string
+            format: binary
+            x-scala-type: fs2.Chunk[Byte]
+          required: true
+      responses:
+        '200':
+          schema:
+            type: file
+            x-scala-type: fs2.Chunk[Byte]

--- a/modules/sample/src/main/resources/issues/issue148.yaml
+++ b/modules/sample/src/main/resources/issues/issue148.yaml
@@ -8,6 +8,8 @@ paths:
       operationId: createFoo
       consumes:
         - application/json
+      produces:
+        - application/json
       parameters:
         - in: header
           name: x-header
@@ -31,6 +33,8 @@ paths:
       operationId: updateFoo
       consumes:
         - multipart/form-data
+      produces:
+        - application/json
       parameters:
         - in: formData
           name: foo

--- a/modules/sample/src/main/resources/petstore.json
+++ b/modules/sample/src/main/resources/petstore.json
@@ -579,6 +579,9 @@
         "summary": "Place an order for a pet",
         "description": "",
         "operationId": "placeOrder",
+        "consumes": [
+          "application/json"
+        ],
         "produces": [
           "application/xml",
           "application/json"
@@ -689,6 +692,9 @@
         "summary": "Create user",
         "description": "This can only be done by the logged in user.",
         "operationId": "createUser",
+        "consumes": [
+          "application/json"
+        ],
         "produces": [
           "application/xml",
           "application/json"
@@ -720,6 +726,9 @@
         "summary": "Creates list of users with given input array",
         "description": "",
         "operationId": "createUsersWithArrayInput",
+        "consumes": [
+          "application/json"
+        ],
         "produces": [
           "application/xml",
           "application/json"
@@ -754,6 +763,9 @@
         "summary": "Creates list of users with given input array",
         "description": "",
         "operationId": "createUsersWithListInput",
+        "consumes": [
+          "application/json"
+        ],
         "produces": [
           "application/xml",
           "application/json"
@@ -899,6 +911,9 @@
         "summary": "Updated user",
         "description": "This can only be done by the logged in user.",
         "operationId": "updateUser",
+        "consumes": [
+          "application/json"
+        ],
         "produces": [
           "application/xml",
           "application/json"

--- a/modules/sample/src/main/resources/polymorphism-mapped.yaml
+++ b/modules/sample/src/main/resources/polymorphism-mapped.yaml
@@ -2,6 +2,10 @@ openapi: 3.0.1
 info:
   version: 1.0.0
 paths: {}
+produces:
+  - application/json
+consumes:
+  - application/json
 components:
   schemas:
     Base:

--- a/modules/sample/src/main/resources/polymorphism.yaml
+++ b/modules/sample/src/main/resources/polymorphism.yaml
@@ -2,6 +2,10 @@ swagger: '2.0'
 info:
   title: Parsing Error Sample
   version: 1.0.0
+produces:
+  - application/json
+consumes:
+  - application/json
 paths:
   /pet/{name}:
     get:

--- a/modules/sample/src/main/resources/raw-response.yaml
+++ b/modules/sample/src/main/resources/raw-response.yaml
@@ -3,6 +3,8 @@ info:
   title: Whatever
   version: 1.0.0
 host: localhost:1234
+produces:
+  - application/json
 paths:
   /foo:
     post:

--- a/project/src/main/scala/ExampleCase.scala
+++ b/project/src/main/scala/ExampleCase.scala
@@ -1,9 +1,10 @@
 package com.twilio.guardrail.sbt
 
-class ExampleCase(val file: java.io.File, val prefix: String, val cliArgs: List[String]) {
-  def args(cliArgs: String*): ExampleCase = new ExampleCase(file, prefix, cliArgs=cliArgs.toList)
+class ExampleCase(val file: java.io.File, val prefix: String, val cliArgs: List[String],val frameworks: Option[Set[String]]) {
+  def args(cliArgs: String*): ExampleCase = new ExampleCase(file, prefix, cliArgs=cliArgs.toList, frameworks = frameworks)
+  def frameworks(frameworks: Set[String]): ExampleCase = new ExampleCase(file,prefix,cliArgs,Some(frameworks))
 }
 object ExampleCase {
-  def apply(file: java.io.File, prefix: String): ExampleCase = new ExampleCase(file, prefix, List.empty)
-  def unapply(value: ExampleCase): Option[(java.io.File, String, List[String])] = Option((value.file, value.prefix, value.cliArgs))
+  def apply(file: java.io.File, prefix: String): ExampleCase = new ExampleCase(file, prefix, List.empty, None)
+  def unapply(value: ExampleCase): Option[(java.io.File, String, List[String],Option[Set[String]])] = Option((value.file, value.prefix, value.cliArgs, value.frameworks))
 }


### PR DESCRIPTION
This PR solves #329 for http4s and somehow also improves situation mentioned in #255. 

To sum up all the changes done:
- We now use `fs2.Stream[F, Byte]` as a default binary data representation instead of `java.io.File`
  - this somehow unifies binary data handling as some parts of generated code were already using `fs2.Stream[F, Byte]`  while some were using `java.io.File`.
  - It means that response definition classes must be generic with `F[_]`. This generic parameter is added only when needed.
  - When generating a client, we need to return `Resource[F, Something[F]]` instead of just `F[Something[F]]`. Again, `Resource` is only used when we determine it's really needed.
  - Users can still provide custom type via `x-scala-type`, such as `Array[Byte]` or `fs2.Chunk[Byte]`. In those cases, we don't need generic response class definitions, nor `Resource` return type for a client.
- I have removed `EntityEncoder[F, String].contramap[$tpe](_.toString)` and `EntityDecoder[F, String].flatMapR[$tpe]...`. I believe that the former is almost always incorrect and the later might be usefully in some specific cases, but seems to me as a ugly hack. I think that the correct way not to implement any kind of `EntityEncoder`/`EntityDecoder` and let the user implement it.
- A lot of tests were missing `produces`/`consumes` definitions. Fixed that with explicit `application/json`. 
- I also modified `testSuite` in a way that allows us to test given file only for a specific set of frameworks.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
