### PR TITLE
Use Optional.ofNullable instead of .of where appropriate

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
@@ -564,7 +564,7 @@ object JacksonGenerator {
           )(
             dv =>
               if (fieldType.isOptional) {
-                optionalOfExpr(dv)
+                optionalOfNullableExpr(dv)
               } else {
                 dv
               }
@@ -640,7 +640,7 @@ object JacksonGenerator {
                         case (_: PrimitiveType, _) => new NameExpr(parameterName)
                         case (ft, pt) if ft.isOptional && pt.isPrimitiveType =>
                           new MethodCallExpr(new NameExpr("Optional"), "of", new NodeList[Expression](new NameExpr(parameterName)))
-                        case (ft, _) if ft.isOptional => optionalOfExpr(new NameExpr(parameterName))
+                        case (ft, _) if ft.isOptional => optionalOfNullableExpr(new NameExpr(parameterName))
                         case _                        => requireNonNullExpr(parameterName)
                       },
                       AssignExpr.Operator.ASSIGN

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/Java.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/Java.scala
@@ -135,6 +135,12 @@ object Java {
     )
   )
 
+  def optionalOfNullableExpr(param: Expression): Expression = new MethodCallExpr(
+    new NameExpr("Optional"),
+    "ofNullable",
+    new NodeList[Expression](param)
+  )
+
   val GENERATED_CODE_COMMENT: Comment = new BlockComment(GENERATED_CODE_COMMENT_LINES.mkString("\n * ", "\n * ", "\n"))
 
   // from https://en.wikipedia.org/wiki/List_of_Java_keywords

--- a/modules/sample-dropwizard/src/test/scala/core/Jackson/JacksonBuilderParamTest.scala
+++ b/modules/sample-dropwizard/src/test/scala/core/Jackson/JacksonBuilderParamTest.scala
@@ -1,0 +1,29 @@
+package core.Jackson
+
+import examples.client.dropwizard.definitions.{Category, Pet}
+import java.util.Optional
+import org.scalatest.{FreeSpec, Matchers}
+
+class JacksonBuilderParamTest extends FreeSpec with Matchers {
+  "POJO builders should not accept nulls for required params" in {
+    assertThrows[NullPointerException] {
+      new Pet.Builder(null: String)
+        .build()
+    }
+  }
+
+  "POJO builders should accept nulls for the value variant for optional params" in {
+    val pet = new Pet.Builder("fluffy")
+      .withCategory(null: Category)
+      .build()
+    pet.getCategory shouldBe Optional.empty
+  }
+
+  "POJO builders should not accept nulls for the Optional<> variant for optional params" in {
+    assertThrows[NullPointerException] {
+      new Pet.Builder("fluffy")
+        .withCategory(null: Optional[Category])
+        .build()
+    }
+  }
+}


### PR DESCRIPTION
Avoids runtime exceptions with the trade off that if you don't expect something you pass to be `null`, and it is, you might be confused.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
