### PR TITLE
Fixed handling of nested structures/enums when polymorphism is used

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -70,6 +70,7 @@ val exampleCases: List[ExampleCase] = List(
   ExampleCase(sampleResource("plain.json"), "tests.dtos"),
   ExampleCase(sampleResource("polymorphism.yaml"), "polymorphism"),
   ExampleCase(sampleResource("polymorphism-mapped.yaml"), "polymorphismMapped"),
+  ExampleCase(sampleResource("polymorphism-nested.yaml"), "polymorphismNested"),
   ExampleCase(sampleResource("raw-response.yaml"), "raw"),
   ExampleCase(sampleResource("redaction.yaml"), "redaction"),
   ExampleCase(sampleResource("server1.yaml"), "tracer").args("--tracing"),

--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,7 @@ val exampleCases: List[ExampleCase] = List(
   ExampleCase(sampleResource("plain.json"), "tests.dtos"),
   ExampleCase(sampleResource("polymorphism.yaml"), "polymorphism"),
   ExampleCase(sampleResource("polymorphism-mapped.yaml"), "polymorphismMapped"),
-  ExampleCase(sampleResource("polymorphism-nested.yaml"), "polymorphismNested"),
+  ExampleCase(sampleResource("polymorphism-nested.yaml"), "polymorphismNested").frameworks(Set("akka-http", "endpoints", "http4s")),
   ExampleCase(sampleResource("raw-response.yaml"), "raw"),
   ExampleCase(sampleResource("redaction.yaml"), "redaction"),
   ExampleCase(sampleResource("server1.yaml"), "tracer").args("--tracing"),

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
@@ -238,13 +238,13 @@ object ProtocolGenerator {
       a <- extractSuperClass(elem, definitions)
       supper <- a.flatTraverse {
         case (clsName, _extends, interfaces) =>
-          val concreteInterfaces = interfaces
+          val concreteInterfacesWithClass = interfaces
             .flatMap(
               interface =>
                 definitions
                   .flatMap({
                     case (cls, tracker) =>
-                      tracker
+                      val result = tracker
                         .refine[Tracker[Schema[_]]]({
                           case x: ComposedSchema if interface.downField("$ref", _.get$ref()).exists(_.get.endsWith(s"/${cls}")) => x
                         })(
@@ -252,15 +252,21 @@ object ProtocolGenerator {
                         )
                         .orRefine({ case x: Schema[_] if interface.downField("$ref", _.get$ref()).exists(_.get.endsWith(s"/${cls}")) => x })(identity _)
                         .toOption
+                      result.map(cls -> _)
                   })
                   .headOption
             )
+          val concreteInterfaces = concreteInterfacesWithClass.map(_._2)
+          val classMapping = (for {
+            (cls, schema) <- concreteInterfacesWithClass
+            name          <- schema.get.getProperties.keySet().asScala.toList
+          } yield (name, cls)).toMap
           for {
             _extendsProps <- extractProperties(_extends)
             requiredFields = getRequiredFieldsRec(_extends) ++ concreteInterfaces.flatMap(getRequiredFieldsRec)
             _withProps <- concreteInterfaces.traverse(extractProperties)
             props = _extendsProps ++ _withProps.flatten
-            (params, _) <- prepareProperties(NonEmptyList.of(clsName), props.map(_.map(_.get)), requiredFields, concreteTypes, definitions)
+            (params, _) <- prepareProperties(NonEmptyList.of(clsName), classMapping, props.map(_.map(_.get)), requiredFields, concreteTypes, definitions)
             interfacesCls = interfaces.flatMap(_.downField("$ref", _.get$ref).map(_.map(_.split("/").last)).get)
             tpe <- parseTypeName(clsName)
 
@@ -304,7 +310,7 @@ object ProtocolGenerator {
       props <- extractProperties(model)
       requiredFields           = getRequiredFieldsRec(model)
       needCamelSnakeConversion = props.forall { case (k, _) => couldBeSnakeCase(k) }
-      (params, nestedDefinitions) <- prepareProperties(clsName, props.map(_.map(_.get)), requiredFields, concreteTypes, definitions)
+      (params, nestedDefinitions) <- prepareProperties(clsName, Map.empty, props.map(_.map(_.get)), requiredFields, concreteTypes, definitions)
       defn                        <- renderDTOClass(clsName.last, params, parents)
       encoder                     <- encodeModel(clsName.last, needCamelSnakeConversion, params, parents)
       decoder                     <- decodeModel(clsName.last, needCamelSnakeConversion, params, parents)
@@ -338,6 +344,7 @@ object ProtocolGenerator {
 
   private def prepareProperties[L <: LA, F[_]](
       clsName: NonEmptyList[String],
+      propertyToTypeLookup: Map[String, String],
       props: List[(String, Schema[_])],
       requiredFields: List[String],
       concreteTypes: List[PropMeta[L]],
@@ -351,8 +358,10 @@ object ProtocolGenerator {
     import F._
     import M._
     import Sc._
+    def getClsName(name: String): NonEmptyList[String] = propertyToTypeLookup.get(name).map(NonEmptyList.of(_)).getOrElse(clsName)
+
     def processProperty(name: String, schema: Tracker[Schema[_]]): Free[F, Option[Either[String, NestedProtocolElems[L]]]] = {
-      val nestedClassName = clsName.append(name.toCamelCase.capitalize)
+      val nestedClassName = getClsName(name).append(name.toCamelCase.capitalize)
       schema
         .refine[Free[F, Option[Either[String, NestedProtocolElems[L]]]]]({ case x: ObjectSchema => x })(
           _ => fromModel(nestedClassName, schema, List.empty, concreteTypes, definitions).map(Some(_))
@@ -366,7 +375,9 @@ object ProtocolGenerator {
         )
         .orRefine({ case a: ArraySchema => a })(_.downField("items", _.getItems()).indexedCosequence.flatTraverse(processProperty(name, _)))
         .orRefine({ case s: StringSchema if Option(s.getEnum).map(_.asScala).exists(_.nonEmpty) => s })(
-          s => fromEnum(nestedClassName.last, s.get).map(Some(_))
+          s => {
+            fromEnum(nestedClassName.last, s.get).map(Some(_))
+          }
         )
         .getOrElse(Free.pure[F, Option[Either[String, NestedProtocolElems[L]]]](Option.empty))
     }
@@ -374,7 +385,7 @@ object ProtocolGenerator {
     for {
       paramsAndNestedDefinitions <- props.traverse[Free[F, ?], (ProtocolParameter[L], Option[NestedProtocolElems[L]])] {
         case (name, schema) =>
-          val typeName = clsName.append(name.toCamelCase.capitalize)
+          val typeName = getClsName(name).append(name.toCamelCase.capitalize)
           for {
             tpe                   <- selectType(typeName)
             maybeNestedDefinition <- processProperty(name, Tracker.hackyAdapt(schema, Vector.empty))
@@ -385,12 +396,12 @@ object ProtocolGenerator {
             customType <- SwaggerUtil.customTypeName(schema)
             isRequired = requiredFields.contains(name)
             defValue <- defaultValue(typeName, schema, isRequired, definitions.map(_.map(_.get)))
-            parameter <- transformProperty(clsName.last, needCamelSnakeConversion, concreteTypes)(name,
-                                                                                                  schema,
-                                                                                                  resolvedType,
-                                                                                                  isRequired,
-                                                                                                  customType.isDefined,
-                                                                                                  defValue)
+            parameter <- transformProperty(getClsName(name).last, needCamelSnakeConversion, concreteTypes)(name,
+                                                                                                           schema,
+                                                                                                           resolvedType,
+                                                                                                           isRequired,
+                                                                                                           customType.isDefined,
+                                                                                                           defValue)
           } yield (parameter, maybeNestedDefinition.flatMap(_.toOption))
       }
       (params, nestedDefinitions) = paramsAndNestedDefinitions.unzip

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
@@ -256,7 +256,7 @@ object ProtocolGenerator {
                   })
                   .headOption
             )
-          val concreteInterfaces = concreteInterfacesWithClass.map(_._2)
+          val (_, concreteInterfaces) = concreteInterfacesWithClass.unzip
           val classMapping = (for {
             (cls, schema) <- concreteInterfacesWithClass
             name          <- schema.get.getProperties.keySet().asScala.toList

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
@@ -253,7 +253,7 @@ object ProtocolGenerator {
           val (_, concreteInterfaces) = concreteInterfacesWithClass.unzip
           val classMapping = (for {
             (cls, schema) <- concreteInterfacesWithClass
-            name          <- schema.get.getProperties.keySet().asScala.toList
+            (name, _)     <- schema.downField("properties", _.getProperties).indexedDistribute.value
           } yield (name, cls)).toMap
           for {
             _extendsProps <- extractProperties(_extends)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
@@ -375,9 +375,7 @@ object ProtocolGenerator {
         )
         .orRefine({ case a: ArraySchema => a })(_.downField("items", _.getItems()).indexedCosequence.flatTraverse(processProperty(name, _)))
         .orRefine({ case s: StringSchema if Option(s.getEnum).map(_.asScala).exists(_.nonEmpty) => s })(
-          s => {
-            fromEnum(nestedClassName.last, s.get).map(Some(_))
-          }
+          s => fromEnum(nestedClassName.last, s.get).map(Some(_))
         )
         .getOrElse(Free.pure[F, Option[Either[String, NestedProtocolElems[L]]]](Option.empty))
     }

--- a/modules/sample/src/main/resources/polymorphism-nested.yaml
+++ b/modules/sample/src/main/resources/polymorphism-nested.yaml
@@ -1,0 +1,45 @@
+swagger: '2.0'
+info:
+  title: Polymorphism nested example
+  version: 1.0.0
+produces:
+  - application/json
+paths:
+  /fo:
+    get:
+      operationId: getPet
+      responses:
+        200:
+          description: Return the details about the pet
+          schema:
+            $ref: '#/definitions/TestResponse'
+definitions:
+  TestResponse:
+    allOf:
+      - $ref: '#/definitions/A'
+      - $ref: '#/definitions/B'
+      - $ref: '#/definitions/C'
+  A:
+    type: object
+    properties:
+      enum1:
+        type: string
+        enum:
+          - A
+          - B
+  B:
+    type: object
+    properties:
+      enum2:
+        type: string
+        enum:
+          - C
+          - D
+  C:
+    type: object
+    properties:
+      obj:
+        type: object
+        properties:
+          value:
+            type: string


### PR DESCRIPTION
This fixes an issue that resulted into a code that was not possible to compile.

Essentially a wrong name of companion object was used when nested enum/case class was referenced.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
