### PR TITLE
bug fix: use 'camelCase' for Java variable name

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
@@ -16,6 +16,7 @@ import com.twilio.guardrail.{ ADT, ClassDefinition, EnumDefinition, RandomType, 
 import com.twilio.guardrail.extract.ServerRawResponse
 import com.twilio.guardrail.generators.{ ScalaParameter, ScalaParameters }
 import com.twilio.guardrail.generators.syntax.Java._
+import com.twilio.guardrail.generators.syntax.RichString
 import com.twilio.guardrail.languages.JavaLanguage
 import com.twilio.guardrail.protocol.terms.Response
 import com.twilio.guardrail.protocol.terms.server._
@@ -191,7 +192,7 @@ object DropwizardServerGenerator {
 
           val creator = new FieldDeclaration(
             util.EnumSet.of(PUBLIC, STATIC, FINAL),
-            new VariableDeclarator(clsType, clsName, new ObjectCreationExpr(null, clsType, new NodeList))
+            new VariableDeclarator(clsType, clsName.toCamelCase, new ObjectCreationExpr(null, clsType, new NodeList))
           )
 
           (List(constructor), creator)


### PR DESCRIPTION
This fixes a bug in the Java code generator.

I observed a line of code that could not be compiled by the Java compiler:

```
  public static final BadRequest BadRequest = new BadRequest();
```

The Java compiler reports an error because the variable name is the same as the class name.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
