### PR TITLE
Including Tracker history in FallbackPropertyTypeHandler

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
@@ -440,7 +440,7 @@ object SwaggerUtil {
           .orRefine({ case p: PasswordSchema => p })(buildResolveNoDefault)
           .orRefine({ case f: FileSchema => f })(buildResolveNoDefault)
           .orRefine({ case u: UUIDSchema => u })(buildResolveNoDefault)
-          .orRefineFallback(x => fallbackPropertyTypeHandler(x.get).map(Resolved[L](_, None, None, None, None))) // This may need to be rawType=string?
+          .orRefineFallback(x => fallbackPropertyTypeHandler(x).map(Resolved[L](_, None, None, None, None))) // This may need to be rawType=string?
       }
     }
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/core/Tracker.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/core/Tracker.scala
@@ -83,6 +83,8 @@ trait HighPriorityTrackerSyntax extends LowPriorityTrackerSyntax {
   }
 
   implicit class OptionSyntax[A](tracker: Tracker[Option[A]]) {
+    def fold[B](default: => B)(f: Tracker[A] => B): B =
+      tracker.unwrapTracker.fold(default)(x => f(Tracker.cloneHistory(tracker, x)))
     def orHistory: Either[Vector[String], Tracker[A]]      = tracker.indexedCosequence.toRight(tracker.history)
     def raiseErrorIfEmpty(err: String): Target[Tracker[A]] = Target.fromOption(tracker.indexedCosequence, s"${err} (${tracker.showHistory})")
     class FlatDownFieldPartiallyApplied[C](val dummy: Boolean = true) {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/SwaggerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/SwaggerGenerator.scala
@@ -198,10 +198,10 @@ object SwaggerGenerator {
           .raiseErrorIfEmpty("Unknown type")
 
       case FallbackPropertyTypeHandler(prop) =>
-        val determinedType = Option(prop.getType()).fold("No type definition")(s => s"type: $s")
-        val className      = prop.getClass.getName
+        val determinedType = prop.downField("type", _.getType()).fold("No type definition")(s => s"type: ${s.unwrapTracker}")
+        val className      = prop.unwrapTracker.getClass.getName
         Target.raiseError(
-          s"""|Unknown type for the following structure (${determinedType}, class: ${className}):
+          s"""|Unknown type for the following structure (${determinedType}, class: ${className}, ${prop.showHistory}):
               |  ${prop.toString().linesIterator.filterNot(_.contains(": null")).mkString("\n  ")}
               |""".stripMargin
         )

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
@@ -307,7 +307,7 @@ case class GetResponses[L <: LA](operationId: String, operation: Tracker[Operati
 case class GetSimpleRef[L <: LA](ref: Tracker[Option[Schema[_]]])                             extends SwaggerTerm[L, String]
 case class GetItems[L <: LA](arr: Tracker[ArraySchema])                                       extends SwaggerTerm[L, Tracker[Schema[_]]]
 case class GetType[L <: LA](model: Tracker[Schema[_]])                                        extends SwaggerTerm[L, Tracker[String]]
-case class FallbackPropertyTypeHandler[L <: LA](prop: Schema[_])                              extends SwaggerTerm[L, L#Type]
+case class FallbackPropertyTypeHandler[L <: LA](prop: Tracker[Schema[_]])                     extends SwaggerTerm[L, L#Type]
 case class ResolveType[L <: LA](name: String, protocolElems: List[StrictProtocolElems[L]])    extends SwaggerTerm[L, StrictProtocolElems[L]]
 case class FallbackResolveElems[L <: LA](lazyElems: List[LazyProtocolElems[L]])               extends SwaggerTerm[L, List[StrictProtocolElems[L]]]
 case class LogPush[L <: LA](name: String)                                                     extends SwaggerTerm[L, Unit]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerms.scala
@@ -67,7 +67,7 @@ class SwaggerTerms[L <: LA, F[_]](implicit I: InjectK[SwaggerTerm[L, ?], F]) {
   def getType(model: Tracker[Schema[_]]): Free[F, Tracker[String]] =
     Free.inject[SwaggerTerm[L, ?], F](GetType(model))
 
-  def fallbackPropertyTypeHandler(prop: Schema[_]): Free[F, L#Type] =
+  def fallbackPropertyTypeHandler(prop: Tracker[Schema[_]]): Free[F, L#Type] =
     Free.inject[SwaggerTerm[L, ?], F](FallbackPropertyTypeHandler(prop))
 
   def resolveType(name: String, protocolElems: List[StrictProtocolElems[L]]): Free[F, StrictProtocolElems[L]] =


### PR DESCRIPTION
For failed type lookups, include the history of the object in the error message

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
