### PR TITLE
Upgrade http4s, cats, cats-effect and circe

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -27,11 +27,11 @@ guardrail version | akka-http | akka-stream | circe  | cats  | Notes
 
 ### http4s
 
-guardrail version | http4s | circe-core | cats  | Notes
------------------ | ------ | ---------- | ----- | -----
-0.34.0 ⚠          | 0.18.0 | 0.9.0      | 1.0.1 | Only clients are supported
-0.39.0            | 0.18.0 |  "         |  "    | First server release
-0.41.1            | 0.19.0 | 0.10.0     | 1.4.0 |
-0.51.0            | 0.20.0 |  "         |  "    |
-0.54.0            |   "    | 0.12.1     |  "    | For Scala 2.11, use --module circe-java8
-0.54.3            | 0.21.0 |  "         |  "    |
+guardrail version | http4s | circe-core | cats  | cats-effect | Notes
+----------------- | ------ | ---------- | ----- | ----------- | -----
+0.34.0 ⚠          | 0.18.0 | 0.9.0      | 1.0.1 | 0.10        | Only clients are supported
+0.39.0            | 0.18.0 |  "         |  "    |  "          | First server release
+0.41.1            | 0.19.0 | 0.10.0     | 1.4.0 | 1.0.0       |
+0.51.0            | 0.20.0 |  "         |  "    |  "          |
+0.54.0            |   "    | 0.12.1     |  "    |  "          | For Scala 2.11, use --module circe-java8
+0.55.4            | 0.21.0 | 0.13.0     | 2.1.0 | 2.1.0       |

--- a/build.sbt
+++ b/build.sbt
@@ -11,10 +11,10 @@ git.useGitDescribe := true
 crossScalaVersions in ThisBuild := Seq("2.12.10")
 
 val akkaVersion          = "10.0.14"
-val catsVersion          = "1.6.0"
-val catsEffectVersion    = "1.0.0"
-val circeVersion         = "0.12.1"
-val http4sVersion        = "0.20.0"
+val catsVersion          = "2.1.0"
+val catsEffectVersion    = "2.1.1"
+val circeVersion         = "0.13.0"
+val http4sVersion        = "0.21.0"
 val scalacheckVersion    = "1.14.3"
 val scalatestVersion     = "3.1.0"
 val scalatestPlusVersion = "3.1.0.0-RC2"

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sGenerator.scala
@@ -32,6 +32,7 @@ object Http4sGenerator {
             q"import org.http4s.implicits._",
             q"import org.http4s.EntityEncoder._",
             q"import org.http4s.EntityDecoder._",
+            q"import org.http4s.Media",
             q"import fs2.Stream",
             q"import io.circe.Json",
             q"import scala.language.higherKinds",
@@ -55,7 +56,7 @@ object Http4sGenerator {
             implicit def emptyEntityEncoder[F[_]: Sync]: EntityEncoder[F, EntityBody[Nothing]] = EntityEncoder.emptyEncoder
 
             implicit def byteStreamEntityDecoder[F[_]:Sync]: EntityDecoder[F, Stream[F, Byte]] = new EntityDecoder[F,Stream[F,Byte]] {
-              override def decode(msg: Message[F], strict: Boolean): DecodeResult[F, Stream[F, Byte]] = DecodeResult.success(msg.body)
+              override def decode(m: Media[F], strict: Boolean): DecodeResult[F, Stream[F, Byte]] = DecodeResult.success(m.body)
               override def consumes: Set[MediaRange] = Set(MediaRange.`*/*`)
             }
 

--- a/modules/codegen/src/test/scala/tests/core/FullyQualifiedNames.scala
+++ b/modules/codegen/src/test/scala/tests/core/FullyQualifiedNames.scala
@@ -55,9 +55,9 @@ class FullyQualifiedNames extends FunSuite with Matchers with SwaggerSpecRunner 
            val req = Request[F](method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/user/" + Formatter.addPath(id)), headers = Headers(allHeaders))
            httpClient.fetch(req)({
              case _root_.org.http4s.Status.Ok(resp) =>
-               F.map(getUserOkDecoder.decode(resp, strict = false).value.flatMap(F.fromEither))(GetUserResponse.Ok.apply)
+               F.map(getUserOkDecoder.decode(resp, strict = false).value.flatMap(F.fromEither))(GetUserResponse.Ok.apply): F[GetUserResponse]
              case resp =>
-               F.raiseError(UnexpectedStatus(resp.status))
+               F.raiseError[GetUserResponse](UnexpectedStatus(resp.status))
            })
          }
        }

--- a/modules/codegen/src/test/scala/tests/generators/http4s/BasicTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/http4s/BasicTest.scala
@@ -133,9 +133,9 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
         val req = Request[F](method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/bar"), headers = Headers(allHeaders))
         httpClient.fetch(req)({
           case _root_.org.http4s.Status.Ok(_) =>
-            F.pure(GetBarResponse.Ok)
+            F.pure(GetBarResponse.Ok): F[GetBarResponse]
           case resp =>
-            F.raiseError(UnexpectedStatus(resp.status))
+            F.raiseError[GetBarResponse](UnexpectedStatus(resp.status))
         })
       }
       def getBaz(headers: List[Header] = List.empty): F[GetBazResponse] = {
@@ -143,9 +143,9 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
         val req = Request[F](method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/baz"), headers = Headers(allHeaders))
         httpClient.fetch(req)({
           case _root_.org.http4s.Status.Ok(resp) =>
-            F.map(getBazOkDecoder.decode(resp, strict = false).value.flatMap(F.fromEither))(GetBazResponse.Ok.apply)
+            F.map(getBazOkDecoder.decode(resp, strict = false).value.flatMap(F.fromEither))(GetBazResponse.Ok.apply): F[GetBazResponse]
           case resp =>
-            F.raiseError(UnexpectedStatus(resp.status))
+            F.raiseError[GetBazResponse](UnexpectedStatus(resp.status))
         })
       }
       def postFoo(headers: List[Header] = List.empty): F[PostFooResponse] = {
@@ -153,9 +153,9 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
         val req = Request[F](method = Method.POST, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders))
         httpClient.fetch(req)({
           case _root_.org.http4s.Status.Ok(_) =>
-            F.pure(PostFooResponse.Ok)
+            F.pure(PostFooResponse.Ok): F[PostFooResponse]
           case resp =>
-            F.raiseError(UnexpectedStatus(resp.status))
+            F.raiseError[PostFooResponse](UnexpectedStatus(resp.status))
         })
       }
       def getFoo(headers: List[Header] = List.empty): F[GetFooResponse] = {
@@ -163,9 +163,9 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
         val req = Request[F](method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders))
         httpClient.fetch(req)({
           case _root_.org.http4s.Status.Ok(_) =>
-            F.pure(GetFooResponse.Ok)
+            F.pure(GetFooResponse.Ok): F[GetFooResponse]
           case resp =>
-            F.raiseError(UnexpectedStatus(resp.status))
+            F.raiseError[GetFooResponse](UnexpectedStatus(resp.status))
         })
       }
       def putFoo(headers: List[Header] = List.empty): F[PutFooResponse] = {
@@ -173,9 +173,9 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
         val req = Request[F](method = Method.PUT, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders))
         httpClient.fetch(req)({
           case _root_.org.http4s.Status.Ok(_) =>
-            F.pure(PutFooResponse.Ok)
+            F.pure(PutFooResponse.Ok): F[PutFooResponse]
           case resp =>
-            F.raiseError(UnexpectedStatus(resp.status))
+            F.raiseError[PutFooResponse](UnexpectedStatus(resp.status))
         })
       }
       def patchFoo(headers: List[Header] = List.empty): F[PatchFooResponse] = {
@@ -183,9 +183,9 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
         val req = Request[F](method = Method.PATCH, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders))
         httpClient.fetch(req)({
           case _root_.org.http4s.Status.Ok(_) =>
-            F.pure(PatchFooResponse.Ok)
+            F.pure(PatchFooResponse.Ok): F[PatchFooResponse]
           case resp =>
-            F.raiseError(UnexpectedStatus(resp.status))
+            F.raiseError[PatchFooResponse](UnexpectedStatus(resp.status))
         })
       }
       def deleteFoo(headers: List[Header] = List.empty): F[DeleteFooResponse] = {
@@ -193,9 +193,9 @@ class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
         val req = Request[F](method = Method.DELETE, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders))
         httpClient.fetch(req)({
           case _root_.org.http4s.Status.Ok(_) =>
-            F.pure(DeleteFooResponse.Ok)
+            F.pure(DeleteFooResponse.Ok): F[DeleteFooResponse]
           case resp =>
-            F.raiseError(UnexpectedStatus(resp.status))
+            F.raiseError[DeleteFooResponse](UnexpectedStatus(resp.status))
         })
       }
     }"""

--- a/modules/codegen/src/test/scala/tests/generators/http4s/client/DefaultParametersTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/http4s/client/DefaultParametersTest.scala
@@ -150,12 +150,12 @@ class DefaultParametersTest extends FunSuite with Matchers with SwaggerSpecRunne
         val req = Request[F](method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/store/order/" + Formatter.addPath(orderId) + "?" + Formatter.addArg("defparm_opt", defparmOpt) + Formatter.addArg("defparm", defparm)), headers = Headers(allHeaders))
         httpClient.fetch(req)({
           case _root_.org.http4s.Status.Ok(resp) =>
-            F.map(getOrderByIdOkDecoder.decode(resp, strict = false).value.flatMap(F.fromEither))(GetOrderByIdResponse.Ok.apply)
+            F.map(getOrderByIdOkDecoder.decode(resp, strict = false).value.flatMap(F.fromEither))(GetOrderByIdResponse.Ok.apply): F[GetOrderByIdResponse]
           case _root_.org.http4s.Status.BadRequest(_) =>
-            F.pure(GetOrderByIdResponse.BadRequest)
+            F.pure(GetOrderByIdResponse.BadRequest): F[GetOrderByIdResponse]
           case _root_.org.http4s.Status.NotFound(_) =>
-            F.pure(GetOrderByIdResponse.NotFound)
-          case resp => F.raiseError(UnexpectedStatus(resp.status))
+            F.pure(GetOrderByIdResponse.NotFound): F[GetOrderByIdResponse]
+          case resp => F.raiseError[GetOrderByIdResponse](UnexpectedStatus(resp.status))
         })
       }
       def deleteOrder(orderId: Long, headers: List[Header] = List.empty): F[DeleteOrderResponse] = {
@@ -163,10 +163,10 @@ class DefaultParametersTest extends FunSuite with Matchers with SwaggerSpecRunne
         val req = Request[F](method = Method.DELETE, uri = Uri.unsafeFromString(host + basePath + "/store/order/" + Formatter.addPath(orderId)), headers = Headers(allHeaders))
         httpClient.fetch(req)({
           case _root_.org.http4s.Status.BadRequest(_) =>
-            F.pure(DeleteOrderResponse.BadRequest)
+            F.pure(DeleteOrderResponse.BadRequest): F[DeleteOrderResponse]
           case _root_.org.http4s.Status.NotFound(_) =>
-            F.pure(DeleteOrderResponse.NotFound)
-          case resp => F.raiseError(UnexpectedStatus(resp.status))
+            F.pure(DeleteOrderResponse.NotFound): F[DeleteOrderResponse]
+          case resp => F.raiseError[DeleteOrderResponse](UnexpectedStatus(resp.status))
         })
       }
     }"""


### PR DESCRIPTION
<!-- Describe your Pull Request -->

Upgrade http4s and dependencies:

http4s 0.21.0
cats 2.1.0
cats-effect 2.1.1
circe 0.13

* scalac had troubles finding the correct lub in the generated code for the http4s client. Solved with explicit type annotations. I don't know why this suddenly became an issue. Also, quasiquotes is not my strong suite, so please review and suggest edits.
* The changes in `CirceVersion` is just cargo culting, not sure if it's necessary

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
