### PR TITLE
Cleanup

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpHelper.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpHelper.scala
@@ -1,28 +1,33 @@
 package com.twilio.guardrail.generators
 
 import cats.data.NonEmptyList
+import com.twilio.guardrail.Target
 import com.twilio.guardrail.terms.RouteMeta
 import scala.meta._
 
 object AkkaHttpHelper {
-  def generateDecoder(tpe: Type, consumes: NonEmptyList[RouteMeta.ContentType]): (Term, Type) = {
+  def generateDecoder(tpe: Type, consumes: NonEmptyList[RouteMeta.ContentType]): Target[(Term, Type)] = {
     val baseType = tpe match {
       case t"Option[$x]" => x
       case x             => x
     }
 
-    val unmarshaller = consumes.map {
-      case RouteMeta.ApplicationJson => q"structuredJsonEntityUnmarshaller"
-      case RouteMeta.TextPlain       => q"stringyJsonEntityUnmarshaller"
-      case contentType               => throw new Exception(s"Unable to generate decoder for ${contentType}")
-    } match {
-      case NonEmptyList(x, Nil) => x
-      case xs                   => q"Unmarshaller.firstOf(..${xs.toList})"
+    for {
+      unmarshallers <- consumes.traverse[Target, Term]({
+        case RouteMeta.ApplicationJson => Target.pure(q"structuredJsonEntityUnmarshaller")
+        case RouteMeta.TextPlain       => Target.pure(q"stringyJsonEntityUnmarshaller")
+        case contentType               => Target.raiseError(s"Unable to generate decoder for ${contentType}")
+      })
+      unmarshaller = unmarshallers match {
+        case NonEmptyList(x, Nil) => x
+        case xs                   => q"Unmarshaller.firstOf(..${xs.toList})"
+      }
+    } yield {
+      val decoder = q""" {
+        ${unmarshaller}.flatMap(_ => _ => json => io.circe.Decoder[${baseType}].decodeJson(json).fold(FastFuture.failed, FastFuture.successful))
+      }
+      """
+      (decoder, baseType)
     }
-    val decoder = q""" {
-      ${unmarshaller}.flatMap(_ => _ => json => io.circe.Decoder[${baseType}].decodeJson(json).fold(FastFuture.failed, FastFuture.successful))
-    }
-    """
-    (decoder, baseType)
   }
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/CirceProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/CirceProtocolGenerator.scala
@@ -2,7 +2,6 @@ package com.twilio.guardrail
 package generators
 
 import _root_.io.swagger.v3.oas.models.media._
-import cats.data.NonEmptyList
 import cats.implicits._
 import cats.~>
 import com.twilio.guardrail.core.Tracker

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/Responses.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/Responses.scala
@@ -9,7 +9,6 @@ import com.twilio.guardrail.languages.LA
 import com.twilio.guardrail.terms.{ ScalaTerms, SwaggerTerms }
 import com.twilio.guardrail.terms.framework.FrameworkTerms
 import io.swagger.v3.oas.models.Operation
-import io.swagger.v3.oas.models.media.Schema
 import scala.collection.JavaConverters._
 
 class Response[L <: LA](val statusCodeName: L#TermName, val statusCode: Int, val value: Option[(L#Type, Option[L#Term])], val headers: Headers[L]) {


### PR DESCRIPTION
- Biting the bullet and converting `AkkaHttpServerGenerator`'s `build` to return `Target`, acknowledging the fact that it can fail.
- Removing unused imports

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.