### PR TITLE
Add support for http4s 0.21.x

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sHelper.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sHelper.scala
@@ -96,6 +96,7 @@ object Http4sHelper {
     q"""
        new org.http4s.dsl.impl.EntityResponseGenerator[F,F] {
           def status = $term
+          val liftG = cats.arrow.FunctionK.id
        }
      """
 


### PR DESCRIPTION
Starting the version 0.21 http4s requires to explicitly provide a transformation functor from G to F in EntityResponseGenerator. The following chores allow compiling generated code using both 0.20 and 0.21 http4s version. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ √] I acknowledge that all my contributions will be made under the project's license.
