### PR TITLE
fix: Restore Scala 2.11 compatibility

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/CirceProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/CirceProtocolGenerator.scala
@@ -369,6 +369,7 @@ object CirceProtocolGenerator {
       case ProtocolImports() =>
         Target.pure(
           List(
+            q"import cats.syntax.either._",
             q"import io.circe._",
             q"import io.circe.syntax._",
             q"import io.circe.generic.semiauto._"


### PR DESCRIPTION
<!-- Describe your Pull Request -->
This restores the compatibility with Scala 2.11.
The root cause is:
https://github.com/circe/circe/issues/756

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
