### PR TITLE
Make WrapToObject optional

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -99,7 +99,7 @@ val exampleCases: List[ExampleCase] = List(
   ExampleCase(sampleResource("plain.json"), "tests.dtos"),
   ExampleCase(sampleResource("polymorphism.yaml"), "polymorphism"),
   ExampleCase(sampleResource("polymorphism-mapped.yaml"), "polymorphismMapped"),
-  ExampleCase(sampleResource("polymorphism-nested.yaml"), "polymorphismNested").frameworks(scalaFrameworks.toSet),
+  ExampleCase(sampleResource("polymorphism-nested.yaml"), "polymorphismNested"),
   ExampleCase(sampleResource("raw-response.yaml"), "raw"),
   ExampleCase(sampleResource("redaction.yaml"), "redaction"),
   ExampleCase(sampleResource("server1.yaml"), "tracer").args("--tracing"),

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
@@ -362,15 +362,15 @@ object ProtocolGenerator {
               widenClass          <- widenClassDefinition(classDefinition.cls)
               companionTerm       <- pureTermName(classDefinition.name)
               companionDefinition <- wrapToObject(companionTerm, classDefinition.staticDefns.extraImports, classDefinition.staticDefns.definitions)
-              widenCompanion      <- widenObjectDefinition(companionDefinition)
-            } yield List(widenClass, widenCompanion)
+              widenCompanion      <- companionDefinition.traverse(widenObjectDefinition)
+            } yield List(widenClass) ++ widenCompanion.fold(classDefinition.staticDefns.definitions)(List(_))
           case enumDefinition: EnumDefinition[L] =>
             for {
               widenClass          <- widenClassDefinition(enumDefinition.cls)
               companionTerm       <- pureTermName(enumDefinition.name)
               companionDefinition <- wrapToObject(companionTerm, enumDefinition.staticDefns.extraImports, enumDefinition.staticDefns.definitions)
-              widenCompanion      <- widenObjectDefinition(companionDefinition)
-            } yield List(widenClass, widenCompanion)
+              widenCompanion      <- companionDefinition.traverse(widenObjectDefinition)
+            } yield List(widenClass) ++ widenCompanion.fold(enumDefinition.staticDefns.definitions)(List(_))
         }
         nestedClasses.map { v =>
           val finalStaticDefns = staticDefns.copy(definitions = staticDefns.definitions ++ v)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
@@ -929,6 +929,7 @@ object JacksonGenerator {
         "com.fasterxml.jackson.annotation.JsonCreator",
         "com.fasterxml.jackson.annotation.JsonIgnoreProperties",
         "com.fasterxml.jackson.annotation.JsonProperty",
+        "com.fasterxml.jackson.annotation.JsonValue",
         "java.util.Optional"
       ).map(safeParseRawImport) ++ List(
             "java.util.Objects.requireNonNull"

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
@@ -486,12 +486,12 @@ object ScalaGenerator {
       )
     }
 
-    def wrapToObject(name: scala.meta.Term.Name, imports: List[scala.meta.Import], definitions: List[scala.meta.Defn]): Target[scala.meta.Defn.Object] =
-      Target.pure(q"""
+    def wrapToObject(name: scala.meta.Term.Name, imports: List[scala.meta.Import], definitions: List[scala.meta.Defn]): Target[Option[scala.meta.Defn.Object]] =
+      Target.pure(Some(q"""
              object $name {
                  ..$imports
                  ..$definitions
              }
-           """)
+           """))
   }
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/LanguageTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/LanguageTerms.scala
@@ -130,7 +130,7 @@ abstract class LanguageTerms[L <: LA, F[_]] {
       server: Server[L]
   ): F[List[WriteTree]]
 
-  def wrapToObject(name: L#TermName, imports: List[L#Import], definitions: List[L#Definition]): F[L#ObjectDefinition]
+  def wrapToObject(name: L#TermName, imports: List[L#Import], definitions: List[L#Definition]): F[Option[L#ObjectDefinition]]
 
   def copy(
       newMonadF: Monad[F] = MonadF,
@@ -209,7 +209,7 @@ abstract class LanguageTerms[L <: LA, F[_]] {
       ) => F[(List[WriteTree], List[L#Statement])] = writeProtocolDefinition _,
       newWriteClient: (Path, List[String], List[L#Import], Option[L#TermName], Option[List[String]], Client[L]) => F[List[WriteTree]] = writeClient _,
       newWriteServer: (Path, List[String], List[L#Import], Option[L#TermName], Option[List[String]], Server[L]) => F[List[WriteTree]] = writeServer _,
-      newWrapToObject: (L#TermName, List[L#Import], List[L#Definition]) => F[L#ObjectDefinition] = wrapToObject _
+      newWrapToObject: (L#TermName, List[L#Import], List[L#Definition]) => F[Option[L#ObjectDefinition]] = wrapToObject _
   ) = new LanguageTerms[L, F] {
     def MonadF                                                   = newMonadF
     def vendorPrefixes()                                         = newVendorPrefixes()

--- a/modules/sample-dropwizard/src/test/scala/core/Jackson/JacksonNestedTest.scala
+++ b/modules/sample-dropwizard/src/test/scala/core/Jackson/JacksonNestedTest.scala
@@ -1,0 +1,28 @@
+package core.Jackson
+
+import java.lang.reflect.Modifier
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import polymorphismNested.client.dropwizard.definitions.{A, B, C, TestResponse}
+
+class JacksonNestedTest extends AnyFreeSpec with Matchers {
+  "Jackson nested schemas" - {
+    "Should have the nested objects in the right place" in {
+      new TestResponse.Builder()
+        .withEnum1(A.Enum1.B)
+        .withEnum2(B.Enum2.D)
+        .withObj(new C.Obj.Builder().withValue("foo").build())
+        .build()
+    }
+
+    "Should have nested classes as public static members" in {
+      classOf[C.Obj].getModifiers & Modifier.PUBLIC mustBe Modifier.PUBLIC
+      classOf[C.Obj].getModifiers & Modifier.STATIC mustBe Modifier.STATIC
+    }
+
+    "Should have nested enums as public non-static members that nonetheless reflect as static" in {
+      classOf[A.Enum1].getModifiers & Modifier.PUBLIC mustBe Modifier.PUBLIC
+      classOf[A.Enum1].getModifiers & Modifier.STATIC mustBe Modifier.STATIC
+    }
+  }
+}


### PR DESCRIPTION
Java doesn't need it, as all declarations should end up as static members of their outer class.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
