### PR TITLE
Better parameter names handling in http4s server

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -84,6 +84,7 @@ val exampleCases: List[ExampleCase] = List(
   ExampleCase(sampleResource("pathological-parameters.yaml"), "pathological"),
   ExampleCase(sampleResource("response-headers.yaml"), "responseHeaders"),
   ExampleCase(sampleResource("binary.yaml"), "binary").frameworks(Set("http4s")),
+  ExampleCase(sampleResource("conflicting-names.yaml"), "conflictingNames")
 )
 
 val exampleFrameworkSuites = Map(

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
@@ -4,6 +4,7 @@ package generators
 import cats.arrow.FunctionK
 import cats.data.NonEmptyList
 import cats.implicits._
+import cats.Traverse
 import com.twilio.guardrail.core.Tracker
 import com.twilio.guardrail.extract.{ ServerRawResponse, TracingLabel }
 import com.twilio.guardrail.generators.syntax._
@@ -201,10 +202,10 @@ object Http4sServerGenerator {
     def qsToHttp4s(operationId: String): List[ScalaParameter[ScalaLanguage]] => Target[Option[Pat]] =
       params =>
         directivesFromParams(
-          arg => _ => Target.pure(p"${Term.Name(s"${operationId.capitalize}${arg.paramName.value.capitalize}Matcher")}(${Pat.Var(arg.paramName)})"),
-          arg => _ => Target.pure(p"${Term.Name(s"${operationId.capitalize}${arg.paramName.value.capitalize}Matcher")}(${Pat.Var(arg.paramName)} @ _*)"),
-          arg => _ => Target.pure(p"${Term.Name(s"${operationId.capitalize}${arg.paramName.value.capitalize}Matcher")}(${Pat.Var(arg.paramName)})"),
-          arg => _ => Target.pure(p"${Term.Name(s"${operationId.capitalize}${arg.paramName.value.capitalize}Matcher")}(${Pat.Var(arg.paramName)})")
+          arg => _ => Target.pure(p"${Term.Name(s"${operationId.capitalize}${arg.argName.value.capitalize}Matcher")}(${Pat.Var(arg.paramName)})"),
+          arg => _ => Target.pure(p"${Term.Name(s"${operationId.capitalize}${arg.argName.value.capitalize}Matcher")}(${Pat.Var(arg.paramName)} @ _*)"),
+          arg => _ => Target.pure(p"${Term.Name(s"${operationId.capitalize}${arg.argName.value.capitalize}Matcher")}(${Pat.Var(arg.paramName)})"),
+          arg => _ => Target.pure(p"${Term.Name(s"${operationId.capitalize}${arg.argName.value.capitalize}Matcher")}(${Pat.Var(arg.paramName)})")
         )(params).map {
           case Nil => Option.empty
           case x :: xs =>
@@ -432,11 +433,11 @@ object Http4sServerGenerator {
           .raiseErrorIfEmpty("Missing operationId")
           .map(_.get)
 
-        formArgs   = parameters.formParams
-        headerArgs = parameters.headerParams
-        pathArgs   = parameters.pathParams
-        qsArgs     = parameters.queryStringParams
-        bodyArgs   = parameters.bodyParams
+        formArgs   <- prepareParameters(parameters.formParams)
+        headerArgs <- prepareParameters(parameters.headerParams)
+        pathArgs   <- prepareParameters(parameters.pathParams)
+        qsArgs     <- prepareParameters(parameters.queryStringParams)
+        bodyArgs   <- prepareParameters(parameters.bodyParams)
 
         http4sMethod <- httpMethodToHttp4s(method)
         pathWithQs   <- pathStrToHttp4s(basePath, path, pathArgs)
@@ -712,6 +713,24 @@ object Http4sServerGenerator {
 
       decoders.distinctBy(_._1.toString()).map(_._2) ++ matchers
     }
+
+    /**
+      * It's not possible to use backticks inside pattern matching as it has different semantics: backticks inside match
+      * are just references to an already existing bindings.
+      */
+    def prepareParameters[F[_]: Traverse](parameters: F[ScalaParameter[ScalaLanguage]]): Target[F[ScalaParameter[ScalaLanguage]]] =
+      Traverse[F].traverse(parameters) { param =>
+        if (param.paramName.syntax == param.paramName.value) {
+          Target.pure(param)
+        } else {
+          // let's try to prefix it with underscore and see if it helps
+          val newName = Term.Name(s"_${param.paramName.value}")
+          Target.log.debug(s"Escaping param ${param.argName.value}").flatMap { _ =>
+            if (newName.syntax == newName.value) Target.pure(param.withParamName(newName))
+            else Target.raiseError(s"Can't escape parameter with name ${param.argName.value}.")
+          }
+        }
+      }
 
     def generateCodecs(
         operationId: String,

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaParameter.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaParameter.scala
@@ -40,6 +40,9 @@ class ScalaParameter[L <: LA] private[generators] (
 
   def withType(newArgType: L#Type, rawType: Option[String] = this.rawType.tpe, rawFormat: Option[String] = this.rawType.format): ScalaParameter[L] =
     new ScalaParameter[L](in, param, paramName, argName, newArgType, RawParameterType(rawType, rawFormat), required, hashAlgorithm, isFile)
+
+  def withParamName(newParamName: L#TermName): ScalaParameter[L] =
+    new ScalaParameter[L](in, param, newParamName, argName, argType, rawType, required, hashAlgorithm, isFile)
 }
 object ScalaParameter {
   def unapply[L <: LA](param: ScalaParameter[L]): Option[(Option[String], L#MethodParameter, L#TermName, RawParameterName, L#Type)] =

--- a/modules/sample/src/main/resources/conflicting-names.yaml
+++ b/modules/sample/src/main/resources/conflicting-names.yaml
@@ -1,0 +1,39 @@
+swagger: "2.0"
+info:
+  title: Whatever
+  version: 1.0.0
+host: localhost:1234
+schemes:
+  - http
+paths:
+  /foo/{type}:
+    post:
+      operationId: foo
+      parameters:
+        - name: type
+          in: path
+          required: true
+          type: string
+        - name: package
+          in: header
+          required: true
+          type: string
+        - name: class
+          in: query
+          required: false
+          type: string
+        - name: 42param
+          in: query
+          required: true
+          type: string
+        - name: kebab-name
+          in: query
+          required: true
+          type: string
+        - name: snake_name
+          in: query
+          required: true
+          type: string
+      responses:
+        '204':
+          description: success action


### PR DESCRIPTION
This PR fixes a use case (http4s server) where parameter name was also scala keyword. This currently generates pattern matching code with backticks. Unfortunately, backticks are used for referencing existing variable inside pattern matching. So they can't be used for variables such as `type`. This PR aims for at least partial fix. Generator now tries to detect it and "fix" it by prefix parameter name with underscore. Not perfect, nor terrible. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
