### PR TITLE
Remove redaction any2stringadd warning

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/CirceProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/CirceProtocolGenerator.scala
@@ -174,9 +174,7 @@ object CirceProtocolGenerator {
             case _                                           => Lit.String("[redacted]")
           }
 
-          val toStringTerms = NonEmptyList
-            .fromList(params)
-            .fold(List.empty[Term])(list => mkToStringTerm(list.head) +: list.tail.map(param => q"${Lit.String(",")} + ${mkToStringTerm(param)}"))
+          val toStringTerms = params.map(p => List(mkToStringTerm(p))).intercalate(List(Lit.String(",")))
 
           List[Defn.Def](
             q"override def toString: String = ${toStringTerms.foldLeft[Term](Lit.String(s"${clsName}("))(

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/CirceProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/CirceProtocolGenerator.scala
@@ -170,7 +170,7 @@ object CirceProtocolGenerator {
 
         val toStringMethod = if (params.exists(_.dataRedaction != DataVisible)) {
           def mkToStringTerm(param: ProtocolParameter[ScalaLanguage]): Term = param match {
-            case param if param.dataRedaction == DataVisible => Term.Name(param.term.name.value)
+            case param if param.dataRedaction == DataVisible => q"${Term.Name(param.term.name.value)}.toString()"
             case _                                           => Lit.String("[redacted]")
           }
 


### PR DESCRIPTION
Removes unnecessary `any2stringadd`

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
