### PR TITLE
ci: SBT workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,5 +29,7 @@ jobs:
         key: ${{ runner.os }}-scala-${{ matrix.scala }}-${{ hashFiles('**/*.sbt') }}
         restore-keys: |
           ${{ runner.os }}-scala-${{ matrix.scala }}-
+    - name: SBT scriptversion
+      run:  sbt --debug --script-version
     - name: Run tests
       run:  sbt ++${{ matrix.scala }} clean checkFormatting testSuite


### PR DESCRIPTION
SBT 1.3.x isn't working properly with {JDK11, JDK13} on Ubuntu

SBT 1.3.6 claims to fix this issue, but SBT 1.3.6 doesn't appear to work properly.

reference:
https://github.com/sbt/sbt/issues/5270

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
