### PR TITLE
Fix build and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,4 @@ jobs:
     - name: print Java version
       run: java -version
     - name: Run tests
-      run:  sbt ++${{ matrix.scala }} checkFormatting scalaTestSuite
+      run:  sbt ++${{ matrix.scala }} checkFormatting testSuite

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ scala:
 # so the release build is always delayed by a full test run unnecessarily.
 script: >
   if ( [[ "$TRAVIS_PULL_REQUEST" != "false" ]] || [[ ! -z "$TRAVIS_TAG" ]] ); then
-    sbt ++$TRAVIS_SCALA_VERSION checkFormatting scalaTestSuite; # TODO enable javaTestSuite
+    sbt ++$TRAVIS_SCALA_VERSION checkFormatting testSuite
   fi
 
 matrix:

--- a/build.sbt
+++ b/build.sbt
@@ -319,6 +319,7 @@ lazy val dropwizardSample = (project in file("modules/sample-dropwizard"))
     ),
     testOptions in Test += Tests.Argument(TestFrameworks.JUnit, "-a", "-v"),
     libraryDependencies ++= Seq(
+      "javax.xml.bind"             %  "jaxb-api"               % jaxbApiVersion, // for jdk11
       "io.dropwizard"              %  "dropwizard-core"        % dropwizardVersion,
       "io.dropwizard"              %  "dropwizard-forms"       % dropwizardVersion,
       "org.asynchttpclient"        %  "async-http-client"      % ahcVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -153,7 +153,7 @@ addCommandAlias("runtimeSuite", "; runtimeScalaSuite ; runtimeJavaSuite")
 addCommandAlias("scalaTestSuite", "; codegen/test ; runtimeScalaSuite")
 addCommandAlias("javaTestSuite", "; codegen/test ; runtimeJavaSuite")
 addCommandAlias("format", "; codegen/scalafmt ; codegen/test:scalafmt ; " + scalaFrameworks.map(x => s"${x}Sample/scalafmt ; ${x}Sample/test:scalafmt").mkString("; "))
-addCommandAlias("checkFormatting", "; codegen/scalafmtCheck ; " + scalaFrameworks.map(x => s"${x}Sample/scalafmtCheck ; ${x}Sample/test:scalafmtCheck").mkString("; "))
+addCommandAlias("checkFormatting", "; codegen/scalafmtCheck ; codegen/test:scalafmtCheck ; " + scalaFrameworks.map(x => s"${x}Sample/scalafmtCheck ; ${x}Sample/test:scalafmtCheck").mkString("; "))
 addCommandAlias("testSuite", "; scalaTestSuite ; javaTestSuite")
 
 addCommandAlias(

--- a/build.sbt
+++ b/build.sbt
@@ -133,15 +133,10 @@ artifact in (Compile, assembly) := {
 
 addArtifact(artifact in (Compile, assembly), assembly)
 
-val resetSample = TaskKey[Unit]("resetSample", "Reset sample module")
 val scalaFrameworks = exampleFrameworkSuites("scala").map(_._2)
 val javaFrameworks = exampleFrameworkSuites("java").map(_._2)
 
-resetSample := {
-  import scala.sys.process._
-  (List("sample") ++ (scalaFrameworks ++ javaFrameworks).map(x => s"sample-${x}"))
-    .foreach(sampleName => s"git clean -fdx modules/${sampleName}/target/generated" !)
-}
+addCommandAlias("resetSample", "; " ++ (scalaFrameworks ++ javaFrameworks).map(x => s"${x}Sample/clean").mkString(" ; "))
 
 // Deprecated command
 addCommandAlias("example", "runtimeSuite")

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -117,13 +117,13 @@ object Common {
     val pkgPath        = resolveFile(outputPath)(pkgName)
     val dtoPackagePath = resolveFile(pkgPath.resolve("definitions"))(dtoPackage)
 
-    val definitions: List[String]   = pkgName :+ "definitions"
+    val definitions: List[String] = pkgName :+ "definitions"
 
     val ProtocolDefinitions(protocolElems, protocolImports, packageObjectImports, packageObjectContents) = proto
     val CodegenDefinitions(clients, servers, supportDefinitions, frameworkImplicits)                     = codegen
     val frameworkImplicitName                                                                            = frameworkImplicits.map(_._1)
 
-    val dtoComponents: List[String] = definitions ++ dtoPackage
+    val dtoComponents: List[String]                 = definitions ++ dtoPackage
     val filteredDtoComponents: Option[List[String]] = if (protocolElems.nonEmpty) Some(dtoComponents) else None
 
     for {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
@@ -120,7 +120,7 @@ case class CoreTermInterp[L <: LA](defaultFramework: String,
         _          <- CoreTarget.log.debug("Processing arguments")
         specPath   <- CoreTarget.fromOption(args.specPath, MissingArg(args, Error.ArgName("--specPath")))
         outputPath <- CoreTarget.fromOption(args.outputPath, MissingArg(args, Error.ArgName("--outputPath")))
-        rawPkgName <- CoreTarget.fromOption(args.packageName, MissingArg(args, Error.ArgName("--packageName")))
+        pkgName    <- CoreTarget.fromOption(args.packageName, MissingArg(args, Error.ArgName("--packageName")))
         kind       = args.kind
         dtoPackage = args.dtoPackage
         context    = args.context
@@ -140,11 +140,9 @@ case class CoreTermInterp[L <: LA](defaultFramework: String,
             swagger =>
               try {
                 (for {
-                  pkgName <- ScalaTerms.scalaTerm[L, CodegenApplication[L, ?]].fullyQualifyPackageName(rawPkgName)
-                  defs <- Common.prepareDefinitions[L, CodegenApplication[L, ?]](kind,
-                                                                                 context,
-                                                                                 Tracker(swagger),
-                                                                                 pkgName ++ ("definitions" :: dtoPackage))
+                  definitionsPkgName <- ScalaTerms.scalaTerm[L, CodegenApplication[L, ?]].fullyQualifyPackageName(pkgName)
+                  defs <- Common
+                    .prepareDefinitions[L, CodegenApplication[L, ?]](kind, context, Tracker(swagger), definitionsPkgName ++ ("definitions" :: dtoPackage))
                   (proto, codegen) = defs
                   result <- Common
                     .writePackage[L, CodegenApplication[L, ?]](proto, codegen, context)(Paths.get(outputPath), pkgName, dtoPackage, customImports)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
@@ -120,7 +120,7 @@ case class CoreTermInterp[L <: LA](defaultFramework: String,
         _          <- CoreTarget.log.debug("Processing arguments")
         specPath   <- CoreTarget.fromOption(args.specPath, MissingArg(args, Error.ArgName("--specPath")))
         outputPath <- CoreTarget.fromOption(args.outputPath, MissingArg(args, Error.ArgName("--outputPath")))
-        pkgName    <- CoreTarget.fromOption(args.packageName, MissingArg(args, Error.ArgName("--packageName")))
+        rawPkgName <- CoreTarget.fromOption(args.packageName, MissingArg(args, Error.ArgName("--packageName")))
         kind       = args.kind
         dtoPackage = args.dtoPackage
         context    = args.context
@@ -140,10 +140,11 @@ case class CoreTermInterp[L <: LA](defaultFramework: String,
             swagger =>
               try {
                 (for {
+                  pkgName <- ScalaTerms.scalaTerm[L, CodegenApplication[L, ?]].fullyQualifyPackageName(rawPkgName)
                   defs <- Common.prepareDefinitions[L, CodegenApplication[L, ?]](kind,
                                                                                  context,
                                                                                  Tracker(swagger),
-                                                                                 List("_root_") ++ pkgName ++ ("definitions" :: dtoPackage))
+                                                                                 pkgName ++ ("definitions" :: dtoPackage))
                   (proto, codegen) = defs
                   result <- Common
                     .writePackage[L, CodegenApplication[L, ?]](proto, codegen, context)(Paths.get(outputPath), pkgName, dtoPackage, customImports)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
@@ -128,6 +128,7 @@ object JavaGenerator {
       case LiftVectorType(value) => safeParseClassOrInterfaceType("java.util.List").map(_.setTypeArguments(new NodeList(value)))
       case LiftVectorTerm(value) => buildMethodCall("java.util.Collections.singletonList", Some(value))
       case LiftMapType(value)    => safeParseClassOrInterfaceType("java.util.Map").map(_.setTypeArguments(STRING_TYPE, value))
+      case FullyQualifyPackageName(rawPkgName) => Target.pure(rawPkgName)
       case LookupEnumDefaultValue(tpe, defaultValue, values) => {
         // FIXME: Is there a better way to do this? There's a gap of coverage here
         defaultValue match {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
@@ -125,9 +125,9 @@ object JavaGenerator {
                                    .setTypeArguments(new NodeList[Type]),
                                  new NodeList())
         )
-      case LiftVectorType(value) => safeParseClassOrInterfaceType("java.util.List").map(_.setTypeArguments(new NodeList(value)))
-      case LiftVectorTerm(value) => buildMethodCall("java.util.Collections.singletonList", Some(value))
-      case LiftMapType(value)    => safeParseClassOrInterfaceType("java.util.Map").map(_.setTypeArguments(STRING_TYPE, value))
+      case LiftVectorType(value)               => safeParseClassOrInterfaceType("java.util.List").map(_.setTypeArguments(new NodeList(value)))
+      case LiftVectorTerm(value)               => buildMethodCall("java.util.Collections.singletonList", Some(value))
+      case LiftMapType(value)                  => safeParseClassOrInterfaceType("java.util.Map").map(_.setTypeArguments(STRING_TYPE, value))
       case FullyQualifyPackageName(rawPkgName) => Target.pure(rawPkgName)
       case LookupEnumDefaultValue(tpe, defaultValue, values) => {
         // FIXME: Is there a better way to do this? There's a gap of coverage here

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
@@ -42,6 +42,7 @@ object ScalaGenerator {
       case LiftVectorType(value)   => Target.pure(t"IndexedSeq[${value}]")
       case LiftVectorTerm(value)   => Target.pure(q"IndexedSeq(${value})")
       case LiftMapType(value)      => Target.pure(t"Map[String, ${value}]")
+      case FullyQualifyPackageName(rawPkgName) => Target.pure("_root_" +: rawPkgName)
       case LookupEnumDefaultValue(tpe, defaultValue, values) => {
         // FIXME: Is there a better way to do this? There's a gap of coverage here
         defaultValue match {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
@@ -1,6 +1,7 @@
 package com.twilio.guardrail.generators
 
 import cats.~>
+import cats.implicits._
 import com.twilio.guardrail._
 import com.twilio.guardrail.Common.resolveFile
 import com.twilio.guardrail.generators.syntax.RichString
@@ -267,25 +268,24 @@ object ScalaGenerator {
         Target.pure(WriteTree(pkgPath.resolve(s"${frameworkDefinitionsName.value}.scala"), sourceToBytes(frameworkDefinitionsFile)))
 
       case WritePackageObject(dtoPackagePath, dtoComponents, customImports, packageObjectImports, protocolImports, packageObjectContents, extraTypes) =>
-        val dtoHead :: dtoRest = dtoComponents
-        val dtoPkg = dtoRest.init
-          .foldLeft[Term.Ref](Term.Name(dtoHead)) {
-            case (acc, next) => Term.Select(acc, Term.Name(next))
-          }
-        val companion = Term.Name(s"${dtoComponents.last}$$")
+        dtoComponents.traverse { case dtoComponents@(dtoHead :: dtoRest) =>
+          val dtoPkg = dtoRest.init
+            .foldLeft[Term.Ref](Term.Name(dtoHead)) {
+              case (acc, next) => Term.Select(acc, Term.Name(next))
+            }
+          val companion = Term.Name(s"${dtoComponents.last}$$")
 
-        val (_, statements) =
-          packageObjectContents.partition(partitionImplicits)
-        val implicits: List[Defn.Val] = packageObjectContents.collect(matchImplicit)
+          val (_, statements) =
+            packageObjectContents.partition(partitionImplicits)
+          val implicits: List[Defn.Val] = packageObjectContents.collect(matchImplicit)
 
-        val mirroredImplicits = implicits
-          .map({ stat =>
-            val List(Pat.Var(mirror)) = stat.pats
-            stat.copy(rhs = q"${companion}.${mirror}")
-          })
+          val mirroredImplicits = implicits
+            .map({ stat =>
+              val List(Pat.Var(mirror)) = stat.pats
+              stat.copy(rhs = q"${companion}.${mirror}")
+            })
 
-        Target.pure(
-          Some(
+          Target.pure(
             WriteTree(
               dtoPackagePath.resolve("package.scala"),
               sourceToBytes(source"""
@@ -303,7 +303,7 @@ object ScalaGenerator {
             """)
             )
           )
-        )
+        }
       case WriteProtocolDefinition(outputPath, pkgName, definitions, dtoComponents, imports, elem) =>
         Target.pure(elem match {
           case EnumDefinition(_, _, _, _, cls, staticDefns) =>
@@ -374,7 +374,7 @@ object ScalaGenerator {
               package ${buildPkgTerm(pkgName ++ pkg)}
               import ${buildPkgTerm(List("_root_") ++ pkgName ++ List("Implicits"))}._
               ..${frameworkImplicitName.map(name => q"import ${buildPkgTerm(List("_root_") ++ pkgName)}.${name}._")}
-              import ${buildPkgTerm(List("_root_") ++ dtoComponents)}._
+              ..${dtoComponents.map(x => q"import ${buildPkgTerm(List("_root_") ++ x)}._")}
               ..${customImports};
               ..${imports};
               ${companionForStaticDefns(staticDefns)};
@@ -399,7 +399,7 @@ object ScalaGenerator {
               ..${extraImports}
               import ${buildPkgTerm(List("_root_") ++ pkgName ++ List("Implicits"))}._
               ..${frameworkImplicitName.map(name => q"import ${buildPkgTerm(List("_root_") ++ pkgName)}.${name}._")}
-              import ${buildPkgTerm(List("_root_") ++ dtoComponents)}._
+              ..${dtoComponents.map(x => q"import ${buildPkgTerm(List("_root_") ++ x)}._")}
               ..${customImports}
               ${handlerDefinition}
               ..${serverDefinitions}

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerm.scala
@@ -88,7 +88,7 @@ case class RenderFrameworkDefinitions[L <: LA](pkgPath: Path,
                                                frameworkDefinitionsName: L#TermName)
     extends ScalaTerm[L, WriteTree]
 case class WritePackageObject[L <: LA](dtoPackagePath: Path,
-                                       dtoComponents: List[String],
+                                       dtoComponents: Option[List[String]],
                                        customImports: List[L#Import],
                                        packageObjectImports: List[L#Import],
                                        protocolImports: List[L#Import],
@@ -106,14 +106,14 @@ case class WriteClient[L <: LA](pkgPath: Path,
                                 pkgName: List[String],
                                 customImports: List[L#Import],
                                 frameworkImplicitName: Option[L#TermName],
-                                dtoComponents: List[String],
+                                dtoComponents: Option[List[String]],
                                 client: Client[L])
     extends ScalaTerm[L, List[WriteTree]]
 case class WriteServer[L <: LA](pkgPath: Path,
                                 pkgName: List[String],
                                 customImports: List[L#Import],
                                 frameworkImplicitName: Option[L#TermName],
-                                dtoComponents: List[String],
+                                dtoComponents: Option[List[String]],
                                 server: Server[L])
     extends ScalaTerm[L, List[WriteTree]]
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerm.scala
@@ -26,6 +26,8 @@ case class LiftVectorType[L <: LA](value: L#Type)   extends ScalaTerm[L, L#Type]
 case class LiftVectorTerm[L <: LA](value: L#Term)   extends ScalaTerm[L, L#Term]
 case class LiftMapType[L <: LA](value: L#Type)      extends ScalaTerm[L, L#Type]
 
+case class FullyQualifyPackageName[L <: LA](rawPkgName: List[String]) extends ScalaTerm[L, List[String]]
+
 case class LookupEnumDefaultValue[L <: LA](tpe: L#TypeName, defaultValue: L#Term, values: List[(String, L#TermName, L#TermSelect)])
     extends ScalaTerm[L, L#TermSelect]
 case class FormatEnumName[L <: LA](enumValue: String) extends ScalaTerm[L, String]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerms.scala
@@ -93,7 +93,7 @@ class ScalaTerms[L <: LA, F[_]](implicit I: InjectK[ScalaTerm[L, ?], F]) {
     Free.inject[ScalaTerm[L, ?], F](RenderFrameworkDefinitions(pkgPath, pkgName, frameworkImports, frameworkDefinitions, frameworkDefinitionsName))
 
   def writePackageObject(dtoPackagePath: Path,
-                         dtoComponents: List[String],
+                         dtoComponents: Option[List[String]],
                          customImports: List[L#Import],
                          packageObjectImports: List[L#Import],
                          protocolImports: List[L#Import],
@@ -113,14 +113,14 @@ class ScalaTerms[L <: LA, F[_]](implicit I: InjectK[ScalaTerm[L, ?], F]) {
                   pkgName: List[String],
                   customImports: List[L#Import],
                   frameworkImplicitName: Option[L#TermName],
-                  dtoComponents: List[String],
+                  dtoComponents: Option[List[String]],
                   client: Client[L]): Free[F, List[WriteTree]] =
     Free.inject[ScalaTerm[L, ?], F](WriteClient(pkgPath, pkgName, customImports, frameworkImplicitName, dtoComponents, client))
   def writeServer(pkgPath: Path,
                   pkgName: List[String],
                   customImports: List[L#Import],
                   frameworkImplicitName: Option[L#TermName],
-                  dtoComponents: List[String],
+                  dtoComponents: Option[List[String]],
                   server: Server[L]): Free[F, List[WriteTree]] =
     Free.inject[ScalaTerm[L, ?], F](WriteServer(pkgPath, pkgName, customImports, frameworkImplicitName, dtoComponents, server))
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerms.scala
@@ -27,6 +27,9 @@ class ScalaTerms[L <: LA, F[_]](implicit I: InjectK[ScalaTerm[L, ?], F]) {
   def liftVectorTerm(value: L#Term): Free[F, L#Term]   = Free.inject[ScalaTerm[L, ?], F](LiftVectorTerm(value))
   def liftMapType(value: L#Type): Free[F, L#Type]      = Free.inject[ScalaTerm[L, ?], F](LiftMapType(value))
 
+  def fullyQualifyPackageName(rawPkgName: List[String]): Free[F, List[String]] =
+    Free.inject[ScalaTerm[L, ?], F](FullyQualifyPackageName(rawPkgName))
+
   def lookupEnumDefaultValue(tpe: L#TypeName, defaultValue: L#Term, values: List[(String, L#TermName, L#TermSelect)]): Free[F, L#TermSelect] =
     Free.inject[ScalaTerm[L, ?], F](LookupEnumDefaultValue(tpe, defaultValue, values))
   def formatEnumName(enumValue: String): Free[F, String] = Free.inject[ScalaTerm[L, ?], F](FormatEnumName(enumValue))

--- a/modules/codegen/src/test/scala/core/issues/Issue429.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue429.scala
@@ -1,8 +1,8 @@
 package core.issues
 
 import com.twilio.guardrail.generators.Http4s
-import com.twilio.guardrail.{ClassDefinition, Context, ProtocolDefinitions}
-import org.scalatest.{FunSuite, Matchers}
+import com.twilio.guardrail.{ ClassDefinition, Context, ProtocolDefinitions }
+import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._

--- a/modules/codegen/src/test/scala/tests/core/FullyQualifiedNames.scala
+++ b/modules/codegen/src/test/scala/tests/core/FullyQualifiedNames.scala
@@ -2,8 +2,8 @@ package tests.core
 
 import com.twilio.guardrail.generators.Http4s
 import com.twilio.guardrail.languages.ScalaLanguage
-import com.twilio.guardrail.{ClassDefinition, Client, Clients, Context, ProtocolDefinitions, Server, Servers}
-import org.scalatest.{FunSuite, Matchers}
+import com.twilio.guardrail.{ ClassDefinition, Client, Clients, Context, ProtocolDefinitions, Server, Servers }
+import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._
@@ -36,14 +36,12 @@ class FullyQualifiedNames extends FunSuite with Matchers with SwaggerSpecRunner 
       |            $ref: '#/definitions/User'
       |""".stripMargin
 
-
-
   test("Test that fully qualified names are used") {
     val (
-      ProtocolDefinitions(List(clz @ ClassDefinition(_, _, fullType, _, _, _)),_, _,_ ),
-      Clients(List(Client(_, _, _, _, client, List(respTrait, respObject))),_),
+      ProtocolDefinitions(List(clz @ ClassDefinition(_, _, fullType, _, _, _)), _, _, _),
+      Clients(List(Client(_, _, _, _, client, List(respTrait, respObject))), _),
       _
-      ) = runSwaggerSpec(swagger, List("_root_", "com", "test"))(Context.empty, Http4s)
+    ) = runSwaggerSpec(swagger, List("_root_", "com", "test"))(Context.empty, Http4s)
 
     clz.fullType shouldEqual t"_root_.com.test.User"
     client.head.toOption.get shouldEqual q"""
@@ -74,7 +72,7 @@ class FullyQualifiedNames extends FunSuite with Matchers with SwaggerSpecRunner 
           }
         }
        """
-    
+
     respObject shouldEqual q"""object GetUserResponse { case class Ok(value: _root_.com.test.User) extends GetUserResponse }"""
 
   }

--- a/modules/codegen/src/test/scala/tests/core/FullyQualifiedNames.scala
+++ b/modules/codegen/src/test/scala/tests/core/FullyQualifiedNames.scala
@@ -56,7 +56,7 @@ class FullyQualifiedNames extends FunSuite with Matchers with SwaggerSpecRunner 
            val allHeaders = headers ++ List[Option[Header]]().flatten
            val req = Request[F](method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/user/" + Formatter.addPath(id)), headers = Headers(allHeaders))
            httpClient.fetch(req)({
-             case org.http4s.Status.Ok(resp) =>
+             case _root_.org.http4s.Status.Ok(resp) =>
                F.map(getUserOkDecoder.decode(resp, strict = false).value.flatMap(F.fromEither))(GetUserResponse.Ok.apply)
              case resp =>
                F.raiseError(UnexpectedStatus(resp.status))

--- a/modules/sample-akkaHttp/src/test/scala/core/issues/Issue121.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/issues/Issue121.scala
@@ -17,7 +17,6 @@ class Issue121Suite extends FunSuite with Matchers with EitherValues with ScalaF
 
   test("akka-http server can respond with 204") {
     import issues.issue121.server.akkaHttp.{ Handler, Resource }
-    import issues.issue121.server.akkaHttp.definitions._
     val route = Resource.routes(new Handler {
       override def deleteFoo(respond: Resource.deleteFooResponse.type)(id: Long): Future[Resource.deleteFooResponse] =
         Future.successful(respond.NoContent)
@@ -32,7 +31,6 @@ class Issue121Suite extends FunSuite with Matchers with EitherValues with ScalaF
 
   test("akka-http client can respond with 204") {
     import issues.issue121.client.akkaHttp.Client
-    import issues.issue121.client.akkaHttp.definitions._
 
     def noContentResponse: HttpRequest => Future[HttpResponse] = _ => Future.successful(HttpResponse(204))
 

--- a/modules/sample-akkaHttp/src/test/scala/core/issues/Issue184.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/issues/Issue184.scala
@@ -24,7 +24,6 @@ class Issue184Suite extends FunSuite with Matchers with EitherValues with ScalaF
 
   test("akka-http server request body validation") {
     import issues.issue184.server.akkaHttp.{ Handler, Resource }
-    import issues.issue184.server.akkaHttp.definitions._
     val route = Resource.routes(new Handler {
       override def deleteFoo(respond: Resource.deleteFooResponse.type)(path: String, query: String, form: String): Future[Resource.deleteFooResponse] =
         Future.successful(respond.NoContent)

--- a/modules/sample-akkaHttp/src/test/scala/core/issues/Issue325.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/issues/Issue325.scala
@@ -22,7 +22,6 @@ class Issue325Suite extends FunSuite with Matchers with EitherValues with ScalaF
 
   test("Ensure that servers can be constructed") {
     import issues.issue325.server.akkaHttp.{ Handler, Resource }
-    import issues.issue325.server.akkaHttp.definitions._
     val route = Resource.routes(new Handler {
       override def testMultipleContentTypes(
           respond: Resource.testMultipleContentTypesResponse.type
@@ -123,7 +122,6 @@ class Issue325Suite extends FunSuite with Matchers with EitherValues with ScalaF
   test("Ensure that clients supply the correct arguments encoded in the expected way") {
     import akka.stream.scaladsl.Sink
     import issues.issue325.client.akkaHttp.{ Client, TestMultipleContentTypesResponse }
-    import issues.issue325.client.akkaHttp.definitions._
 
     def expectResponse(p: (String, List[Multipart.FormData.BodyPart.Strict]) => Boolean)(implicit ec: ExecutionContext): HttpRequest => Future[HttpResponse] = {
       req =>

--- a/modules/sample-akkaHttp/src/test/scala/core/issues/Issue357.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/issues/Issue357.scala
@@ -18,7 +18,6 @@ class Issue357Suite extends FunSpec with Matchers with EitherValues with ScalaFu
 
   describe("akka-http server should") {
     import issues.issue357.server.akkaHttp.{ Handler, Resource }
-    import issues.issue357.server.akkaHttp.definitions._
     val route = Resource.routes(new Handler {
       def deleteFoo(respond: Resource.deleteFooResponse.type)(path: String, query: String, form: String): Future[Resource.deleteFooResponse] =
         Future.successful((path, query, form) match {
@@ -102,7 +101,6 @@ class Issue357Suite extends FunSpec with Matchers with EitherValues with ScalaFu
 
   describe("akka-http client should") {
     import issues.issue357.client.akkaHttp.{ Client, DeleteFooResponse, PatchFooResponse, PutFooResponse }
-    import issues.issue357.client.akkaHttp.definitions._
 
     object pathRE {
       def unapply(value: Uri.Path): Option[String] =

--- a/modules/sample-akkaHttp/src/test/scala/core/issues/Issue405.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/issues/Issue405.scala
@@ -29,7 +29,6 @@ class Issue405 extends FunSuite with Matchers with EitherValues with ScalaFuture
 
   test("Empty string for a required form param should parse as empty string") {
     import issues.issue405.server.akkaHttp.{ Handler, Resource }
-    import issues.issue405.server.akkaHttp.definitions._
 
     val route = Route.seal(Resource.routes(new Handler {
       override def foo(respond: Resource.fooResponse.type)(bar: String, baz: Option[String]): Future[Resource.fooResponse] =
@@ -45,7 +44,6 @@ class Issue405 extends FunSuite with Matchers with EitherValues with ScalaFuture
 
   test("Empty string for an optional form param should parse as empty string") {
     import issues.issue405.server.akkaHttp.{ Handler, Resource }
-    import issues.issue405.server.akkaHttp.definitions._
 
     val route = Route.seal(Resource.routes(new Handler {
       override def foo(respond: Resource.fooResponse.type)(bar: String, baz: Option[String]): Future[Resource.fooResponse] = {
@@ -63,7 +61,6 @@ class Issue405 extends FunSuite with Matchers with EitherValues with ScalaFuture
 
   test("Omitting a required parameter should still reject the request") {
     import issues.issue405.server.akkaHttp.{ Handler, Resource }
-    import issues.issue405.server.akkaHttp.definitions._
 
     val route = Route.seal(Resource.routes(new Handler {
       override def foo(respond: Resource.fooResponse.type)(bar: String, baz: Option[String]): Future[Resource.fooResponse] =
@@ -79,7 +76,6 @@ class Issue405 extends FunSuite with Matchers with EitherValues with ScalaFuture
 
   test("Omitting an optional parameter should still pass None to the endpoint") {
     import issues.issue405.server.akkaHttp.{ Handler, Resource }
-    import issues.issue405.server.akkaHttp.definitions._
 
     val route = Route.seal(Resource.routes(new Handler {
       override def foo(respond: Resource.fooResponse.type)(bar: String, baz: Option[String]): Future[Resource.fooResponse] = {

--- a/modules/sample-http4s/src/test/scala/core/issues/Issue121.scala
+++ b/modules/sample-http4s/src/test/scala/core/issues/Issue121.scala
@@ -18,7 +18,6 @@ class Issue121Suite extends FunSuite with Matchers with EitherValues with ScalaF
   override implicit val patienceConfig = PatienceConfig(10 seconds, 1 second)
 
   test("http4s server can respond with 204") {
-    import issues.issue121.server.http4s.definitions._
     import issues.issue121.server.http4s.{ DeleteFooResponse, Handler, Resource }
 
     val route = new Resource[IO]().routes(new Handler[IO] {
@@ -45,7 +44,6 @@ class Issue121Suite extends FunSuite with Matchers with EitherValues with ScalaF
 
   test("http4s client can respond with 204") {
     import issues.issue121.client.http4s.Client
-    import issues.issue121.client.http4s.definitions._
 
     def noContentResponse: Http4sClient[IO] =
       Http4sClient.fromHttpApp[IO](Kleisli.pure(Response[IO](Status.NoContent)))


### PR DESCRIPTION
Resolves #443 

So, master started failing to compile after merging #434 due to some Scala-specific changes being applied directly in the "core" interpreter. This wasn't caught earlier because the Java tests haven't been run during the PR validation process.

- [x] Switching from `scalaTestSuite` to `testSuite` in travis and github actions
- [x] Adding `codegen:test` formatting check
- [x] Moving `_root_` package prefix to `ScalaGenerator` (identity in `JavaGenerator`)
- [x] Only add `definitions` imports if there are actually definitions (avoid errors during Java codegen if there are no definitions)

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
