### PR TITLE
codegen performance improvements

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/CLI.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/CLI.scala
@@ -178,9 +178,10 @@ trait CLICommon {
                 value =>
                   Target
                     .pushLogger(StructuredLogger.error(s"${AnsiColor.RED}Error in ${rs.path}${AnsiColor.RESET}"))
+                    .toEitherT
                     .subflatMap(_ => Either.left[Error, List[Path]](value))
               )
-              <* Target.pushLogger(StructuredLogger.reset)
+              <* Target.pushLogger(StructuredLogger.reset).toEitherT
         )
       )
       .map(_.distinct)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/CLI.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/CLI.scala
@@ -96,7 +96,7 @@ trait CLICommon {
 
     val fallback = List.empty[Path]
     import CLICommon.unsafePrintHelp
-    val (logger, paths) = result
+    val /*(logger,*/ paths /*)*/ = result
       .fold(
         {
           case MissingArg(args, Error.ArgName(arg)) =>
@@ -143,9 +143,8 @@ trait CLICommon {
         },
         identity
       )
-      .runEmpty
 
-    println(logger.show)
+    // println(logger.show)
   }
 
   def runLanguages(

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/CLI.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/CLI.scala
@@ -166,7 +166,7 @@ trait CLICommon {
         }).map(_.toList)
     })
 
-  def guardrailRunner: Map[String, NonEmptyList[Args]] => Target[List[java.nio.file.Path]] = { tasks =>
+  def guardrailRunner: Map[String, NonEmptyList[Args]] => CoreTarget[List[java.nio.file.Path]] = { tasks =>
     runLanguages(tasks)
       .flatMap(
         _.flatTraverse(

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ReadSwagger.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ReadSwagger.scala
@@ -9,7 +9,7 @@ import io.swagger.v3.parser.core.models.ParseOptions
 
 case class ReadSwagger[T](path: Path, next: OpenAPI => T)
 object ReadSwagger {
-  def readSwagger[T](rs: ReadSwagger[Target[T]]): Target[T] =
+  def readSwagger[T](rs: ReadSwagger[Target[T]]): CoreTarget[T] =
     if (rs.path.toFile.exists()) {
       val opts = new ParseOptions()
       opts.setResolve(true)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ReadSwagger.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ReadSwagger.scala
@@ -18,7 +18,7 @@ object ReadSwagger {
           Option(new OpenAPIParser().readLocation(rs.path.toAbsolutePath.toString, new util.LinkedList(), opts).getOpenAPI),
           UserError(s"Spec file ${rs.path} is incorrectly formatted.")
         )
-        .flatMap(rs.next)
+        .flatMap(rs.next(_).toEitherT)
     } else {
       CoreTarget.raiseError(UserError(s"Spec file ${rs.path} does not exist."))
     }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Target.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Target.scala
@@ -1,0 +1,100 @@
+package com.twilio.guardrail
+
+import com.twilio.swagger.core.StructuredLogger
+import cats.{ Applicative, MonadError }
+import cats.data.EitherT
+import cats.Traverse
+import cats.Eval
+
+object Target extends LogAbstraction {
+  type F[A] = Target[A]
+  val A = new Applicative[Target] {
+    def pure[A](x: A): Target[A] = new TargetValue(x)
+    def ap[A, B](ff: Target[A => B])(fa: Target[A]): Target[B] =
+      (ff, fa) match {
+        case (TargetValue(f), TargetValue(a)) => new TargetValue(f(a))
+        case (TargetError(err), _)            => new TargetError(err)
+        case (_, TargetError(err))            => new TargetError(err)
+      }
+  }
+  def pushLogger(value: StructuredLogger): Target[Unit] = new TargetValue(()) // IndexedStateT.modify(_ |+| value))
+  def pure[T](x: T): Target[T]                          = A.pure(x)
+  @deprecated("Use raiseError instead", "v0.41.2")
+  def error[T](x: String): Target[T]          = raiseError(x)
+  def raiseError[T](x: String): Target[T]     = new TargetError(UserError(x))
+  def raiseException[T](x: String): Target[T] = new TargetError(RuntimeFailure(x))
+  def fromOption[T](x: Option[T], default: => String): Target[T] =
+    x.fold[Target[T]](new TargetError(UserError(default)))(new TargetValue(_))
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeExtract[T](x: Target[T]): T =
+    x.valueOr({ err =>
+      throw new Exception(err.toString)
+    })
+  // .runEmptyA
+
+  implicit val targetInstances = new MonadError[Target, Error] with Traverse[Target] {
+    def pure[A](x: A): Target[A] = Target.A.pure(x)
+
+    def handleErrorWith[A](fa: Target[A])(f: Error => Target[A]): Target[A] = fa match {
+      case fa @ TargetValue(_) => fa
+      case TargetError(err)    => f(err)
+    }
+    def raiseError[A](e: Error): Target[A] = new TargetError(e)
+
+    def flatMap[A, B](fa: Target[A])(f: A => Target[B]): Target[B] = fa match {
+      case TargetValue(a)   => f(a)
+      case TargetError(err) => new TargetError(err)
+    }
+    def tailRecM[A, B](a: A)(f: A => Target[Either[A, B]]): Target[B] =
+      f(a) match {
+        case TargetError(err) =>
+          new TargetError(err)
+        case TargetValue(e) =>
+          e match {
+            case Left(b)  => tailRecM(b)(f)
+            case Right(a) => new TargetValue(a)
+          }
+      }
+
+    def foldLeft[A, B](fa: Target[A], b: B)(f: (B, A) => B): B = fa match {
+      case TargetValue(a) => f(b, a)
+      case TargetError(_) => b
+    }
+    def foldRight[A, B](fa: Target[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] = fa match {
+      case TargetValue(a) => f(a, lb)
+      case TargetError(_) => lb
+    }
+    def traverse[G[_], A, B](fa: Target[A])(f: A => G[B])(implicit G: Applicative[G]): G[Target[B]] = fa match {
+      case TargetValue(a) => G.ap(G.pure(Target.pure[B](_)))(f(a))
+      case TargetError(e) => G.pure[Target[B]](new TargetError(e))
+    }
+  }
+}
+
+sealed abstract class Target[A] {
+  def valueOr[AA >: A](fallback: Error => AA): AA
+  def toEitherT: EitherT[cats.Id, Error, A]
+  def map[B](f: A => B): Target[B]
+  def flatMap[B](f: A => Target[B]): Target[B]
+  def recover[AA >: A](f: Error => AA): Target[AA]
+}
+object TargetValue {
+  def unapply[A](x: TargetValue[A]): Option[A] = Some(x.value)
+}
+class TargetValue[A](val value: A) extends Target[A] {
+  def valueOr[AA >: A](fallback: Error => AA): AA  = value
+  def toEitherT: EitherT[cats.Id, Error, A]        = EitherT.right[Error](cats.Monad[cats.Id].pure(value))
+  def map[B](f: A => B): Target[B]                 = new TargetValue(f(value))
+  def flatMap[B](f: A => Target[B]): Target[B]     = f(value)
+  def recover[AA >: A](f: Error => AA): Target[AA] = new TargetValue(value)
+}
+object TargetError {
+  def unapply[A](x: TargetError[A]): Option[Error] = Some(x.error)
+}
+class TargetError[A](val error: Error) extends Target[A] {
+  def valueOr[AA >: A](fallback: Error => AA): AA  = fallback(error)
+  def toEitherT: EitherT[cats.Id, Error, A]        = EitherT.left[A](cats.Monad[cats.Id].pure(error))
+  def map[B](f: A => B): Target[B]                 = new TargetError(error)
+  def flatMap[B](f: A => Target[B]): Target[B]     = new TargetError(error)
+  def recover[AA >: A](f: Error => AA): Target[AA] = new TargetValue(f(error))
+}

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
@@ -19,7 +19,7 @@ case class CoreTermInterp[L <: LA](
   def apply[T](x: CoreTerm[L, T]): CoreTarget[T] = x match {
     case GetDefaultFramework() =>
       CoreTarget.log.function("getDefaultFramework") {
-        Target.log.debug(s"Providing ${defaultFramework}") >> CoreTarget.pure(Some(defaultFramework))
+        CoreTarget.log.debug(s"Providing ${defaultFramework}") >> CoreTarget.pure(Some(defaultFramework))
       }
 
     case ExtractGenerator(context, vendorDefaultFramework) =>
@@ -60,7 +60,7 @@ case class CoreTermInterp[L <: LA](
       type To   = List[Args]
       val start: From = (List.empty[Args], args.toList)
       import CoreTarget.log.debug
-      Target.log.function("parseArgs") {
+      CoreTarget.log.function("parseArgs") {
         FlatMap[CoreTarget].tailRecM[From, To](start)({
           case pair @ (sofar, rest) =>
             val empty = sofar
@@ -118,7 +118,7 @@ case class CoreTermInterp[L <: LA](
         case x: Parsed.Error      => Left(x)
         case Parsed.Success(tree) => Right(tree)
       }
-      Target.log.function("processArgSet")(for {
+      CoreTarget.log.function("processArgSet")(for {
         _          <- CoreTarget.log.debug("Processing arguments")
         specPath   <- CoreTarget.fromOption(args.specPath, MissingArg(args, Error.ArgName("--specPath")))
         outputPath <- CoreTarget.fromOption(args.outputPath, MissingArg(args, Error.ArgName("--outputPath")))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
@@ -2,7 +2,7 @@ package com.twilio.guardrail
 package core
 
 import cats.data.{ NonEmptyList, State }
-import cats.free.{ Free, GuardrailFreeHacks }
+// Issue #496: Injected StructuredLogger too slow import cats.free.{ Free, GuardrailFreeHacks }
 import cats.implicits._
 import cats.{ FlatMap, ~> }
 import com.twilio.guardrail.languages.LA
@@ -150,8 +150,9 @@ case class CoreTermInterp[L <: LA](
                   result <- Common
                     .writePackage[L, CodegenApplication[L, ?]](proto, codegen, context)(Paths.get(outputPath), pkgName, dtoPackage, customImports)
                 } yield result
-                GuardrailFreeHacks
-                  .injectLogs(program, Set("LogPush", "LogPop", "LogDebug", "LogInfo", "LogWarning", "LogError"), Sw.log.push, Sw.log.pop, Free.pure(()))
+                // Issue #496: Injected StructuredLogger too slow
+                // GuardrailFreeHacks.injectLogs(program, Set("LogPush", "LogPop", "LogDebug", "LogInfo", "LogWarning", "LogError"), Sw.log.push, Sw.log.pop, Free.pure(()))
+                program
                   .foldMap(targetInterpreter)
               } catch {
                 case NonFatal(ex) =>

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaModule.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaModule.scala
@@ -12,6 +12,8 @@ import cats.arrow.FunctionK
 import cats.data.NonEmptyList
 
 object JavaModule extends AbstractModule[JavaLanguage] {
+  implicit val coreTargetMonad: cats.Monad[CoreTarget] = cats.data.EitherT.catsDataMonadErrorForEitherT[cats.Id, Error]
+
   def jackson: FunctionK[ModelInterpreters[JavaLanguage, ?], Target] = {
     val interpDefinitionPM
         : FunctionK[DefinitionPM[JavaLanguage, ?], Target]                         = JacksonGenerator.ProtocolSupportTermInterp or JacksonGenerator.ModelProtocolTermInterp

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaModule.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaModule.scala
@@ -6,6 +6,8 @@ import cats.data.NonEmptyList
 import cats.arrow.FunctionK
 
 object ScalaModule extends AbstractModule[ScalaLanguage] {
+  implicit val coreTargetMonad: cats.Monad[CoreTarget] = cats.data.EitherT.catsDataMonadErrorForEitherT[cats.Id, Error]
+
   def circe: FunctionK[ModelInterpreters[ScalaLanguage, ?], Target] = {
     val interpDefinitionPM
         : FunctionK[DefinitionPM[ScalaLanguage, ?], Target]                         = CirceProtocolGenerator.ProtocolSupportTermInterp or CirceProtocolGenerator.ModelProtocolTermInterp

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
@@ -40,7 +40,7 @@ package guardrail {
   object Target extends LogAbstraction {
     type F[A] = Target[A]
     val A                                                 = Applicative[Target]
-    def pushLogger(value: StructuredLogger): Target[Unit] = EitherT.right(IndexedStateT.modify(_ |+| value))
+    def pushLogger(value: StructuredLogger): Target[Unit] = EitherT.pure(()) // IndexedStateT.modify(_ |+| value))
     def pure[T](x: T): Target[T]                          = A.pure(x)
     @deprecated("Use raiseError instead", "v0.41.2")
     def error[T](x: String): Target[T]          = raiseError(x)
@@ -51,15 +51,15 @@ package guardrail {
     @SuppressWarnings(Array("org.wartremover.warts.Throw"))
     def unsafeExtract[T](x: Target[T]): T =
       x.valueOr({ err =>
-          throw new Exception(err.toString)
-        })
-        .runEmptyA
+        throw new Exception(err.toString)
+      })
+    // .runEmptyA
   }
 
   object CoreTarget extends LogAbstraction {
     type F[A] = CoreTarget[A]
     val A                                                     = Applicative[CoreTarget]
-    def pushLogger(value: StructuredLogger): CoreTarget[Unit] = EitherT.right(IndexedStateT.modify(_ |+| value))
+    def pushLogger(value: StructuredLogger): CoreTarget[Unit] = EitherT.pure(()) // IndexedStateT.modify(_ |+| value))
     def pure[T](x: T): CoreTarget[T]                          = x.pure[CoreTarget]
     def fromOption[T](x: Option[T], default: => Error): CoreTarget[T] =
       EitherT.fromOption(x, default)
@@ -69,9 +69,9 @@ package guardrail {
     @SuppressWarnings(Array("org.wartremover.warts.Throw"))
     def unsafeExtract[T](x: CoreTarget[T]): T =
       x.valueOr({ err =>
-          throw new Exception(err.toString)
-        })
-        .runEmptyA
+        throw new Exception(err.toString)
+      })
+    //.runEmptyA
   }
 }
 
@@ -94,9 +94,9 @@ package object guardrail {
   type CodegenApplication[L <: LA, T] = EitherK[ScalaTerm[L, ?], Parser[L, ?], T]
 
   type Logger[T]     = IndexedStateT[Id, StructuredLogger, StructuredLogger, T]
-  type Target[A]     = EitherT[Logger, Error, A]
-  type CoreTarget[A] = EitherT[Logger, Error, A]
+  type Target[A]     = EitherT[Id, Error, A]
+  type CoreTarget[A] = EitherT[Id, Error, A]
 
   // Likely can be removed in future versions of scala or cats? -Ypartial-unification seems to get confused here -- possibly higher arity issues?
-  implicit val loggerMonad: cats.Monad[Logger] = cats.data.IndexedStateT.catsDataMonadForIndexedStateT[cats.Id, StructuredLogger]
+  // implicit val loggerMonad: cats.Monad[Logger] = cats.data.IndexedStateT.catsDataMonadForIndexedStateT[cats.Id, StructuredLogger]
 }

--- a/modules/codegen/src/test/scala/core/GuardrailFreeHacksSuite.scala
+++ b/modules/codegen/src/test/scala/core/GuardrailFreeHacksSuite.scala
@@ -23,6 +23,7 @@ case class Passthrough(value: String) extends Algebra[String]
   *  For documentation, please see GuardrailFreeHacks itself.
   */
 class GuardrailFreeHacksSuite extends FunSuite with Matchers {
+  /*
   def genLogEntries(): StructuredLogger = {
     type Program[A] = EitherK[Algebra, SwaggerTerm[ScalaLanguage, ?], A]
     val Sw = SwaggerTerms.swaggerTerm[ScalaLanguage, Program]
@@ -170,4 +171,5 @@ class GuardrailFreeHacksSuite extends FunSuite with Matchers {
     implicit val logLevel = LogLevels.Silent
     genLogEntries().show should ===(expected)
   }
+ */
 }

--- a/modules/codegen/src/test/scala/core/StructuredLoggerSuite.scala
+++ b/modules/codegen/src/test/scala/core/StructuredLoggerSuite.scala
@@ -7,6 +7,7 @@ import com.twilio.swagger.core._
 import org.scalatest.{ FunSuite, Matchers }
 
 class StructuredLoggerSuite extends FunSuite with Matchers {
+  /*
   test("Structured Logger can nest functions") {
     val structure =
       Target.log.function("first") {
@@ -30,4 +31,5 @@ class StructuredLoggerSuite extends FunSuite with Matchers {
       logEntries.show should ===(expected)
     }
   }
+ */
 }

--- a/modules/codegen/src/test/scala/support/SwaggerSpecRunner.scala
+++ b/modules/codegen/src/test/scala/support/SwaggerSpecRunner.scala
@@ -39,7 +39,7 @@ trait SwaggerSpecRunner extends EitherValues {
       Sc: ScalaTerms[L, CodegenApplication[L, ?]],
       Sw: SwaggerTerms[L, CodegenApplication[L, ?]]
   ): (ProtocolDefinitions[L], Clients[L], Servers[L]) = {
-    val (clientLogger, (proto, CodegenDefinitions(clients, Nil, clientSupportDefs, _))) =
+    val /*(clientLogger,*/ (proto, CodegenDefinitions(clients, Nil, clientSupportDefs, _)) =
       Common
         .prepareDefinitions[L, CodegenApplication[L, ?]](
           CodegenTarget.Client,
@@ -51,9 +51,9 @@ trait SwaggerSpecRunner extends EitherValues {
         .valueOr({ err =>
           throw new Exception(err.toString)
         })
-        .runEmpty
+    //.runEmpty
 
-    val (serverLogger, (_, CodegenDefinitions(Nil, servers, serverSupportDefs, _))) =
+    val /*(serverLogger,*/ (_, CodegenDefinitions(Nil, servers, serverSupportDefs, _)) =
       Common
         .prepareDefinitions[L, CodegenApplication[L, ?]](
           CodegenTarget.Server,
@@ -65,7 +65,7 @@ trait SwaggerSpecRunner extends EitherValues {
         .valueOr({ err =>
           throw new Exception(err.toString)
         })
-        .runEmpty
+    //.runEmpty
 
     // FIXME: In lieu of https://github.com/scalatest/scalatest/issues/405,
     // figure out a way to use https://stackoverflow.com/a/7219813 to only println
@@ -92,15 +92,21 @@ trait SwaggerSpecRunner extends EitherValues {
       Sc: ScalaTerms[L, CodegenApplication[L, ?]],
       Sw: SwaggerTerms[L, CodegenApplication[L, ?]]
   ): (StructuredLogger, Error) =
-    Common
-      .prepareDefinitions[L, CodegenApplication[L, ?]](
-        kind,
-        context,
-        Tracker(swagger),
-        List.empty
-      )
-      .foldMap(framework)
-      .value
-      .runEmpty
-      .map(_.map(_.left.value))
+    (
+      StructuredLogger(Vector.empty),
+      Common
+        .prepareDefinitions[L, CodegenApplication[L, ?]](
+          kind,
+          context,
+          Tracker(swagger),
+          List.empty
+        )
+        .foldMap(framework) match {
+        case TargetError(err) => err
+        case _                => ???
+      }
+    )
+  //.value
+  //.runEmpty
+  //.map(_.map(_.left.value))
 }


### PR DESCRIPTION
- Temporarily disables StructuredLogger
- Replaces `EitherT` in `Target` with a bespoke implementation

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.