### PR TITLE
Removing hackyadapt

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
@@ -428,38 +428,36 @@ object ProtocolGenerator {
     } yield params -> nestedDefinitions.flatten
   }
 
-  def modelTypeAlias[L <: LA, F[_]](clsName: String, abstractModel: Schema[_])(
+  def modelTypeAlias[L <: LA, F[_]](clsName: String, abstractModel: Tracker[Schema[_]])(
       implicit
       Fw: FrameworkTerms[L, F],
       Sc: ScalaTerms[L, F],
       Sw: SwaggerTerms[L, F]
   ): Free[F, ProtocolElems[L]] = {
     import Fw._
-    val model = abstractModel match {
-      case m: ObjectSchema => Some(m)
-      case m: ComposedSchema =>
-        m.getAllOf.asScala.toList.get(1).flatMap {
-          case m: ObjectSchema => Some(m)
-          case _               => None
-        }
-      case _ => None
-    }
+    val model: Option[Tracker[ObjectSchema]] = abstractModel
+      .refine[Option[Tracker[ObjectSchema]]]({ case m: ObjectSchema => m })(x => Option(x))
+      .orRefine({ case m: ComposedSchema => m })(
+        _.downField("allOf", _.getAllOf()).indexedCosequence
+          .get(1)
+          .flatMap(
+            _.refine({ case o: ObjectSchema => o })(Option.apply)
+              .orRefineFallback(_ => None)
+          )
+      )
+      .orRefineFallback(_ => None)
     for {
-      tpe <- model
-        .flatMap(model => Option(model.getType))
-        .fold[Free[F, L#Type]](objectType(None))(
-          raw =>
-            model
-              .flatTraverse(SwaggerUtil.customTypeName[L, F, ObjectSchema])
-              .flatMap(
-                customTypeName =>
-                  SwaggerUtil.typeName[L, F](
-                    Tracker.hackyAdapt(Option(raw), Vector.empty),
-                    Tracker.hackyAdapt(model.flatMap(f => Option(f.getFormat)), Vector.empty),
-                    customTypeName
-                  )
-              )
-        )
+      tpe <- model.fold[Free[F, L#Type]](objectType(None)) { m =>
+        val raw = m.downField("type", _.getType())
+        for {
+          tpeName <- SwaggerUtil.customTypeName[L, F, Tracker[ObjectSchema]](m)
+          res <- SwaggerUtil.typeName[L, F](
+            raw,
+            m.downField("format", _.getFormat()),
+            tpeName
+          )
+        } yield res
+      }
       res <- typeAlias[L, F](clsName, tpe)
     } yield res
   }
@@ -595,7 +593,7 @@ object ProtocolGenerator {
                 for {
                   enum  <- fromEnum(clsName, m, dtoPackage)
                   model <- fromModel(NonEmptyList.of(clsName), m, List.empty, concreteTypes, definitions.value, dtoPackage)
-                  alias <- modelTypeAlias(clsName, m.get)
+                  alias <- modelTypeAlias(clsName, m)
                 } yield enum.orElse(model).getOrElse(alias)
             )
             .orRefine({ case c: ComposedSchema => c })(
@@ -603,7 +601,7 @@ object ProtocolGenerator {
                 for {
                   parents <- extractParents(comp, definitions.value, concreteTypes, dtoPackage)
                   model   <- fromModel(NonEmptyList.of(clsName), comp, parents, concreteTypes, definitions.value, dtoPackage)
-                  alias   <- modelTypeAlias(clsName, comp.get)
+                  alias   <- modelTypeAlias(clsName, comp)
                 } yield model.getOrElse(alias)
             )
             .orRefine({ case a: ArraySchema => a })(arr => fromArray(clsName, arr, concreteTypes))
@@ -612,7 +610,7 @@ object ProtocolGenerator {
                 for {
                   enum  <- fromEnum(clsName, m, dtoPackage)
                   model <- fromModel(NonEmptyList.of(clsName), m, List.empty, concreteTypes, definitions.value, dtoPackage)
-                  alias <- modelTypeAlias(clsName, m.get)
+                  alias <- modelTypeAlias(clsName, m)
                 } yield enum.orElse(model).getOrElse(alias)
             )
             .valueOr(

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/core/Tracker.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/core/Tracker.scala
@@ -95,7 +95,7 @@ trait HighPriorityTrackerSyntax extends LowPriorityTrackerSyntax {
   implicit class RefineSyntax[A](tracker: Tracker[A]) {
     class RefinePartiallyApplied[C](val dummy: Boolean = true) {
       def apply[B1](r: PartialFunction[A, B1])(f: Tracker[B1] => C): Either[Tracker[A], C] =
-        r.andThen(value => f(tracker.map(_ => value)))
+        r.andThen(value => f(Tracker.cloneHistory(tracker, value)))
           .andThen(Right(_))
           .applyOrElse(tracker.get, (_: A) => Left(tracker))
     }
@@ -105,7 +105,7 @@ trait HighPriorityTrackerSyntax extends LowPriorityTrackerSyntax {
   implicit class RefineEitherSyntax[A, C](value: Either[Tracker[A], C]) {
     def orRefine[B1](r: PartialFunction[A, B1])(f: Tracker[B1] => C): Either[Tracker[A], C] =
       value.fold({ tracker =>
-        r.andThen(value => f(tracker.map(_ => value)))
+        r.andThen(value => f(Tracker.cloneHistory(tracker, value)))
           .andThen(Right(_))
           .applyOrElse(tracker.get, (_: A) => Left(tracker))
       }, Right(_))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/core/Tracker.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/core/Tracker.scala
@@ -35,6 +35,7 @@ trait LowPriorityTrackerEvidence {
 }
 
 trait HighPriorityTrackerEvidence extends LowPriorityTrackerEvidence {
+  implicit def jlBooleanConvincer: Tracker.Convincer[Option[java.lang.Boolean], Option[Boolean]] = Tracker.Convincer(_.map(x => x))
   implicit def optionalArrayConvincer[A]: Tracker.Convincer[Option[Array[A]], List[A]]           = Tracker.Convincer(_.fold(List.empty[A])(_.toList))
   implicit def optionaljuListConvincer[A]: Tracker.Convincer[Option[java.util.List[A]], List[A]] = Tracker.Convincer(_.fold(List.empty[A])(_.asScala.toList))
   implicit def optionalListConvincer[A]: Tracker.Convincer[Option[List[A]], List[A]]             = Tracker.Convincer(_.getOrElse(List.empty[A]))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/core/Tracker.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/core/Tracker.scala
@@ -144,6 +144,5 @@ object Tracker extends HighPriorityTrackerEvidence with HighPriorityTrackerSynta
   }
 
   def apply(swagger: OpenAPI): Tracker[OpenAPI]                     = new Tracker(swagger, Vector.empty)
-  def hackyAdapt[A](value: A, history: Vector[String]): Tracker[A]  = new Tracker(value, history)
   def cloneHistory[A, B](tracker: Tracker[A], value: B): Tracker[B] = new Tracker(value, tracker.history)
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/CirceProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/CirceProtocolGenerator.scala
@@ -85,7 +85,10 @@ object CirceProtocolGenerator {
                   terms ++
                   List(Some(values), encoder, decoder).flatten ++
                   implicits ++
-                  List(q"def parse(value: String): Option[${Type.Name(clsName)}] = values.find(_.value == value)")
+                  List(
+                    q"def parse(value: String): Option[${Type.Name(clsName)}] = values.find(_.value == value)",
+                    q"implicit val order: cats.Order[${Type.Name(clsName)}] = cats.Order.by[${Type.Name(clsName)}, Int](values.indexOf)"
+                  )
           )
         )
       case BuildAccessor(clsName, termName) =>

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
@@ -795,10 +795,10 @@ object JacksonGenerator {
             expressionDefaultValue <- defaultValue match {
               case Some(e: Expression) => Target.pure(Some(e))
               case Some(_) =>
-                Target.log.warning(s"Can't generate default value for class $clsName and property $name.").map(_ => None)
+                Target.log.warning(s"Can't generate default value for class $clsName and property $name.") >> Target.pure(None)
               case None => Target.pure(None)
             }
-            _declDefaultPair <- Option(isRequired)
+            (finalDeclType, finalDefaultValue) <- Option(isRequired)
               .filterNot(_ == false)
               .fold[Target[(Type, Option[Expression])]](
                 (
@@ -813,7 +813,6 @@ object JacksonGenerator {
                   )
                 ).mapN((_, _))
               )(Function.const(Target.pure((tpe, expressionDefaultValue))) _)
-            (finalDeclType, finalDefaultValue) = _declDefaultPair
             term <- safeParseParameter(s"final ${finalDeclType} ${argName.escapeIdentifier}")
             dep = classDep.filterNot(_.asString == clsName) // Filter out our own class name
           } yield ProtocolParameter[JavaLanguage](term, name, dep, rawType, readOnlyKey, emptyToNull, dataRedaction, defaultValue)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
@@ -95,7 +95,7 @@ case class RouteMeta(path: Tracker[String], method: HttpMethod, operation: Track
         case (contentType, mediaType) =>
           mediaType
             .refine[Option[Tracker[Schema[_]]]]({ case mt @ MediaType(None, _, _) if contentType == "text/plain" => mt })(
-              x => Option(x.map(_ => new StringSchema()))
+              x => Option(Tracker.cloneHistory(x, new StringSchema()))
             )
             .orRefine({ case mt @ MediaType(schema, _, _) => schema })(_.indexedDistribute)
             .orRefineFallback(_ => None)
@@ -121,7 +121,7 @@ case class RouteMeta(path: Tracker[String], method: HttpMethod, operation: Track
         .downField[Option[java.util.Map[String, Object]]]("extensions", _.getExtensions())
         .get
         .foreach(x => p.setExtensions(x))
-      schema.map(_ => p)
+      Tracker.cloneHistory(schema, p)
     }
   }
 
@@ -154,7 +154,7 @@ case class RouteMeta(path: Tracker[String], method: HttpMethod, operation: Track
       required.get.foreach(x => p.setRequired(x))
 
       extensions.get.foreach(x => p.setExtensions(x))
-      ref.map(_ => p)
+      Tracker.cloneHistory(ref, p)
     }
 
     val refParam = ref.cotraverse { x =>
@@ -168,7 +168,7 @@ case class RouteMeta(path: Tracker[String], method: HttpMethod, operation: Track
 
       extensions.get.foreach(x => p.setExtensions(x))
 
-      ref.map(_ => p)
+      Tracker.cloneHistory(ref, p)
     }
 
     content.orElse(refParam)
@@ -215,7 +215,7 @@ case class RouteMeta(path: Tracker[String], method: HttpMethod, operation: Track
               p.setRequired(false)
             }
 
-            mt.map(_ => p)
+            Tracker.cloneHistory(mt, p)
           }
       })
       .traverse[State[ParameterCountState, ?], Tracker[Parameter]] { p =>

--- a/modules/codegen/src/test/scala/core/issues/Issue370.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue370.scala
@@ -79,6 +79,7 @@ class Issue370 extends FunSuite with Matchers with SwaggerSpecRunner {
             implicit val addPathValue: AddPath[Value] = AddPath.build(_.value)
             implicit val showValue: Show[Value] = Show.build(_.value)
             def parse(value: String): Option[Value] = values.find(_.value == value)
+            implicit val order: cats.Order[Value] = cats.Order.by[Value, Int](values.indexOf)
           }
           case class Nested(value: Option[Foo.Nested.Value] = Option(Foo.Nested.Value.C))
           object Nested {
@@ -101,6 +102,7 @@ class Issue370 extends FunSuite with Matchers with SwaggerSpecRunner {
               implicit val addPathValue: AddPath[Value] = AddPath.build(_.value)
               implicit val showValue: Show[Value] = Show.build(_.value)
               def parse(value: String): Option[Value] = values.find(_.value == value)
+              implicit val order: cats.Order[Value] = cats.Order.by[Value, Int](values.indexOf)
             }
           }
         }

--- a/modules/codegen/src/test/scala/core/issues/Issue429.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue429.scala
@@ -43,6 +43,7 @@ class Issue429 extends FunSuite with Matchers with SwaggerSpecRunner {
         implicit val addPathStatusCode: AddPath[StatusCode] = AddPath.build(_.value)
         implicit val showStatusCode: Show[StatusCode] = Show.build(_.value)
         def parse(value: String): Option[StatusCode] = values.find(_.value == value)
+        implicit val order: cats.Order[StatusCode] = cats.Order.by[StatusCode, Int](values.indexOf)
       }
       """
 

--- a/modules/codegen/src/test/scala/core/issues/Issue43.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue43.scala
@@ -145,6 +145,7 @@ class Issue43 extends FunSpec with Matchers with SwaggerSpecRunner {
             implicit val addPathHuntingSkill: AddPath[HuntingSkill] = AddPath.build(_.value)
             implicit val showHuntingSkill: Show[HuntingSkill] = Show.build(_.value)
             def parse(value: String): Option[HuntingSkill] = values.find(_.value == value)
+            implicit val order: cats.Order[HuntingSkill] = cats.Order.by[HuntingSkill, Int](values.indexOf)
           }
         }
       """

--- a/modules/codegen/src/test/scala/tests/core/BacktickTest.scala
+++ b/modules/codegen/src/test/scala/tests/core/BacktickTest.scala
@@ -202,6 +202,7 @@ class BacktickTest extends FunSuite with Matchers with SwaggerSpecRunner {
       implicit val `addPathdashy-enum`: AddPath[`dashy-enum`] = AddPath.build(_.value)
       implicit val `showdashy-enum`: Show[`dashy-enum`] = Show.build(_.value)
       def parse(value: String): Option[`dashy-enum`] = values.find(_.value == value)
+      implicit val order: cats.Order[`dashy-enum`] = cats.Order.by[`dashy-enum`, Int](values.indexOf)
     }
     """
 

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/DefinitionSpec.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/DefinitionSpec.scala
@@ -123,6 +123,7 @@ class DefinitionSpec extends FunSuite with Matchers with SwaggerSpecRunner {
       implicit val showThird: Show[Third] = Show.build(_.value)
 
       def parse(value: String): Option[Third] = values.find(_.value == value)
+      implicit val order: cats.Order[Third] = cats.Order.by[Third, Int](values.indexOf)
     }
     """
 

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/EnumTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/EnumTest.scala
@@ -84,6 +84,7 @@ class EnumTest extends FunSuite with Matchers with SwaggerSpecRunner {
       implicit val showBar: Show[Bar] = Show.build(_.value)
 
       def parse(value: String): Option[Bar] = values.find(_.value == value)
+      implicit val order: cats.Order[Bar] = cats.Order.by[Bar, Int](values.indexOf)
     }
     """
 


### PR DESCRIPTION
- Removing `hackyAdapt`
- Propagating `Tracker` more
- Switching from `map(_ => a)` to `Tracker.cloneHistory(...)` for visibility

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
