### PR TITLE
Switching to sonatypeBundleRelease

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ script: >
 matrix:
   include:
   - jdk: openjdk8
-  - jdk: openjdk11
 
 # Cache configs taken from https://www.scala-sbt.org/1.0/docs/Travis-CI-with-sbt.html
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,5 +49,5 @@ before_install:
   fi
 after_success:
 - if [ $TRAVIS_PULL_REQUEST = 'false' ] && [[ "$TRAVIS_TAG" = v* ]]; then
-    sbt ++$TRAVIS_SCALA_VERSION codegen/clean publishBintray codegen/bintrayRelease publishSonatype sonatypeClose sonatypeRelease microsite/publishMicrosite;
+    sbt ++$TRAVIS_SCALA_VERSION codegen/clean publishBintray codegen/bintrayRelease publishSonatype sonatypeBundleRelease microsite/publishMicrosite;
   fi


### PR DESCRIPTION
Resolves #432

- According to [the docs](https://github.com/xerial/sbt-sonatype#commands), only `sonatypeBundleRelease` should be necessary.
- Also removing the JDK11 Matrix build, as it's very slow on Travis covered by Github Actions, and complicates the release process on every release (manual intervention is required to avoid conflicting releases)
 
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
