### PR TITLE
improve parameter error messages

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/SwaggerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/SwaggerGenerator.scala
@@ -16,11 +16,13 @@ import scala.collection.JavaConverters._
 import scala.util.Try
 
 object SwaggerGenerator {
-  private def parameterSchemaType(parameter: Tracker[Parameter]): Target[Tracker[String]] =
+  private def parameterSchemaType(parameter: Tracker[Parameter]): Target[Tracker[String]] = {
+    val parameterName: String = Option(parameter.get.getName).fold("no name")(s => s"named: ${s}")
     for {
-      schema <- parameter.downField("schema", _.getSchema).raiseErrorIfEmpty("Parameter has no schema")
-      tpe    <- schema.downField("type", _.getType).raiseErrorIfEmpty("Parameter has no schema type")
+      schema <- parameter.downField("schema", _.getSchema).raiseErrorIfEmpty(s"Parameter (${parameterName}) has no schema")
+      tpe    <- schema.downField("type", _.getType).raiseErrorIfEmpty(s"Parameter (${parameterName}) has no schema type")
     } yield tpe
+  }
 
   def apply[L <: LA]() = new (SwaggerTerm[L, ?] ~> Target) {
     def splitOperationParts(operationId: String): (List[String], String) = {


### PR DESCRIPTION
Include the parameter name in the  error messages

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
