### PR TITLE
Ensure Decoders for both Http4s and Akka are not capitalized when generating

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
@@ -7,6 +7,7 @@ import cats.implicits._
 import com.twilio.guardrail.SwaggerUtil
 import com.twilio.guardrail.core.Tracker
 import com.twilio.guardrail.extract.{ ServerRawResponse, TracingLabel }
+import com.twilio.guardrail.generators.syntax._
 import com.twilio.guardrail.generators.syntax.RichOperation
 import com.twilio.guardrail.generators.syntax.Scala._
 import com.twilio.guardrail.generators.operations.TracingLabelFormatter
@@ -258,7 +259,7 @@ object AkkaHttpServerGenerator {
       Target.pure(
         body.map {
           case ScalaParameter(_, _, _, _, argType) =>
-            q"entity(as[${argType}](${Term.Name(s"${operationId}Decoder")}))"
+            q"entity(as[${argType}](${Term.Name(s"${operationId.uncapitalized}Decoder")}))"
         }
       )
 
@@ -809,7 +810,7 @@ object AkkaHttpServerGenerator {
           val (decoder, baseType) = AkkaHttpHelper.generateDecoder(argType, consumes)
           List(
             q"""
-              val ${Pat.Typed(Pat.Var(Term.Name(s"${operationId}Decoder")), t"FromRequestUnmarshaller[$baseType]")} = {
+              val ${Pat.Typed(Pat.Var(Term.Name(s"${operationId.uncapitalized}Decoder")), t"FromRequestUnmarshaller[$baseType]")} = {
                 val extractEntity = implicitly[Unmarshaller[HttpMessage, HttpEntity]]
                 val unmarshalEntity = ${decoder}
                 extractEntity.andThen(unmarshalEntity)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
@@ -163,7 +163,7 @@ object Http4sServerGenerator {
       Target.pure(
         body.map {
           case ScalaParameter(_, _, paramName, _, _) =>
-            content => q"req.decodeWith(${Term.Name(s"${operationId}Decoder")}, strict = false) { ${param"$paramName"} => $content }"
+            content => q"req.decodeWith(${Term.Name(s"${operationId.uncapitalized}Decoder")}, strict = false) { ${param"$paramName"} => $content }"
         }
       )
 
@@ -718,7 +718,8 @@ object Http4sServerGenerator {
       bodyArgs.toList.flatMap {
         case ScalaParameter(_, _, _, _, argType) =>
           List(
-            q"private[this] val ${Pat.Typed(Pat.Var(Term.Name(s"${operationId}Decoder")), t"EntityDecoder[F, $argType]")} = ${Http4sHelper.generateDecoder(argType, consumes)}"
+            q"private[this] val ${Pat.Typed(Pat.Var(Term.Name(s"${operationId.uncapitalized}Decoder")), t"EntityDecoder[F, $argType]")} = ${Http4sHelper
+              .generateDecoder(argType, consumes)}"
           )
       }
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/package.scala
@@ -86,6 +86,14 @@ package object syntax {
     def toSnakeCase: String = splitParts(s).mkString("_")
 
     def toDashedCase: String = splitParts(s).mkString("-")
+
+    def uncapitalized: String =
+      if (s.nonEmpty) {
+        val inUnPacked              = s.toCharArray
+        val lowercaseFirstCharacter = Character.toLowerCase(inUnPacked(0))
+        new String(lowercaseFirstCharacter +: inUnPacked.tail)
+      } else s
+
   }
 
   implicit def RichSchema    = new RichNotNullShower[Schema[_]](_)

--- a/modules/codegen/src/test/scala/core/issues/Issue416.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue416.scala
@@ -1,0 +1,66 @@
+package core.issues
+
+import com.twilio.guardrail.{ Context, Server, Servers }
+import com.twilio.guardrail.generators.Http4s
+import org.scalatest.{ FunSuite, Matchers }
+import support.SwaggerSpecRunner
+
+class Issue416 extends FunSuite with Matchers with SwaggerSpecRunner {
+
+  import scala.meta._
+
+  val swagger: String =
+    s"""
+       |swagger: '2.0'
+       |host: petstore.swagger.io
+       |paths:
+       |  /:
+       |    get:
+       |      parameters:
+       |      - in: body
+       |        name: response
+       |        schema:
+       |           $$ref: "#/definitions/SinkConfiguration"
+       |      operationId: GetRoot
+       |      responses:
+       |        200:
+       |         description: description
+       |
+       |definitions:
+       |  SinkConfiguration:
+       |    type: object
+       |    required:
+       |      - name
+       |    properties:
+       |      name:
+       |        type: string
+       |""".stripMargin
+
+  test("Ensure mapRoute is generated") {
+    val (_, _, Servers(Server(_, _, genHandler, genResource :: _) :: Nil, Nil)) = runSwaggerSpec(swagger)(Context.empty, Http4s)
+
+    val resource = q"""
+      class Resource[F[_]](mapRoute: (String, Request[F], F[Response[F]]) => F[Response[F]] = (_: String, _: Request[F], r: F[Response[F]]) => r)(implicit F: Async[F]) extends Http4sDsl[F] {
+        private[this] val getRootDecoder: EntityDecoder[F, Option[SinkConfiguration]] = jsonOf[F, Option[SinkConfiguration]]
+        def routes(handler: Handler[F]): HttpRoutes[F] = HttpRoutes.of {
+          {
+            case req @ GET -> Root =>
+              mapRoute("GetRoot", req, {
+                req.decodeWith(getRootDecoder, strict = false) { body =>
+                  handler.GetRoot(GetRootResponse)(body) flatMap ({
+                    case GetRootResponse.Ok =>
+                      F.pure(Response[F](status = org.http4s.Status.Ok))
+                  })
+                }
+              })
+          }
+        }
+      }
+    """
+    // Cause structure is slightly different but source code is the same the value converted to string and then parsed
+    compare(genResource.toString().parse[Stat].get, resource)
+  }
+
+  private def compare(actual: Tree, expected: Tree): Unit =
+    actual.structure shouldEqual expected.structure
+}


### PR DESCRIPTION
Fixes issue #416 

Add a method to `com.twilio.guardrail.generators.syntax.RichString` to ensure a string is not capitalized, this is required as capitalised operationIds which are used in the creation of decoder names break the scalameta invariant check (I'm unsure of the actual root cause to this). Now, even when endpoints have capitalised operationIds and a body parameter then will now generate correctly.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
