### PR TITLE
Propagate tracker

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
@@ -151,7 +151,7 @@ object SwaggerUtil {
         log.debug(s"model:\n${log.schemaToString(model)}") >> (model match {
           case ref: Schema[_] if Option(ref.get$ref).isDefined =>
             for {
-              ref <- getSimpleRef(ref)
+              ref <- getSimpleRef(Tracker.hackyAdapt(Option(ref), Vector.empty))
             } yield Deferred[L](ref)
           case arr: ArraySchema =>
             for {
@@ -403,7 +403,7 @@ object SwaggerUtil {
                 }
               } yield res
           )
-          .orRefine({ case ref: Schema[_] if Option(ref.get$ref).isDefined => ref })(ref => getSimpleRef(ref.get).map(Deferred[L]))
+          .orRefine({ case ref: Schema[_] if Option(ref.get$ref).isDefined => ref })(ref => getSimpleRef(ref.map(Option.apply _)).map(Deferred[L]))
           .orRefine({ case b: BooleanSchema => b })(buildResolve(litBoolean))
           .orRefine({ case s: StringSchema => s })(buildResolve(litString))
           .orRefine({ case s: EmailSchema => s })(buildResolveNoDefault)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/core/Tracker.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/core/Tracker.scala
@@ -108,6 +108,9 @@ trait HighPriorityTrackerSyntax extends LowPriorityTrackerSyntax {
           .andThen(Right(_))
           .applyOrElse(tracker.get, (_: A) => Left(tracker))
       }, Right(_))
+
+    def orRefineFallback(f: Tracker[A] => C): C =
+      value.fold(f, identity _)
   }
 
   implicit class Syntax[A](tracker: Tracker[A]) {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/extract/Default.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/extract/Default.scala
@@ -1,5 +1,6 @@
 package com.twilio.guardrail.extract
 
+import com.twilio.guardrail.core.Tracker
 import io.swagger.v3.oas.models.media.{ BooleanSchema, IntegerSchema, NumberSchema, StringSchema }
 import io.swagger.v3.oas.models.parameters.Parameter
 
@@ -29,6 +30,12 @@ object Default {
 
     implicit val getDefaultQueryParameterParameter: GetDefault[Parameter] =
       build[Parameter](_.getSchema.getDefault)
+
+    implicit def proxyDefaultForTracker[A](implicit ev: GetDefault[A]): GetDefault[Tracker[A]] =
+      new GetDefault[Tracker[A]] {
+        def extract[T](from: Tracker[A])(implicit T: Extractable[T]): Option[T] =
+          ev.extract[T](from.unwrapTracker)
+      }
   }
 
   case class DefaultAdapter[F](from: F) extends AnyVal {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
@@ -237,7 +237,7 @@ case class RouteMeta(path: Tracker[String], method: HttpMethod, operation: Track
       protocolElems: List[StrictProtocolElems[L]]
   )(implicit Fw: FrameworkTerms[L, F], Sc: ScalaTerms[L, F], Sw: SwaggerTerms[L, F]): Free[F, ScalaParameters[L]] =
     for {
-      a <- ScalaParameter.fromParameters(protocolElems).apply(parameters.map(_.get))
+      a <- ScalaParameter.fromParameters(protocolElems).apply(parameters)
     } yield new ScalaParameters[L](a)
 }
 
@@ -265,18 +265,18 @@ case class ExtractOAuth2SecurityScheme[L <: LA](schemeName: String, securitySche
     extends SwaggerTerm[L, OAuth2SecurityScheme[L]]
 case class GetClassName[L <: LA](operation: Tracker[Operation], vendorPrefixes: List[String]) extends SwaggerTerm[L, List[String]]
 case class GetParameterName[L <: LA](parameter: Parameter)                                    extends SwaggerTerm[L, String]
-case class GetBodyParameterSchema[L <: LA](parameter: Parameter)                              extends SwaggerTerm[L, Schema[_]]
-case class GetHeaderParameterType[L <: LA](parameter: Parameter)                              extends SwaggerTerm[L, String]
-case class GetPathParameterType[L <: LA](parameter: Parameter)                                extends SwaggerTerm[L, String]
-case class GetQueryParameterType[L <: LA](parameter: Parameter)                               extends SwaggerTerm[L, String]
-case class GetCookieParameterType[L <: LA](parameter: Parameter)                              extends SwaggerTerm[L, String]
-case class GetFormParameterType[L <: LA](parameter: Parameter)                                extends SwaggerTerm[L, String]
-case class GetSerializableParameterType[L <: LA](parameter: Parameter)                        extends SwaggerTerm[L, String]
-case class GetRefParameterRef[L <: LA](parameter: Tracker[Parameter])                         extends SwaggerTerm[L, String]
-case class FallbackParameterHandler[L <: LA](parameter: Parameter)                            extends SwaggerTerm[L, SwaggerUtil.ResolvedType[L]]
+case class GetBodyParameterSchema[L <: LA](parameter: Tracker[Parameter])                     extends SwaggerTerm[L, Schema[_]]
+case class GetHeaderParameterType[L <: LA](parameter: Tracker[Parameter])                     extends SwaggerTerm[L, Tracker[String]]
+case class GetPathParameterType[L <: LA](parameter: Tracker[Parameter])                       extends SwaggerTerm[L, Tracker[String]]
+case class GetQueryParameterType[L <: LA](parameter: Tracker[Parameter])                      extends SwaggerTerm[L, Tracker[String]]
+case class GetCookieParameterType[L <: LA](parameter: Tracker[Parameter])                     extends SwaggerTerm[L, Tracker[String]]
+case class GetFormParameterType[L <: LA](parameter: Tracker[Parameter])                       extends SwaggerTerm[L, Tracker[String]]
+case class GetSerializableParameterType[L <: LA](parameter: Tracker[Parameter])               extends SwaggerTerm[L, Tracker[String]]
+case class GetRefParameterRef[L <: LA](parameter: Tracker[Parameter])                         extends SwaggerTerm[L, Tracker[String]]
+case class FallbackParameterHandler[L <: LA](parameter: Tracker[Parameter])                   extends SwaggerTerm[L, SwaggerUtil.ResolvedType[L]]
 case class GetOperationId[L <: LA](operation: Tracker[Operation])                             extends SwaggerTerm[L, String]
 case class GetResponses[L <: LA](operationId: String, operation: Tracker[Operation])          extends SwaggerTerm[L, NonEmptyList[(String, Tracker[ApiResponse])]]
-case class GetSimpleRef[L <: LA](ref: Schema[_])                                              extends SwaggerTerm[L, String]
+case class GetSimpleRef[L <: LA](ref: Tracker[Option[Schema[_]]])                             extends SwaggerTerm[L, String]
 case class GetItems[L <: LA](arr: ArraySchema)                                                extends SwaggerTerm[L, Schema[_]]
 case class GetType[L <: LA](model: Schema[_])                                                 extends SwaggerTerm[L, String]
 case class FallbackPropertyTypeHandler[L <: LA](prop: Schema[_])                              extends SwaggerTerm[L, L#Type]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerms.scala
@@ -35,19 +35,19 @@ class SwaggerTerms[L <: LA, F[_]](implicit I: InjectK[SwaggerTerm[L, ?], F]) {
     Free.inject[SwaggerTerm[L, ?], F](GetClassName(operation, vendorPrefixes))
   def getParameterName(parameter: Parameter): Free[F, String] =
     Free.inject[SwaggerTerm[L, ?], F](GetParameterName(parameter))
-  def getBodyParameterSchema(parameter: Parameter): Free[F, Schema[_]] =
+  def getBodyParameterSchema(parameter: Tracker[Parameter]): Free[F, Schema[_]] =
     Free.inject[SwaggerTerm[L, ?], F](GetBodyParameterSchema(parameter))
 
-  def getHeaderParameterType(parameter: Parameter): Free[F, String]      = Free.inject[SwaggerTerm[L, ?], F](GetHeaderParameterType(parameter))
-  def getPathParameterType(parameter: Parameter): Free[F, String]        = Free.inject[SwaggerTerm[L, ?], F](GetPathParameterType(parameter))
-  def getQueryParameterType(parameter: Parameter): Free[F, String]       = Free.inject[SwaggerTerm[L, ?], F](GetQueryParameterType(parameter))
-  def getCookieParameterType(parameter: Parameter): Free[F, String]      = Free.inject[SwaggerTerm[L, ?], F](GetCookieParameterType(parameter))
-  def getFormParameterType(parameter: Parameter): Free[F, String]        = Free.inject[SwaggerTerm[L, ?], F](GetFormParameterType(parameter))
-  def getRefParameterRef(parameter: Tracker[Parameter]): Free[F, String] = Free.inject[SwaggerTerm[L, ?], F](GetRefParameterRef(parameter))
+  def getHeaderParameterType(parameter: Tracker[Parameter]): Free[F, Tracker[String]] = Free.inject[SwaggerTerm[L, ?], F](GetHeaderParameterType(parameter))
+  def getPathParameterType(parameter: Tracker[Parameter]): Free[F, Tracker[String]]   = Free.inject[SwaggerTerm[L, ?], F](GetPathParameterType(parameter))
+  def getQueryParameterType(parameter: Tracker[Parameter]): Free[F, Tracker[String]]  = Free.inject[SwaggerTerm[L, ?], F](GetQueryParameterType(parameter))
+  def getCookieParameterType(parameter: Tracker[Parameter]): Free[F, Tracker[String]] = Free.inject[SwaggerTerm[L, ?], F](GetCookieParameterType(parameter))
+  def getFormParameterType(parameter: Tracker[Parameter]): Free[F, Tracker[String]]   = Free.inject[SwaggerTerm[L, ?], F](GetFormParameterType(parameter))
+  def getRefParameterRef(parameter: Tracker[Parameter]): Free[F, Tracker[String]]     = Free.inject[SwaggerTerm[L, ?], F](GetRefParameterRef(parameter))
 
-  def getSerializableParameterType(parameter: Parameter): Free[F, String] =
+  def getSerializableParameterType(parameter: Tracker[Parameter]): Free[F, Tracker[String]] =
     Free.inject[SwaggerTerm[L, ?], F](GetSerializableParameterType(parameter))
-  def fallbackParameterHandler(parameter: Parameter): Free[F, SwaggerUtil.ResolvedType[L]] =
+  def fallbackParameterHandler(parameter: Tracker[Parameter]): Free[F, SwaggerUtil.ResolvedType[L]] =
     Free.inject[SwaggerTerm[L, ?], F](FallbackParameterHandler(parameter))
 
   def getOperationId(operation: Tracker[Operation]): Free[F, String] =
@@ -56,7 +56,7 @@ class SwaggerTerms[L <: LA, F[_]](implicit I: InjectK[SwaggerTerm[L, ?], F]) {
   def getResponses(operationId: String, operation: Tracker[Operation]): Free[F, NonEmptyList[(String, Tracker[ApiResponse])]] =
     Free.inject[SwaggerTerm[L, ?], F](GetResponses(operationId, operation))
 
-  def getSimpleRef(ref: Schema[_]): Free[F, String] =
+  def getSimpleRef(ref: Tracker[Option[Schema[_]]]): Free[F, String] =
     Free.inject[SwaggerTerm[L, ?], F](GetSimpleRef(ref))
 
   def getItems(arr: ArraySchema): Free[F, Schema[_]] =


### PR DESCRIPTION
Continuing to advance Tracker through the codebase, with a focus on removing warnings and pushing Tracker to where error logs are emitted so we can give contextual information.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
