### PR TITLE
Attempting to debug microsite issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,10 @@ scala:
 # Travis doesn't know it's safe to do a relase build (tag build) at the same time as the safety net master build,
 # so the release build is always delayed by a full test run unnecessarily.
 script: >
-  if ( [[ "$TRAVIS_PULL_REQUEST" != "false" ]] || [[ ! -z "$TRAVIS_TAG" ]] ); then
-    sbt ++$TRAVIS_SCALA_VERSION checkFormatting testSuite
+  if [[ "$TRAVIS_PULL_REQUEST_BRANCH" = "microsite-fix" && "$TRAVIS_PULL_REQUEST_SLUG" = "blast-hardcheese/guardrail" ]]; then
+    sbt microsite/publishMicrosite;
+  elif ( [[ "$TRAVIS_PULL_REQUEST" != "false" ]] || [[ ! -z "$TRAVIS_TAG" ]] ); then
+    sbt ++$TRAVIS_SCALA_VERSION checkFormatting testSuite;
   fi
 
 matrix:
@@ -55,5 +57,5 @@ before_script:
 
 after_success:
 - if [ $TRAVIS_PULL_REQUEST = 'false' ] && [[ "$TRAVIS_TAG" = v* ]]; then
-    sbt ++$TRAVIS_SCALA_VERSION codegen/clean publishBintray codegen/bintrayRelease publishSonatype sonatypeBundleRelease microsite/makeMicrosite microsite/publishMicrosite;
+    sbt ++$TRAVIS_SCALA_VERSION codegen/clean publishBintray codegen/bintrayRelease publishSonatype sonatypeBundleRelease microsite/publishMicrosite;
   fi


### PR DESCRIPTION
Currently, the CSS directory is not uploaded when doing a release. This PR follows up #511, by setting the log level and attempting to publish microsites from a particular branch instead of having to do a release every time.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
