### PR TITLE
use '@v1' for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK
-      uses: actions/setup-java@v1.2.0
+      uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java }}
     - name: print Java version
       run: java -version
-    - uses: actions/cache@v1.0.3
+    - uses: actions/cache@v1
       with:
         path: ~/.cache/coursier
         key: ${{ runner.os }}-scala-${{ matrix.scala }}-${{ hashFiles('**/*.sbt') }}


### PR DESCRIPTION
Per discussion with GitHub engineers, '@v1' is preferred over '@v1.0.3'

The tag '@v1' is updated whenever GitHub makes a new release

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
