### PR TITLE
Issue 405 Fix regression in empty string Form param handling in AkkaHttpServer 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,6 +63,7 @@ val exampleCases: List[ExampleCase] = List(
   ExampleCase(sampleResource("issues/issue351.yaml"), "issues.issue351"),
   ExampleCase(sampleResource("issues/issue357.yaml"), "issues.issue357"),
   ExampleCase(sampleResource("issues/issue364.yaml"), "issues.issue364").args("--dtoPackage", "some.thing"),
+  ExampleCase(sampleResource("issues/issue405.yaml"), "issues.issue405"),
   ExampleCase(sampleResource("multipart-form-data.yaml"), "multipartFormData"),
   ExampleCase(sampleResource("petstore.json"), "examples").args("--import", "support.PositiveLong"),
   ExampleCase(sampleResource("plain.json"), "tests.dtos"),

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
@@ -569,7 +569,6 @@ object AkkaHttpServerGenerator {
 
               case RouteMeta.UrlencodedFormData => {
                 val unmarshallerTerm = q"FormDataUnmarshaller"
-//              unmarshaller.andThen(jsonDecoderUnmarshaller[A]).apply(value).recoverWith({
                 val fru = q"""
                   implicit val ${Pat.Var(unmarshallerTerm)}: FromRequestUnmarshaller[Either[Throwable, ${optionalTypes}]] =
                     implicitly[FromRequestUnmarshaller[FormData]].flatMap { implicit executionContext => implicit mat => formData =>

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
@@ -569,11 +569,12 @@ object AkkaHttpServerGenerator {
 
               case RouteMeta.UrlencodedFormData => {
                 val unmarshallerTerm = q"FormDataUnmarshaller"
+//              unmarshaller.andThen(jsonDecoderUnmarshaller[A]).apply(value).recoverWith({
                 val fru = q"""
                   implicit val ${Pat.Var(unmarshallerTerm)}: FromRequestUnmarshaller[Either[Throwable, ${optionalTypes}]] =
                     implicitly[FromRequestUnmarshaller[FormData]].flatMap { implicit executionContext => implicit mat => formData =>
                       def unmarshalField[A: Decoder](name: String, value: String, unmarshaller: Unmarshaller[String, io.circe.Json]): Future[A] =
-                        contentRequiredUnmarshaller.andThen(unmarshaller.andThen(jsonDecoderUnmarshaller[A])).apply(value).recoverWith({
+                        unmarshaller.andThen(jsonDecoderUnmarshaller[A]).apply(value).recoverWith({
                           case ex =>
                             Future.failed(RejectionError(MalformedFormFieldRejection(name, ex.getMessage, Some(ex))))
                         })

--- a/modules/sample-akkaHttp/src/test/scala/core/issues/Issue405.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/issues/Issue405.scala
@@ -1,0 +1,73 @@
+package core.issues
+
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.server.RejectionHandler
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.SpanSugar._
+import org.scalatest.{EitherValues, FunSuite, Matchers}
+import akka.http.scaladsl.server.Directives.complete
+
+import scala.concurrent.Future
+
+/** Changes
+  *
+  * - Required String form param should accept empty string
+  * - Option String for param should accept emtpy string
+  */
+class Issue405 extends FunSuite with Matchers with EitherValues with ScalaFutures with ScalatestRouteTest {
+  override implicit val patienceConfig = PatienceConfig(10 seconds, 1 second)
+
+  test("Empty string for a required form param should parse as empty string") {
+    import issues.issue405.server.akkaHttp.{ Handler, Resource }
+    import issues.issue405.server.akkaHttp.definitions._
+
+    implicit def rejectionHandler =
+      RejectionHandler.newBuilder()
+        .handle { case rej =>
+          complete(HttpResponse(StatusCodes.BadRequest, entity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, s"Request failed with $rej")))
+        }
+        .result()
+
+    val route = Resource.routes(new Handler {
+      override def foo(respond: Resource.fooResponse.type)(bar: String, baz: Option[String]): Future[Resource.fooResponse] =
+        Future.successful(respond.NoContent)
+    })
+
+    /* Pass empty string to required Bar param */
+    Post("/Foo")
+      .withEntity(
+        Multipart
+          .FormData(
+            Multipart.FormData.BodyPart.Strict("Bar", "")
+          )
+          .toEntity
+      ) ~> route ~> check {
+      response.status shouldBe (StatusCodes.NoContent)
+    }
+  }
+
+  test("Empty string for an optional form param should parse as empty string") {
+    import issues.issue405.server.akkaHttp.{ Handler, Resource }
+    import issues.issue405.server.akkaHttp.definitions._
+
+    val route = Resource.routes(new Handler {
+      override def foo(respond: Resource.fooResponse.type)(bar: String, baz: Option[String]): Future[Resource.fooResponse] =
+        baz
+          .map(_ => Future.successful(respond.NoContent))
+          .getOrElse(Future.failed(new Exception("Baz was parsed as None")))
+    })
+
+    /* Pass empty string to required Bar param */
+    Post("/Foo")
+      .withEntity(
+        Multipart
+          .FormData(
+            Multipart.FormData.BodyPart.Strict("Baz", "")
+          )
+          .toEntity
+      ) ~> route ~> check {
+      response.status shouldBe (StatusCodes.NoContent)
+    }
+  }
+}

--- a/modules/sample-akkaHttp/src/test/scala/core/issues/Issue405.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/issues/Issue405.scala
@@ -1,11 +1,11 @@
 package core.issues
 
 import akka.http.scaladsl.model._
-import akka.http.scaladsl.server.{RejectionHandler, Route}
+import akka.http.scaladsl.server.{ RejectionHandler, Route }
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.SpanSugar._
-import org.scalatest.{EitherValues, FunSuite, Matchers}
+import org.scalatest.{ EitherValues, FunSuite, Matchers }
 import akka.http.scaladsl.model.FormData
 import akka.http.scaladsl.server.Directives.complete
 
@@ -19,9 +19,13 @@ import scala.concurrent.Future
 class Issue405 extends FunSuite with Matchers with EitherValues with ScalaFutures with ScalatestRouteTest {
   override implicit val patienceConfig = PatienceConfig(10 seconds, 1 second)
 
-  implicit val rejectionHandler: RejectionHandler = RejectionHandler.newBuilder().handle { case rej =>
-    complete(HttpResponse(StatusCodes.BadRequest, entity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, s"Request failed with $rej")))
-  }.result()
+  implicit val rejectionHandler: RejectionHandler = RejectionHandler
+    .newBuilder()
+    .handle {
+      case rej =>
+        complete(HttpResponse(StatusCodes.BadRequest, entity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, s"Request failed with $rej")))
+    }
+    .result()
 
   test("Empty string for a required form param should parse as empty string") {
     import issues.issue405.server.akkaHttp.{ Handler, Resource }

--- a/modules/sample-akkaHttp/src/test/scala/core/issues/Issue405.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/issues/Issue405.scala
@@ -31,7 +31,7 @@ class Issue405 extends FunSuite with Matchers with EitherValues with ScalaFuture
 
     val route = Resource.routes(new Handler {
       override def foo(respond: Resource.fooResponse.type)(bar: String, baz: Option[String]): Future[Resource.fooResponse] =
-        Future.successful(respond.NoContent)
+        Future.successful(respond.OK(s"Bar is '$bar'"))
     })
 
     /* Pass empty string to required Bar param */
@@ -43,7 +43,8 @@ class Issue405 extends FunSuite with Matchers with EitherValues with ScalaFuture
           )
           .toEntity
       ) ~> route ~> check {
-      response.status shouldBe (StatusCodes.NoContent)
+      response.status shouldBe (StatusCodes.OK)
+      response.entity.asInstanceOf[String] shouldBe "Bar is ''"
     }
   }
 
@@ -52,10 +53,10 @@ class Issue405 extends FunSuite with Matchers with EitherValues with ScalaFuture
     import issues.issue405.server.akkaHttp.definitions._
 
     val route = Resource.routes(new Handler {
-      override def foo(respond: Resource.fooResponse.type)(bar: String, baz: Option[String]): Future[Resource.fooResponse] =
-        baz
-          .map(_ => Future.successful(respond.NoContent))
-          .getOrElse(Future.failed(new Exception("Baz was parsed as None")))
+      override def foo(respond: Resource.fooResponse.type)(bar: String, baz: Option[String]): Future[Resource.fooResponse] = {
+        val msg = baz.map(s => s"present: '$s'").getOrElse("missing")
+        Future.successful(respond.OK(s"Baz is $msg"))
+      }
     })
 
     /* Pass empty string to required Bar param */
@@ -67,7 +68,8 @@ class Issue405 extends FunSuite with Matchers with EitherValues with ScalaFuture
           )
           .toEntity
       ) ~> route ~> check {
-      response.status shouldBe (StatusCodes.NoContent)
+      response.status shouldBe (StatusCodes.OK)
+      response.entity.asInstanceOf[String] shouldBe "Baz is present: ''"
     }
   }
 }

--- a/modules/sample-akkaHttp/src/test/scala/core/issues/Issue405.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/issues/Issue405.scala
@@ -1,11 +1,12 @@
 package core.issues
 
 import akka.http.scaladsl.model._
-import akka.http.scaladsl.server.RejectionHandler
+import akka.http.scaladsl.server.{RejectionHandler, Route}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.SpanSugar._
 import org.scalatest.{EitherValues, FunSuite, Matchers}
+import akka.http.scaladsl.model.FormData
 import akka.http.scaladsl.server.Directives.complete
 
 import scala.concurrent.Future
@@ -18,33 +19,23 @@ import scala.concurrent.Future
 class Issue405 extends FunSuite with Matchers with EitherValues with ScalaFutures with ScalatestRouteTest {
   override implicit val patienceConfig = PatienceConfig(10 seconds, 1 second)
 
+  implicit val rejectionHandler: RejectionHandler = RejectionHandler.newBuilder().handle { case rej =>
+    complete(HttpResponse(StatusCodes.BadRequest, entity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, s"Request failed with $rej")))
+  }.result()
+
   test("Empty string for a required form param should parse as empty string") {
     import issues.issue405.server.akkaHttp.{ Handler, Resource }
     import issues.issue405.server.akkaHttp.definitions._
 
-    implicit def rejectionHandler =
-      RejectionHandler.newBuilder()
-        .handle { case rej =>
-          complete(HttpResponse(StatusCodes.BadRequest, entity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, s"Request failed with $rej")))
-        }
-        .result()
-
-    val route = Resource.routes(new Handler {
+    val route = Route.seal(Resource.routes(new Handler {
       override def foo(respond: Resource.fooResponse.type)(bar: String, baz: Option[String]): Future[Resource.fooResponse] =
         Future.successful(respond.OK(s"Bar is '$bar'"))
-    })
+    }))
 
     /* Pass empty string to required Bar param */
-    Post("/Foo")
-      .withEntity(
-        Multipart
-          .FormData(
-            Multipart.FormData.BodyPart.Strict("Bar", "")
-          )
-          .toEntity
-      ) ~> route ~> check {
+    Post("/v1/Foo", FormData(Map("Bar" -> ""))) ~> route ~> check {
       response.status shouldBe (StatusCodes.OK)
-      response.entity.asInstanceOf[String] shouldBe "Bar is ''"
+      responseAs[String] shouldBe "\"Bar is ''\""
     }
   }
 
@@ -52,24 +43,17 @@ class Issue405 extends FunSuite with Matchers with EitherValues with ScalaFuture
     import issues.issue405.server.akkaHttp.{ Handler, Resource }
     import issues.issue405.server.akkaHttp.definitions._
 
-    val route = Resource.routes(new Handler {
+    val route = Route.seal(Resource.routes(new Handler {
       override def foo(respond: Resource.fooResponse.type)(bar: String, baz: Option[String]): Future[Resource.fooResponse] = {
         val msg = baz.map(s => s"present: '$s'").getOrElse("missing")
         Future.successful(respond.OK(s"Baz is $msg"))
       }
-    })
+    }))
 
     /* Pass empty string to required Bar param */
-    Post("/Foo")
-      .withEntity(
-        Multipart
-          .FormData(
-            Multipart.FormData.BodyPart.Strict("Baz", "")
-          )
-          .toEntity
-      ) ~> route ~> check {
+    Post("/v1/Foo", FormData(Map("Bar" -> "whatevs", "Baz" -> ""))) ~> route ~> check {
       response.status shouldBe (StatusCodes.OK)
-      response.entity.asInstanceOf[String] shouldBe "Baz is present: ''"
+      responseAs[String] shouldBe "\"Baz is present: ''\""
     }
   }
 }

--- a/modules/sample/src/main/resources/issues/issue405.yaml
+++ b/modules/sample/src/main/resources/issues/issue405.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.0
+info:
+  title: Test Server
+  version: "1.0"
+servers:
+  - url: http://localhost:8000
+paths:
+  /v1/Foo:
+    post:
+      summary: Test resource
+      operationId: foo
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              properties:
+                Bar:
+                  type: string
+                  description: A required string parameter that should accept empty string
+                Baz:
+                  type: string
+                  description: An optional string parameter that should accept empty string
+              required:
+                - Bar
+      responses:
+        204:
+          description: Success

--- a/modules/sample/src/main/resources/issues/issue405.yaml
+++ b/modules/sample/src/main/resources/issues/issue405.yaml
@@ -23,5 +23,10 @@ paths:
               required:
                 - Bar
       responses:
-        204:
-          description: Success
+        200:
+          description: Ok
+          content:
+              text/plain:
+                schema:
+                  type: string
+


### PR DESCRIPTION
This fixes https://github.com/twilio/guardrail/issues/405 by removing the `contentRequiredUnmarshaller` from the generated form param parsing code. This prevented clients from sending empty string values to String form params which was a regression from earlier versions of guardrail. 

The `contentRequiredUnmarshaller` is not required because for other types, the type specific parser should fail on an empty string input, however for String this should be allowed.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
