### PR TITLE
Fully qualified http status in http4s client

### DIFF
--- a/modules/codegen/src/test/scala/tests/generators/http4s/BasicTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/http4s/BasicTest.scala
@@ -132,7 +132,7 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
         val allHeaders = headers ++ List[Option[Header]]().flatten
         val req = Request[F](method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/bar"), headers = Headers(allHeaders))
         httpClient.fetch(req)({
-          case Ok(_) =>
+          case org.http4s.Status.Ok(_) =>
             F.pure(GetBarResponse.Ok)
           case resp =>
             F.raiseError(UnexpectedStatus(resp.status))
@@ -142,7 +142,7 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
         val allHeaders = headers ++ List[Option[Header]]().flatten
         val req = Request[F](method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/baz"), headers = Headers(allHeaders))
         httpClient.fetch(req)({
-          case Ok(resp) =>
+          case org.http4s.Status.Ok(resp) =>
             F.map(getBazOkDecoder.decode(resp, strict = false).value.flatMap(F.fromEither))(GetBazResponse.Ok.apply)
           case resp =>
             F.raiseError(UnexpectedStatus(resp.status))
@@ -152,7 +152,7 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
         val allHeaders = headers ++ List[Option[Header]]().flatten
         val req = Request[F](method = Method.POST, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders))
         httpClient.fetch(req)({
-          case Ok(_) =>
+          case org.http4s.Status.Ok(_) =>
             F.pure(PostFooResponse.Ok)
           case resp =>
             F.raiseError(UnexpectedStatus(resp.status))
@@ -162,7 +162,7 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
         val allHeaders = headers ++ List[Option[Header]]().flatten
         val req = Request[F](method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders))
         httpClient.fetch(req)({
-          case Ok(_) =>
+          case org.http4s.Status.Ok(_) =>
             F.pure(GetFooResponse.Ok)
           case resp =>
             F.raiseError(UnexpectedStatus(resp.status))
@@ -172,7 +172,7 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
         val allHeaders = headers ++ List[Option[Header]]().flatten
         val req = Request[F](method = Method.PUT, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders))
         httpClient.fetch(req)({
-          case Ok(_) =>
+          case org.http4s.Status.Ok(_) =>
             F.pure(PutFooResponse.Ok)
           case resp =>
             F.raiseError(UnexpectedStatus(resp.status))
@@ -182,7 +182,7 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
         val allHeaders = headers ++ List[Option[Header]]().flatten
         val req = Request[F](method = Method.PATCH, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders))
         httpClient.fetch(req)({
-          case Ok(_) =>
+          case org.http4s.Status.Ok(_) =>
             F.pure(PatchFooResponse.Ok)
           case resp =>
             F.raiseError(UnexpectedStatus(resp.status))
@@ -192,7 +192,7 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
         val allHeaders = headers ++ List[Option[Header]]().flatten
         val req = Request[F](method = Method.DELETE, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders))
         httpClient.fetch(req)({
-          case Ok(_) =>
+          case org.http4s.Status.Ok(_) =>
             F.pure(DeleteFooResponse.Ok)
           case resp =>
             F.raiseError(UnexpectedStatus(resp.status))

--- a/modules/codegen/src/test/scala/tests/generators/http4s/client/DefaultParametersTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/http4s/client/DefaultParametersTest.scala
@@ -149,11 +149,11 @@ class DefaultParametersTest extends FunSuite with Matchers with SwaggerSpecRunne
         val allHeaders = headers ++ List[Option[Header]](Some(Header("HeaderMeThis", Formatter.show(headerMeThis)))).flatten
         val req = Request[F](method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/store/order/" + Formatter.addPath(orderId) + "?" + Formatter.addArg("defparm_opt", defparmOpt) + Formatter.addArg("defparm", defparm)), headers = Headers(allHeaders))
         httpClient.fetch(req)({
-          case Ok(resp) =>
+          case org.http4s.Status.Ok(resp) =>
             F.map(getOrderByIdOkDecoder.decode(resp, strict = false).value.flatMap(F.fromEither))(GetOrderByIdResponse.Ok.apply)
-          case BadRequest(_) =>
+          case org.http4s.Status.BadRequest(_) =>
             F.pure(GetOrderByIdResponse.BadRequest)
-          case NotFound(_) =>
+          case org.http4s.Status.NotFound(_) =>
             F.pure(GetOrderByIdResponse.NotFound)
           case resp => F.raiseError(UnexpectedStatus(resp.status))
         })
@@ -162,9 +162,9 @@ class DefaultParametersTest extends FunSuite with Matchers with SwaggerSpecRunne
         val allHeaders = headers ++ List[Option[Header]]().flatten
         val req = Request[F](method = Method.DELETE, uri = Uri.unsafeFromString(host + basePath + "/store/order/" + Formatter.addPath(orderId)), headers = Headers(allHeaders))
         httpClient.fetch(req)({
-          case BadRequest(_) =>
+          case org.http4s.Status.BadRequest(_) =>
             F.pure(DeleteOrderResponse.BadRequest)
-          case NotFound(_) =>
+          case org.http4s.Status.NotFound(_) =>
             F.pure(DeleteOrderResponse.NotFound)
           case resp => F.raiseError(UnexpectedStatus(resp.status))
         })


### PR DESCRIPTION
Use fully qualified names to avoid conflicts

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
