### PR TITLE
MIME type overhaul

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import complete.DefaultParsers._
+
 val projectName = "guardrail-root"
 name := projectName
 organization in ThisBuild := "com.twilio"
@@ -106,11 +108,11 @@ val exampleCases: List[ExampleCase] = List(
   ExampleCase(sampleResource("base64.yaml"), "base64").frameworks(scalaFrameworks.toSet),
 )
 
-def exampleArgs(language: String): List[List[String]] = exampleCases
+def exampleArgs(language: String, framework: Option[String] = None): List[List[String]] = exampleCases
   .foldLeft(List[List[String]](List(language)))({
     case (acc, ExampleCase(path, prefix, extra, onlyFrameworks)) =>
       acc ++ (for {
-        frameworkSuite <- exampleFrameworkSuites(language)
+        frameworkSuite <- exampleFrameworkSuites(language).filter(efs => framework.forall(_ == efs._1))
         (frameworkName, frameworkPackage, kinds) = frameworkSuite
         if onlyFrameworks.forall(_.contains(frameworkName))
         kind <- kinds
@@ -140,6 +142,17 @@ fullRunTask(
   "com.twilio.guardrail.CLI",
   exampleArgs("scala").flatten.filter(_.nonEmpty): _*
 )
+
+lazy val runExample: InputKey[Unit] = inputKey[Unit]("Run generators with example args (usage: runExample [language] [framework])")
+runExample := Def.inputTaskDyn {
+  val args: Seq[String] = spaceDelimited("<arg>").parsed
+  val runArgs = args match {
+    case language :: framework :: Nil => exampleArgs(language, Some(framework))
+    case language :: Nil => exampleArgs(language)
+    case Nil => exampleArgs("scala") ++ exampleArgs("java")
+  }
+  runTask(Test, "com.twilio.guardrail.CLI", runArgs.flatten.filter(_.nonEmpty): _*)
+}.evaluated
 
 artifact in (Compile, assembly) := {
   (artifact in (Compile, assembly)).value

--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,8 @@ val exampleCases: List[ExampleCase] = List(
   ExampleCase(sampleResource("server2.yaml"), "tracer").args("--tracing"),
   ExampleCase(sampleResource("pathological-parameters.yaml"), "pathological"),
   ExampleCase(sampleResource("response-headers.yaml"), "responseHeaders"),
-  ExampleCase(sampleResource("binary.yaml"), "binary").frameworks(Set("http4s")),
+  ExampleCase(sampleResource("random-content-types.yaml"), "randomContentTypes").frameworks(Set("dropwizard", "http4s")),
+  ExampleCase(sampleResource("binary.yaml"), "binary").frameworks(Set("dropwizard", "http4s")),
   ExampleCase(sampleResource("conflicting-names.yaml"), "conflictingNames"),
   ExampleCase(sampleResource("base64.yaml"), "base64").frameworks(scalaFrameworks.toSet),
 )

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
@@ -440,6 +440,7 @@ object SwaggerUtil {
           .orRefine({ case d: NumberSchema => d })(buildResolveNoDefault)
           .orRefine({ case p: PasswordSchema => p })(buildResolveNoDefault)
           .orRefine({ case f: FileSchema => f })(buildResolveNoDefault)
+          .orRefine({ case b: BinarySchema => b })(buildResolveNoDefault)
           .orRefine({ case u: UUIDSchema => u })(buildResolveNoDefault)
           .orRefineFallback(x => fallbackPropertyTypeHandler(x).map(Resolved[L](_, None, None, None, None))) // This may need to be rawType=string?
       }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpHelper.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpHelper.scala
@@ -2,11 +2,11 @@ package com.twilio.guardrail.generators
 
 import cats.data.NonEmptyList
 import com.twilio.guardrail.Target
-import com.twilio.guardrail.terms.RouteMeta
+import com.twilio.guardrail.protocol.terms.{ ApplicationJson, ContentType, TextPlain }
 import scala.meta._
 
 object AkkaHttpHelper {
-  def generateDecoder(tpe: Type, consumes: NonEmptyList[RouteMeta.ContentType]): Target[(Term, Type)] = {
+  def generateDecoder(tpe: Type, consumes: NonEmptyList[ContentType]): Target[(Term, Type)] = {
     val baseType = tpe match {
       case t"Option[$x]" => x
       case x             => x
@@ -14,9 +14,9 @@ object AkkaHttpHelper {
 
     for {
       unmarshallers <- consumes.traverse[Target, Term]({
-        case RouteMeta.ApplicationJson => Target.pure(q"structuredJsonEntityUnmarshaller")
-        case RouteMeta.TextPlain       => Target.pure(q"stringyJsonEntityUnmarshaller")
-        case contentType               => Target.raiseError(s"Unable to generate decoder for ${contentType}")
+        case ApplicationJson => Target.pure(q"structuredJsonEntityUnmarshaller")
+        case TextPlain       => Target.pure(q"stringyJsonEntityUnmarshaller")
+        case contentType     => Target.raiseError(s"Unable to generate decoder for ${contentType}")
       })
       unmarshaller = unmarshallers match {
         case NonEmptyList(x, Nil) => x

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
@@ -12,7 +12,7 @@ import com.twilio.guardrail.generators.syntax.RichOperation
 import com.twilio.guardrail.generators.syntax.Scala._
 import com.twilio.guardrail.generators.operations.TracingLabelFormatter
 import com.twilio.guardrail.languages.ScalaLanguage
-import com.twilio.guardrail.protocol.terms.Responses
+import com.twilio.guardrail.protocol.terms.{ ApplicationJson, ContentType, MultipartFormData, OctetStream, Responses, TextPlain, UrlencodedFormData }
 import com.twilio.guardrail.protocol.terms.server._
 import com.twilio.guardrail.terms.RouteMeta
 import com.twilio.guardrail.shims._
@@ -331,19 +331,19 @@ object AkkaHttpServerGenerator {
       override def toString(): String = s"Binding($value)"
     }
 
-    def formToAkka(consumes: NonEmptyList[RouteMeta.ContentType], operationId: String)(
+    def formToAkka(consumes: NonEmptyList[ContentType], operationId: String)(
         params: List[ScalaParameter[ScalaLanguage]]
     ): Target[(Option[Term], List[Stat])] = Target.log.function("formToAkka") {
       for {
-        _ <- if (params.exists(_.isFile) && !consumes.exists(_ == RouteMeta.MultipartFormData)) {
+        _ <- if (params.exists(_.isFile) && !consumes.exists(_ == MultipartFormData)) {
           Target.log.warning("type: file detected, automatically enabling multipart/form-data handling")
         } else {
           Target.pure(())
         }
 
         hasFile              = params.exists(_.isFile)
-        urlencoded           = consumes.exists(_ == RouteMeta.UrlencodedFormData)
-        multipart            = consumes.exists(_ == RouteMeta.MultipartFormData)
+        urlencoded           = consumes.exists(_ == UrlencodedFormData)
+        multipart            = consumes.exists(_ == MultipartFormData)
         referenceAccumulator = q"fileReferences"
 
         result <- NonEmptyList
@@ -539,7 +539,7 @@ object AkkaHttpServerGenerator {
             for {
               (handlers, unmarshallerTerms) <- consumes.distinct
                 .traverse[(List[Stat], ?), Target[NonEmptyList[Term.Name]]]({
-                  case RouteMeta.MultipartFormData => {
+                  case MultipartFormData => {
                     val unmarshallerTerm = q"MultipartFormDataUnmarshaller"
                     val fru = q"""
                   object ${partsTerm} {
@@ -583,7 +583,7 @@ object AkkaHttpServerGenerator {
                     (fru, Target.pure(NonEmptyList.one(unmarshallerTerm)))
                   }
 
-                  case RouteMeta.UrlencodedFormData => {
+                  case UrlencodedFormData => {
                     val unmarshallerTerm = q"FormDataUnmarshaller"
                     val fru = q"""
                   implicit val ${Pat.Var(unmarshallerTerm)}: FromRequestUnmarshaller[Either[Throwable, ${optionalTypes}]] =
@@ -623,11 +623,11 @@ object AkkaHttpServerGenerator {
                     (List(fru), Target.pure(NonEmptyList.one(unmarshallerTerm)))
                   }
 
-                  case RouteMeta.ApplicationJson => (Nil, Target.raiseError(s"Unable to generate unmarshaller for application/json"))
+                  case ApplicationJson => (Nil, Target.raiseError(s"Unable to generate unmarshaller for application/json"))
 
-                  case RouteMeta.OctetStream => (Nil, Target.raiseError(s"Unable to generate unmarshaller for application/octet-stream"))
+                  case OctetStream => (Nil, Target.raiseError(s"Unable to generate unmarshaller for application/octet-stream"))
 
-                  case RouteMeta.TextPlain => (Nil, Target.raiseError(s"Unable to generate unmarshaller for text/plain"))
+                  case TextPlain => (Nil, Target.raiseError(s"Unable to generate unmarshaller for text/plain"))
                 })
                 .traverse(_.flatSequence)
 
@@ -683,8 +683,8 @@ object AkkaHttpServerGenerator {
         _ <- Target.log.debug(s"generateRoute(${resourceName}, ${basePath}, ${route}, ${tracingFields})")
         RouteMeta(path, method, operation, securityRequirements) = route
         consumes = NonEmptyList
-          .fromList(operation.get.consumes.toList.flatMap(RouteMeta.ContentType.unapply(_)))
-          .getOrElse(NonEmptyList.one(RouteMeta.ApplicationJson))
+          .fromList(operation.get.consumes.toList.flatMap(ContentType.unapply(_)))
+          .getOrElse(NonEmptyList.one(ApplicationJson))
         operationId <- operation
           .downField("operationId", _.getOperationId())
           .map(_.map(splitOperationParts).map(_._2))
@@ -801,14 +801,14 @@ object AkkaHttpServerGenerator {
         operationId: String,
         bodyArgs: Option[ScalaParameter[ScalaLanguage]],
         responses: Responses[ScalaLanguage],
-        consumes: NonEmptyList[RouteMeta.ContentType]
+        consumes: NonEmptyList[ContentType]
     ): Target[List[Defn.Val]] =
       generateDecoders(operationId, bodyArgs, consumes)
 
     def generateDecoders(
         operationId: String,
         bodyArgs: Option[ScalaParameter[ScalaLanguage]],
-        consumes: NonEmptyList[RouteMeta.ContentType]
+        consumes: NonEmptyList[ContentType]
     ): Target[List[Defn.Val]] =
       bodyArgs.toList.traverse {
         case ScalaParameter(_, _, _, _, argType) =>

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpServerGenerator.scala
@@ -12,7 +12,17 @@ import com.twilio.guardrail.generators.syntax.RichOperation
 import com.twilio.guardrail.generators.syntax.Scala._
 import com.twilio.guardrail.generators.operations.TracingLabelFormatter
 import com.twilio.guardrail.languages.ScalaLanguage
-import com.twilio.guardrail.protocol.terms.{ ApplicationJson, ContentType, MultipartFormData, OctetStream, Responses, TextPlain, UrlencodedFormData }
+import com.twilio.guardrail.protocol.terms.{
+  ApplicationJson,
+  BinaryContent,
+  ContentType,
+  MultipartFormData,
+  OctetStream,
+  Responses,
+  TextContent,
+  TextPlain,
+  UrlencodedFormData
+}
 import com.twilio.guardrail.protocol.terms.server._
 import com.twilio.guardrail.terms.RouteMeta
 import com.twilio.guardrail.shims._
@@ -625,9 +635,9 @@ object AkkaHttpServerGenerator {
 
                   case ApplicationJson => (Nil, Target.raiseError(s"Unable to generate unmarshaller for application/json"))
 
-                  case OctetStream => (Nil, Target.raiseError(s"Unable to generate unmarshaller for application/octet-stream"))
+                  case BinaryContent(name) => (Nil, Target.raiseError(s"Unable to generate unmarshaller for $name"))
 
-                  case TextPlain => (Nil, Target.raiseError(s"Unable to generate unmarshaller for text/plain"))
+                  case TextContent(name) => (Nil, Target.raiseError(s"Unable to generate unmarshaller for $name"))
                 })
                 .traverse(_.flatSequence)
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/EndpointsClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/EndpointsClientGenerator.scala
@@ -8,7 +8,7 @@ import cats.implicits._
 import com.twilio.guardrail.generators.syntax.Scala._
 import com.twilio.guardrail.generators.syntax._
 import com.twilio.guardrail.languages.ScalaLanguage
-import com.twilio.guardrail.protocol.terms.Responses
+import com.twilio.guardrail.protocol.terms.{ ContentType, MultipartFormData, Responses, TextPlain }
 import com.twilio.guardrail.protocol.terms.client._
 import com.twilio.guardrail.terms.RouteMeta
 import com.twilio.guardrail.shims._
@@ -125,8 +125,8 @@ object EndpointsClientGenerator {
             staticQueryParams: Option[Term],
             headerParams: Term,
             responses: Responses[ScalaLanguage],
-            produces: Seq[RouteMeta.ContentType],
-            consumes: Seq[RouteMeta.ContentType],
+            produces: Seq[ContentType],
+            consumes: Seq[ContentType],
             tracing: Boolean
         )(
             tracingArgsPre: List[ScalaParameter[ScalaLanguage]],
@@ -144,7 +144,7 @@ object EndpointsClientGenerator {
           val (fallbackBodyAlgebra, fallbackBodyArgument) = (Some(q"emptyRequest"), None)
 
           val (textPlainAlgebra, textPlainArgument): (Option[Term], Option[Term]) =
-            if (consumes.contains(RouteMeta.TextPlain))
+            if (consumes.contains(TextPlain))
               (bodyArgs.map(_ => q"textPlainRequest"), bodyArgs.map(sp => if (sp.required) sp.paramName else q"""${sp.paramName}.getOrElse("")"""))
             else (None, None)
 
@@ -152,7 +152,7 @@ object EndpointsClientGenerator {
             (
               formDataParams.map(
                 _ =>
-                  if (consumes.contains(RouteMeta.MultipartFormData)) {
+                  if (consumes.contains(MultipartFormData)) {
                     q"multipartFormDataRequest"
                   } else {
                     q"formDataRequest[List[(String, String)]]()"
@@ -365,8 +365,8 @@ object EndpointsClientGenerator {
             // Placeholder for when more functions get logging
             _ <- Target.pure(())
 
-            produces = operation.get.produces.toList.flatMap(RouteMeta.ContentType.unapply(_))
-            consumes = operation.get.consumes.toList.flatMap(RouteMeta.ContentType.unapply(_))
+            produces = operation.get.produces.toList.flatMap(ContentType.unapply(_))
+            consumes = operation.get.consumes.toList.flatMap(ContentType.unapply(_))
 
             headerArgs = parameters.headerParams
             pathArgs   = parameters.pathParams
@@ -382,7 +382,7 @@ object EndpointsClientGenerator {
 
             // _ <- Target.log.debug(s"Generated: $urlWithParams")
             // Generate FormData arguments
-            formDataParams = generateFormDataParams(formArgs, consumes.contains(RouteMeta.MultipartFormData))
+            formDataParams = generateFormDataParams(formArgs, consumes.contains(MultipartFormData))
             // Generate header arguments
             headerParams = generateHeaderParams(headerArgs)
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sHelper.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sHelper.scala
@@ -1,8 +1,7 @@
 package com.twilio.guardrail.generators
 
 import com.twilio.guardrail.languages.ScalaLanguage
-import com.twilio.guardrail.protocol.terms.{ Response, Responses }
-import com.twilio.guardrail.terms.RouteMeta
+import com.twilio.guardrail.protocol.terms.{ ApplicationJson, ContentType, Response, Responses }
 import com.twilio.guardrail.StrictProtocolElems
 import scala.meta._
 
@@ -62,8 +61,8 @@ object Http4sHelper {
     List[Defn](cls, companion)
   }
 
-  def generateDecoder(tpe: Type, consumes: Seq[RouteMeta.ContentType]): Term =
-    if (consumes.contains(RouteMeta.ApplicationJson) || consumes.isEmpty)
+  def generateDecoder(tpe: Type, consumes: Seq[ContentType]): Term =
+    if (consumes.contains(ApplicationJson) || consumes.isEmpty)
       q"jsonOf[F, $tpe]"
     else
       tpe match {
@@ -83,8 +82,8 @@ object Http4sHelper {
         case _             => q"EntityDecoder[F, $tpe]"
       }
 
-  def generateEncoder(tpe: Type, produces: Seq[RouteMeta.ContentType]): Term =
-    if (produces.contains(RouteMeta.ApplicationJson) || produces.isEmpty)
+  def generateEncoder(tpe: Type, produces: Seq[ContentType]): Term =
+    if (produces.contains(ApplicationJson) || produces.isEmpty)
       q"jsonEncoderOf[F, $tpe]"
     else
       tpe match {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sServerGenerator.scala
@@ -11,7 +11,7 @@ import com.twilio.guardrail.generators.syntax._
 import com.twilio.guardrail.generators.operations.TracingLabelFormatter
 import com.twilio.guardrail.generators.syntax.Scala._
 import com.twilio.guardrail.languages.ScalaLanguage
-import com.twilio.guardrail.protocol.terms.{ Header, Response, Responses }
+import com.twilio.guardrail.protocol.terms.{ ContentType, Header, Response, Responses }
 import com.twilio.guardrail.protocol.terms.server._
 import com.twilio.guardrail.shims._
 import com.twilio.guardrail.terms.RouteMeta
@@ -566,8 +566,8 @@ object Http4sServerGenerator {
                 )
               )
 
-        val consumes = operation.get.consumes.toList.flatMap(RouteMeta.ContentType.unapply(_))
-        val produces = operation.get.produces.toList.flatMap(RouteMeta.ContentType.unapply(_))
+        val consumes = operation.get.consumes.toList.flatMap(ContentType.unapply(_))
+        val produces = operation.get.produces.toList.flatMap(ContentType.unapply(_))
         val codecs   = if (ServerRawResponse(operation).getOrElse(false)) Nil else generateCodecs(operationId, bodyArgs, responses, consumes, produces)
         val respType = if (isGeneric) t"$responseType[F]" else responseType
         Some(
@@ -739,15 +739,15 @@ object Http4sServerGenerator {
         operationId: String,
         bodyArgs: Option[ScalaParameter[ScalaLanguage]],
         responses: Responses[ScalaLanguage],
-        consumes: Seq[RouteMeta.ContentType],
-        produces: Seq[RouteMeta.ContentType]
+        consumes: Seq[ContentType],
+        produces: Seq[ContentType]
     ): List[Defn.Val] =
       generateDecoders(operationId, bodyArgs, consumes) ++ generateEncoders(operationId, responses, produces) ++ generateResponseGenerators(
             operationId,
             responses
           )
 
-    def generateDecoders(operationId: String, bodyArgs: Option[ScalaParameter[ScalaLanguage]], consumes: Seq[RouteMeta.ContentType]): List[Defn.Val] =
+    def generateDecoders(operationId: String, bodyArgs: Option[ScalaParameter[ScalaLanguage]], consumes: Seq[ContentType]): List[Defn.Val] =
       bodyArgs.toList.flatMap {
         case ScalaParameter(_, _, _, _, argType) =>
           List(
@@ -756,7 +756,7 @@ object Http4sServerGenerator {
           )
       }
 
-    def generateEncoders(operationId: String, responses: Responses[ScalaLanguage], produces: Seq[RouteMeta.ContentType]): List[Defn.Val] =
+    def generateEncoders(operationId: String, responses: Responses[ScalaLanguage], produces: Seq[ContentType]): List[Defn.Val] =
       for {
         response        <- responses.value
         typeDefaultPair <- response.value

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
@@ -469,7 +469,7 @@ object AsyncHttpClientClientGenerator {
           )
 
           val allConsumes = operation.get.consumes.flatMap(ContentType.unapply).toList
-          val consumes    = DropwizardHelpers.getBestConsumes(operation.get.getOperationId, allConsumes, parameters)
+          val consumes    = DropwizardHelpers.getBestConsumes(operation, allConsumes, parameters)
           val allProduces = operation.get.produces.flatMap(ContentType.unapply).toList
           val produces =
             responses.value.map(resp => (resp.statusCode, DropwizardHelpers.getBestProduces(operation.get.getOperationId, allProduces, resp))).toMap
@@ -689,7 +689,7 @@ object AsyncHttpClientClientGenerator {
                                             .flatten
                                             .getOrElse({
                                               println(
-                                                s"WARNING: no supported content type specified for ${operation.get.getOperationId}'s ${response.statusCode} response; falling back to application/json"
+                                                s"WARNING: no supported content type specified at ${operation.showHistory}'s ${response.statusCode} response; falling back to application/json"
                                               )
                                               ApplicationJson
                                             }) match {
@@ -715,7 +715,7 @@ object AsyncHttpClientClientGenerator {
                                                 case _ if valueType.isNamed("String")      => "getResponseBody"
                                                 case _ =>
                                                   println(
-                                                    s"WARNING: Don't know how to handle response of type ${valueType.asString} for content type $contentType for operation ${operation.get.getOperationId}; falling back to String"
+                                                    s"WARNING: Don't know how to handle response of type ${valueType.asString} for content type $contentType at ${operation.showHistory}; falling back to String"
                                                   )
                                                   "getResponseBody"
                                               }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
@@ -134,10 +134,11 @@ object AsyncHttpClientClientGenerator {
         new NodeList[Expression](
           new ObjectCreationExpr(
             null,
-            FILE_PART_TYPE,
+            INPUT_STREAM_PART_TYPE,
             new NodeList(
               new StringLiteralExpr(param.argName.value),
-              new NameExpr(name)
+              new NameExpr(name),
+              new StringLiteralExpr(param.argName.value)
             )
           )
         )
@@ -176,20 +177,7 @@ object AsyncHttpClientClientGenerator {
       new MethodCallExpr(new NameExpr("builder"), "setBody", new NodeList[Expression](expr))
 
     if (param.isFile) {
-      Option(
-        new ExpressionStmt(
-          wrapSetBody(
-            new ObjectCreationExpr(
-              null,
-              FILE_PART_TYPE,
-              new NodeList(
-                new StringLiteralExpr(param.argName.value),
-                new NameExpr(param.paramName.asString)
-              )
-            )
-          )
-        )
-      )
+      Option(new ExpressionStmt(wrapSetBody(new NameExpr(param.paramName.asString))))
     } else {
       contentType match {
         case Some(ApplicationJson) =>
@@ -798,7 +786,7 @@ object AsyncHttpClientClientGenerator {
                                               // FIXME: need to standardize on a type for byte streams
                                               new AssignExpr(
                                                 new VariableDeclarationExpr(new VariableDeclarator(valueType, "result"), finalModifier),
-                                                new MethodCallExpr(new NameExpr("response"), "getResponseBodyAsByteBuffer"),
+                                                new MethodCallExpr(new NameExpr("response"), "getResponseBodyAsStream"),
                                                 AssignExpr.Operator.ASSIGN
                                               )
                                           }
@@ -897,7 +885,7 @@ object AsyncHttpClientClientGenerator {
             "org.asynchttpclient.Request",
             "org.asynchttpclient.RequestBuilder",
             "org.asynchttpclient.Response",
-            "org.asynchttpclient.request.body.multipart.FilePart",
+            "org.asynchttpclient.request.body.multipart.InputStreamPart",
             "org.asynchttpclient.request.body.multipart.StringPart"
           ).map(safeParseRawImport) ++ List(
                 "java.util.Objects.requireNonNull"

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientHelpers.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientHelpers.scala
@@ -11,6 +11,6 @@ object AsyncHttpClientHelpers {
   val REQUEST_BUILDER_TYPE: ClassOrInterfaceType                          = StaticJavaParser.parseClassOrInterfaceType("RequestBuilder")
   val REQUEST_TYPE: ClassOrInterfaceType                                  = StaticJavaParser.parseClassOrInterfaceType("Request")
   val RESPONSE_TYPE: ClassOrInterfaceType                                 = StaticJavaParser.parseClassOrInterfaceType("Response")
-  val FILE_PART_TYPE: ClassOrInterfaceType                                = StaticJavaParser.parseClassOrInterfaceType("FilePart")
+  val INPUT_STREAM_PART_TYPE: ClassOrInterfaceType                        = StaticJavaParser.parseClassOrInterfaceType("InputStreamPart")
   val STRING_PART_TYPE: ClassOrInterfaceType                              = StaticJavaParser.parseClassOrInterfaceType("StringPart")
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientHelpers.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientHelpers.scala
@@ -2,6 +2,9 @@ package com.twilio.guardrail.generators.Java
 
 import com.github.javaparser.StaticJavaParser
 import com.github.javaparser.ast.`type`.ClassOrInterfaceType
+import com.twilio.guardrail.{ SupportDefinition, Target }
+import com.twilio.guardrail.generators.syntax.Java._
+import com.twilio.guardrail.languages.JavaLanguage
 
 object AsyncHttpClientHelpers {
   val DEFAULT_ASYNC_HTTP_CLIENT_CONFIG_BUILDER_TYPE: ClassOrInterfaceType = StaticJavaParser.parseClassOrInterfaceType("DefaultAsyncHttpClientConfig.Builder")
@@ -13,4 +16,36 @@ object AsyncHttpClientHelpers {
   val RESPONSE_TYPE: ClassOrInterfaceType                                 = StaticJavaParser.parseClassOrInterfaceType("Response")
   val INPUT_STREAM_PART_TYPE: ClassOrInterfaceType                        = StaticJavaParser.parseClassOrInterfaceType("InputStreamPart")
   val STRING_PART_TYPE: ClassOrInterfaceType                              = StaticJavaParser.parseClassOrInterfaceType("StringPart")
+
+  def asyncHttpClientUtilsSupportDef: Target[SupportDefinition[JavaLanguage]] = loadSupportDefinitionFromString(
+    "AsyncHttpClientUtils",
+    """
+      import org.asynchttpclient.Response;
+
+      import java.nio.charset.Charset;
+      import java.util.Locale;
+      import java.util.Optional;
+
+      public class AsyncHttpClientUtils {
+          public static Optional<Charset> getResponseCharset(final Response response) {
+              return Optional.ofNullable(response.getHeader("Content-Type")).flatMap(contentType -> {
+                  final int charsetStart = contentType.toLowerCase(Locale.US).indexOf("charset=");
+                  if (charsetStart != -1) {
+                      final int charsetEnd = contentType.indexOf(";", charsetStart + 8);
+                      final String charsetStr = contentType.substring(
+                              charsetStart + 8,
+                              charsetEnd != -1 ? charsetEnd : contentType.length());
+                      try {
+                          return Optional.of(Charset.forName(charsetStr));
+                      } catch (final Exception e) {
+                          return Optional.empty();
+                      }
+                  } else {
+                      return Optional.empty();
+                  }
+              });
+          }
+      }
+    """
+  )
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardGenerator.scala
@@ -10,7 +10,7 @@ import com.twilio.guardrail.terms.framework._
 object DropwizardGenerator {
   object FrameworkInterp extends (FrameworkTerm[JavaLanguage, ?] ~> Target) {
     def apply[T](term: FrameworkTerm[JavaLanguage, T]): Target[T] = term match {
-      case FileType(format)   => safeParseType(format.getOrElse("java.io.File"))
+      case FileType(format)   => safeParseType(format.getOrElse("java.io.InputStream"))
       case ObjectType(format) => safeParseType("com.fasterxml.jackson.databind.JsonNode")
 
       case GetFrameworkImports(tracing) =>

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardHelpers.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardHelpers.scala
@@ -1,0 +1,58 @@
+package com.twilio.guardrail.generators.Java
+
+import cats.data.NonEmptyList
+import cats.syntax.foldable._
+import com.github.javaparser.ast.`type`.Type
+import com.twilio.guardrail.generators.ScalaParameters
+import com.twilio.guardrail.generators.syntax.Java._
+import com.twilio.guardrail.languages.JavaLanguage
+import com.twilio.guardrail.protocol.terms._
+
+object DropwizardHelpers {
+  private val CONSUMES_PRIORITY = NonEmptyList.of(ApplicationJson, TextPlain, OctetStream)
+  private val PRODUCES_PRIORITY = NonEmptyList.of(ApplicationJson, TextPlain, OctetStream)
+
+  def getBestConsumes(operationId: String, contentTypes: List[ContentType], parameters: ScalaParameters[JavaLanguage]): Option[ContentType] =
+    Option(parameters.formParams.nonEmpty)
+      .filter(_ == true)
+      .map(
+        _ =>
+          if (parameters.formParams.exists(_.isFile) || contentTypes.contains(MultipartFormData)) {
+            MultipartFormData
+          } else {
+            UrlencodedFormData
+          }
+      )
+      .orElse(
+        parameters.bodyParams.map({ bodyParam =>
+          CONSUMES_PRIORITY
+            .collectFirstSome(ct => contentTypes.find(_ == ct))
+            .orElse(contentTypes.collectFirst({ case tc: TextContent => tc }))
+            .orElse(contentTypes.collectFirst({ case bc: BinaryContent => bc }))
+            .getOrElse({
+              val fallback =
+                if (bodyParam.argType.isPrimitiveType || bodyParam.argType.isNamed("String")) TextPlain
+                else ApplicationJson
+              println(s"WARNING: no supported body param type for operation '$operationId'; falling back to $fallback")
+              fallback
+            })
+        })
+      )
+
+  def getBestProduces(operationId: String, contentTypes: List[ContentType], response: Response[JavaLanguage]): Option[ContentType] =
+    response.value
+      .map(_._1)
+      .flatMap({ valueType: Type =>
+        PRODUCES_PRIORITY
+          .collectFirstSome(ct => contentTypes.find(_ == ct))
+          .orElse(contentTypes.collectFirst({ case tc: TextContent => tc }))
+          .orElse(contentTypes.collectFirst({ case bc: BinaryContent => bc }))
+          .orElse({
+            val fallback = if (valueType.isNamed("String")) TextPlain else ApplicationJson
+            println(
+              s"WARNING: no supported body param type for operation '$operationId', response code ${response.statusCode}; falling back to ${fallback.value}"
+            )
+            Option(fallback)
+          })
+      })
+}

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardHelpers.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardHelpers.scala
@@ -3,16 +3,18 @@ package com.twilio.guardrail.generators.Java
 import cats.data.NonEmptyList
 import cats.syntax.foldable._
 import com.github.javaparser.ast.`type`.Type
+import com.twilio.guardrail.core.Tracker
 import com.twilio.guardrail.generators.ScalaParameters
 import com.twilio.guardrail.generators.syntax.Java._
 import com.twilio.guardrail.languages.JavaLanguage
 import com.twilio.guardrail.protocol.terms._
+import io.swagger.v3.oas.models.Operation
 
 object DropwizardHelpers {
   private val CONSUMES_PRIORITY = NonEmptyList.of(ApplicationJson, TextPlain, OctetStream)
   private val PRODUCES_PRIORITY = NonEmptyList.of(ApplicationJson, TextPlain, OctetStream)
 
-  def getBestConsumes(operationId: String, contentTypes: List[ContentType], parameters: ScalaParameters[JavaLanguage]): Option[ContentType] =
+  def getBestConsumes(operation: Tracker[Operation], contentTypes: List[ContentType], parameters: ScalaParameters[JavaLanguage]): Option[ContentType] =
     if (parameters.formParams.nonEmpty) {
       if (parameters.formParams.exists(_.isFile) || contentTypes.contains(MultipartFormData)) {
         Some(MultipartFormData)
@@ -29,7 +31,7 @@ object DropwizardHelpers {
             val fallback =
               if (bodyParam.argType.isPrimitiveType || bodyParam.argType.isNamed("String")) TextPlain
               else ApplicationJson
-            println(s"WARNING: no supported body param type for operation '$operationId'; falling back to $fallback")
+            println(s"WARNING: no supported body param type at ${operation.showHistory}; falling back to $fallback")
             fallback
           })
       })

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
@@ -284,7 +284,7 @@ object DropwizardServerGenerator {
                 }
 
                 val allConsumes = operation.get.consumes.flatMap(ContentType.unapply).toList
-                val consumes    = DropwizardHelpers.getBestConsumes(operationId, allConsumes, parameters)
+                val consumes    = DropwizardHelpers.getBestConsumes(operation, allConsumes, parameters)
                 consumes
                   .map(c => new SingleMemberAnnotationExpr(new Name("Consumes"), c.toJaxRsAnnotationName))
                   .foreach(method.addAnnotation)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvcServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvcServerGenerator.scala
@@ -9,35 +9,34 @@ import com.github.javaparser.StaticJavaParser
 import com.github.javaparser.ast.Modifier._
 import com.github.javaparser.ast.Modifier.Keyword._
 import com.github.javaparser.ast.{ Node, NodeList }
-import com.github.javaparser.ast.`type`.{ ClassOrInterfaceType, PrimitiveType, Type, VoidType }
+import com.github.javaparser.ast.`type`.{ ClassOrInterfaceType, PrimitiveType, Type }
 import com.github.javaparser.ast.body._
 import com.github.javaparser.ast.expr._
 import com.github.javaparser.ast.stmt._
-import com.twilio.guardrail.{ ADT, ClassDefinition, EnumDefinition, RandomType, RenderedRoutes, StrictProtocolElems, SupportDefinition, Target }
+import com.twilio.guardrail.{ ADT, ClassDefinition, EnumDefinition, RandomType, RenderedRoutes, StrictProtocolElems, Target }
 import com.twilio.guardrail.extract.ServerRawResponse
 import com.twilio.guardrail.generators.{ ScalaParameter, ScalaParameters }
 import com.twilio.guardrail.generators.syntax.Java._
-import com.twilio.guardrail.languages.{ JavaLanguage, LA }
-import com.twilio.guardrail.protocol.terms.{ Response, Responses }
+import com.twilio.guardrail.languages.JavaLanguage
+import com.twilio.guardrail.protocol.terms.{ ApplicationJson, ContentType, MultipartFormData, OctetStream, Response, TextPlain, UrlencodedFormData }
 import com.twilio.guardrail.protocol.terms.server._
 import com.twilio.guardrail.shims.OperationExt
 import com.twilio.guardrail.terms.RouteMeta
 import io.swagger.v3.oas.models.responses.ApiResponse
-
 import scala.collection.JavaConverters._
 import scala.compat.java8.OptionConverters._
 import scala.language.existentials
 import scala.util.Try
 
 object SpringMvcServerGenerator {
-  private implicit class ContentTypeExt(val ct: RouteMeta.ContentType) extends AnyVal {
+  private implicit class ContentTypeExt(val ct: ContentType) extends AnyVal {
     def toSpringMediaType: String =
       (ct match {
-        case RouteMeta.ApplicationJson    => "APPLICATION_JSON"
-        case RouteMeta.UrlencodedFormData => "APPLICATION_FORM_URLENCODED"
-        case RouteMeta.MultipartFormData  => "MULTIPART_FORM_DATA"
-        case RouteMeta.TextPlain          => "TEXT_PLAIN"
-        case RouteMeta.OctetStream        => "APPLICATION_OCTET_STREAM"
+        case ApplicationJson    => "APPLICATION_JSON"
+        case UrlencodedFormData => "APPLICATION_FORM_URLENCODED"
+        case MultipartFormData  => "MULTIPART_FORM_DATA"
+        case TextPlain          => "TEXT_PLAIN"
+        case OctetStream        => "APPLICATION_OCTET_STREAM"
       }) + "_VALUE"
   }
 
@@ -82,36 +81,36 @@ object SpringMvcServerGenerator {
       }
     })
 
-  def getBestConsumes(contentTypes: List[RouteMeta.ContentType], parameters: ScalaParameters[JavaLanguage]): Option[RouteMeta.ContentType] = {
+  def getBestConsumes(contentTypes: List[ContentType], parameters: ScalaParameters[JavaLanguage]): Option[ContentType] = {
     val priorityOrder = NonEmptyList.of(
-      RouteMeta.UrlencodedFormData,
-      RouteMeta.ApplicationJson,
-      RouteMeta.MultipartFormData,
-      RouteMeta.TextPlain
+      UrlencodedFormData,
+      ApplicationJson,
+      MultipartFormData,
+      TextPlain
     )
 
     priorityOrder
-      .foldLeft[Option[RouteMeta.ContentType]](None)({
+      .foldLeft[Option[ContentType]](None)({
         case (s @ Some(_), _) => s
         case (None, next)     => contentTypes.find(_ == next)
       })
-      .orElse(parameters.formParams.headOption.map(_ => RouteMeta.UrlencodedFormData))
-      .orElse(parameters.bodyParams.map(_ => RouteMeta.ApplicationJson))
+      .orElse(parameters.formParams.headOption.map(_ => UrlencodedFormData))
+      .orElse(parameters.bodyParams.map(_ => ApplicationJson))
   }
 
   private def getBestProduces(
-      contentTypes: List[RouteMeta.ContentType],
+      contentTypes: List[ContentType],
       responses: List[ApiResponse],
       protocolElems: List[StrictProtocolElems[JavaLanguage]]
-  ): Option[RouteMeta.ContentType] = {
+  ): Option[ContentType] = {
     val priorityOrder = NonEmptyList.of(
-      RouteMeta.ApplicationJson,
-      RouteMeta.TextPlain,
-      RouteMeta.OctetStream
+      ApplicationJson,
+      TextPlain,
+      OctetStream
     )
 
     priorityOrder
-      .foldLeft[Option[RouteMeta.ContentType]](None)({
+      .foldLeft[Option[ContentType]](None)({
         case (s @ Some(_), _) => s
         case (None, next)     => contentTypes.find(_ == next)
       })
@@ -121,9 +120,9 @@ object SpringMvcServerGenerator {
             protocolElems
               .find(pe => definitionName(Option(resp.get$ref())).contains(pe.name))
               .flatMap({
-                case _: ClassDefinition[_]                                              => Some(RouteMeta.ApplicationJson)
-                case RandomType(_, tpe) if tpe.isPrimitiveType || tpe.isNamed("String") => Some(RouteMeta.TextPlain)
-                case _: ADT[_] | _: EnumDefinition[_]                                   => Some(RouteMeta.TextPlain)
+                case _: ClassDefinition[_]                                              => Some(ApplicationJson)
+                case RandomType(_, tpe) if tpe.isPrimitiveType || tpe.isNamed("String") => Some(TextPlain)
+                case _: ADT[_] | _: EnumDefinition[_]                                   => Some(TextPlain)
                 case _                                                                  => None
               })
           })
@@ -314,16 +313,16 @@ object SpringMvcServerGenerator {
                   nodeList.addLast(new MemberValuePair("path", new StringLiteralExpr(pathSuffix)))
                 }
 
-                val consumes = getBestConsumes(operation.get.consumes.flatMap(RouteMeta.ContentType.unapply).toList, parameters)
+                val consumes = getBestConsumes(operation.get.consumes.flatMap(ContentType.unapply).toList, parameters)
                   .orElse({
                     if (parameters.formParams.nonEmpty) {
                       if (parameters.formParams.exists(_.isFile)) {
-                        Some(RouteMeta.MultipartFormData)
+                        Some(MultipartFormData)
                       } else {
-                        Some(RouteMeta.UrlencodedFormData)
+                        Some(UrlencodedFormData)
                       }
                     } else if (parameters.bodyParams.nonEmpty) {
-                      Some(RouteMeta.ApplicationJson)
+                      Some(ApplicationJson)
                     } else {
                       None
                     }
@@ -335,7 +334,7 @@ object SpringMvcServerGenerator {
 
                 val successResponses =
                   operation.get.getResponses.entrySet.asScala.filter(entry => Try(entry.getKey.toInt / 100 == 2).getOrElse(false)).map(_.getValue).toList
-                val produces = getBestProduces(operation.get.produces.flatMap(RouteMeta.ContentType.unapply).toList, successResponses, protocolElems)
+                val produces = getBestProduces(operation.get.produces.flatMap(ContentType.unapply).toList, successResponses, protocolElems)
                 produces
                   .map(c => new MemberValuePair("produces", new FieldAccessExpr(new NameExpr("MediaType"), c.toSpringMediaType)))
                   .foreach(nodeList.addLast)
@@ -411,7 +410,7 @@ object SpringMvcServerGenerator {
                   (parameters.pathParams, "PathVariable"),
                   (parameters.headerParams, "RequestHeader"),
                   (parameters.queryStringParams, "RequestParam"),
-                  (parameters.formParams, if (consumes.contains(RouteMeta.MultipartFormData)) "RequestParam" else "ModelAttribute")
+                  (parameters.formParams, if (consumes.contains(MultipartFormData)) "RequestParam" else "ModelAttribute")
                 ).flatMap({
                   case (params, annotationName) =>
                     params.map({ param =>

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/Java.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/Java.scala
@@ -2,24 +2,14 @@ package com.twilio.guardrail.generators.syntax
 
 import cats.implicits._
 import com.github.javaparser.StaticJavaParser
-import com.github.javaparser.ast.`type`.{ ClassOrInterfaceType, PrimitiveType, Type }
+import com.github.javaparser.ast.`type`.{ ClassOrInterfaceType, Type }
 import com.github.javaparser.ast.body._
 import com.github.javaparser.ast.comments.{ BlockComment, Comment }
-import com.github.javaparser.ast.expr.{
-  ClassExpr,
-  Expression,
-  FieldAccessExpr,
-  LiteralStringValueExpr,
-  MethodCallExpr,
-  Name,
-  NameExpr,
-  SimpleName,
-  StringLiteralExpr,
-  ThisExpr
-}
+import com.github.javaparser.ast.expr._
 import com.github.javaparser.ast.nodeTypes.{ NodeWithName, NodeWithSimpleName }
 import com.github.javaparser.ast.{ CompilationUnit, ImportDeclaration, Node, NodeList }
 import com.twilio.guardrail.languages.JavaLanguage
+import com.twilio.guardrail.languages.JavaLanguage.JavaTypeName
 import com.twilio.guardrail.{ SupportDefinition, Target }
 import scala.collection.JavaConverters._
 import scala.compat.java8.OptionConverters._
@@ -53,17 +43,11 @@ object Java {
         case cls: ClassOrInterfaceType if name.contains(".") =>
           (cls.getScope.asScala.fold("")(_.getName.asString + ".") + cls.getNameAsString) == name
         case cls: ClassOrInterfaceType => cls.getNameAsString == name
-        case pt: PrimitiveType         => pt.asString == name
-        case _                         => false
+        case other                     => other.asString == name
       }
 
-    def name: Option[String] =
-      tpe match {
-        case cls: ClassOrInterfaceType =>
-          Some(cls.getScope.asScala.fold("")(_.getName.asString + ".") + cls.getNameAsString)
-        case pt: PrimitiveType => Option(pt.asString)
-        case _                 => None
-      }
+    @deprecated("Just use Type#asString", "0.0.0")
+    def name: Option[String] = Option(tpe.asString)
   }
 
   implicit class RichListOfNode[T <: Node](val l: List[T]) extends AnyVal {
@@ -126,6 +110,7 @@ object Java {
   def safeParseSimpleName(s: String): Target[SimpleName] = safeParse("safeParseSimpleName")(StaticJavaParser.parseSimpleName, s)
   def safeParseName(s: String): Target[Name]             = safeParse("safeParseName")(StaticJavaParser.parseName, s)
   def safeParseType(s: String): Target[Type]             = safeParse("safeParseType")(StaticJavaParser.parseType, s)
+  def safeParseTypeName(s: String): Target[JavaTypeName] = safeParse("safeParseTypeName")(s => JavaTypeName(StaticJavaParser.parseType(s)), s)
   def safeParseClassOrInterfaceType(s: String): Target[ClassOrInterfaceType] =
     safeParse("safeParseClassOrInterfaceType")(StaticJavaParser.parseClassOrInterfaceType, s)
   def safeParseExpression[T <: Expression](s: String)(implicit cls: ClassTag[T]): Target[T] =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/languages/JavaLanguage.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/languages/JavaLanguage.scala
@@ -4,8 +4,8 @@ import com.twilio.guardrail.languages.JavaLanguage.JavaTypeName
 
 object JavaLanguage {
   case class JavaTypeName(tpe: com.github.javaparser.ast.`type`.Type) {
-    def asString: String          = toString
-    override def toString: String = tpe.asString
+    def asString: String          = tpe.asString
+    override def toString: String = asString
   }
 }
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/languages/JavaLanguage.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/languages/JavaLanguage.scala
@@ -1,5 +1,14 @@
 package com.twilio.guardrail.languages
 
+import com.twilio.guardrail.languages.JavaLanguage.JavaTypeName
+
+object JavaLanguage {
+  case class JavaTypeName(tpe: com.github.javaparser.ast.`type`.Type) {
+    def asString: String          = toString
+    override def toString: String = tpe.asString
+  }
+}
+
 class JavaLanguage extends LanguageAbstraction {
 
   type Statement = com.github.javaparser.ast.stmt.Statement
@@ -31,7 +40,7 @@ class JavaLanguage extends LanguageAbstraction {
   type ValueDefinition = com.github.javaparser.ast.body.VariableDeclarator
   type MethodParameter = com.github.javaparser.ast.body.Parameter
   type Type            = com.github.javaparser.ast.`type`.Type
-  type TypeName        = com.github.javaparser.ast.expr.Name
+  type TypeName        = JavaTypeName
   type Annotation      = com.github.javaparser.ast.expr.AnnotationExpr
 
   // Result

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/Content.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/Content.scala
@@ -1,0 +1,26 @@
+package com.twilio.guardrail.protocol.terms
+
+import cats.Order
+import cats.implicits._
+import java.util.Locale
+
+sealed abstract class ContentType(val value: String) {
+  override val toString: String = value
+}
+case object ApplicationJson    extends ContentType("application/json")
+case object MultipartFormData  extends ContentType("multipart/form-data")
+case object UrlencodedFormData extends ContentType("application/x-www-form-urlencoded")
+case object TextPlain          extends ContentType("text/plain")
+case object OctetStream        extends ContentType("application/octet-stream")
+
+object ContentType {
+  def unapply(value: String): Option[ContentType] = value.toLowerCase(Locale.US) match {
+    case "application/json"                  => Some(ApplicationJson)
+    case "multipart/form-data"               => Some(MultipartFormData)
+    case "application/x-www-form-urlencoded" => Some(UrlencodedFormData)
+    case "text/plain"                        => Some(TextPlain)
+    case "application/octet-stream"          => Some(OctetStream)
+    case _                                   => None
+  }
+  implicit val ContentTypeOrder: Order[ContentType] = Order[String].contramap[ContentType](_.value)
+}

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/Content.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/Content.scala
@@ -7,20 +7,67 @@ import java.util.Locale
 sealed abstract class ContentType(val value: String) {
   override val toString: String = value
 }
-case object ApplicationJson    extends ContentType("application/json")
-case object MultipartFormData  extends ContentType("multipart/form-data")
-case object UrlencodedFormData extends ContentType("application/x-www-form-urlencoded")
-case object TextPlain          extends ContentType("text/plain")
-case object OctetStream        extends ContentType("application/octet-stream")
+sealed class TextContent(value: String)   extends ContentType(value)
+sealed class BinaryContent(value: String) extends ContentType(value)
+
+object TextContent {
+  def unapply(contentType: ContentType): Option[String] = contentType match {
+    case tc: TextContent => Some(tc.value)
+    case _               => None
+  }
+}
+
+object BinaryContent {
+  def unapply(contentType: ContentType): Option[String] = contentType match {
+    case bc: BinaryContent => Some(bc.value)
+    case _                 => None
+  }
+}
+
+case object ApplicationJson    extends TextContent("application/json")
+case object MultipartFormData  extends TextContent("multipart/form-data")
+case object UrlencodedFormData extends TextContent("application/x-www-form-urlencoded")
+case object TextPlain          extends TextContent("text/plain")
+case object OctetStream        extends BinaryContent("application/octet-stream")
 
 object ContentType {
+  // This is not intended to be exhaustive, but should hopefully cover cases we're likely to see.
+  // See https://www.iana.org/assignments/media-types/media-types.xhtml for all IANA registered types.
+  // Note that types that end in "+json" or "+xml" are handled explicitly in the match statement.
+  private val APPLICATION_TEXT_TYPES = Set(
+    "application/jose",
+    "application/jwt",
+    "application/mbox",
+    "application/node",
+    "application/sdp",
+    "application/sgml",
+    "application/sql",
+    "application/x-pem-file",
+    "application/xml",
+    "application/xml-dtd",
+    "application/xml-external-parsed-entity"
+  )
+
+  private def isApplicationText(name: String) =
+    name.startsWith("application/") && (name.endsWith("+json") || name.endsWith("+xml") || APPLICATION_TEXT_TYPES.contains(name))
+
+  private def isTextRegistry(name: String) = name.startsWith("text/")
+
+  private def isUnsupported(name: String) =
+    name == "application/xml" || // We explicitly avoid support for XML for now to avoid breaking existing specs
+      (name.startsWith("multipart/") && name != "multipart/form-data") ||
+      name.startsWith("example/")
+
   def unapply(value: String): Option[ContentType] = value.toLowerCase(Locale.US) match {
-    case "application/json"                  => Some(ApplicationJson)
-    case "multipart/form-data"               => Some(MultipartFormData)
-    case "application/x-www-form-urlencoded" => Some(UrlencodedFormData)
-    case "text/plain"                        => Some(TextPlain)
-    case "application/octet-stream"          => Some(OctetStream)
-    case _                                   => None
+    case "application/json"                            => Some(ApplicationJson)
+    case "multipart/form-data"                         => Some(MultipartFormData)
+    case "application/x-www-form-urlencoded"           => Some(UrlencodedFormData)
+    case "text/plain"                                  => Some(TextPlain)
+    case "application/octet-stream"                    => Some(OctetStream)
+    case x if isUnsupported(x)                         => None
+    case x if isTextRegistry(x) | isApplicationText(x) => Some(new TextContent(value))
+    case _                                             => Some(new BinaryContent(value))
   }
+
   implicit val ContentTypeOrder: Order[ContentType] = Order[String].contramap[ContentType](_.value)
 }

--- a/modules/sample-dropwizard/src/test/scala/core/Dropwizard/AsyncHttpClientUtilsTest.java
+++ b/modules/sample-dropwizard/src/test/scala/core/Dropwizard/AsyncHttpClientUtilsTest.java
@@ -1,0 +1,46 @@
+package core.Dropwizard;
+
+import examples.client.dropwizard.AsyncHttpClientUtils;
+import org.asynchttpclient.Response;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AsyncHttpClientUtilsTest {
+    @Test
+    public void testCharsetNoContentType() {
+        final Response response = mock(Response.class);
+        when(response.getHeader(eq("Content-Type"))).thenReturn(null);
+
+        assertThat(AsyncHttpClientUtils.getResponseCharset(response)).isEmpty();
+    }
+
+    @Test
+    public void testCharsetNone() {
+        final Response response = mock(Response.class);
+        when(response.getHeader(eq("Content-Type"))).thenReturn("text/plain");
+
+        assertThat(AsyncHttpClientUtils.getResponseCharset(response)).isEmpty();
+    }
+
+    @Test
+    public void testCharsetAtEnd() {
+        final Response response = mock(Response.class);
+        when(response.getHeader(eq("Content-Type"))).thenReturn("text/plain; charset=utf-8");
+
+        assertThat(AsyncHttpClientUtils.getResponseCharset(response)).contains(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    public void testCharsetInMiddle() {
+        final Response response = mock(Response.class);
+        when(response.getHeader(eq("Content-Type"))).thenReturn("text/plain; charset=utf-8; foobar=baz");
+
+        assertThat(AsyncHttpClientUtils.getResponseCharset(response)).contains(StandardCharsets.UTF_8);
+    }
+}

--- a/modules/sample/src/main/resources/binary.yaml
+++ b/modules/sample/src/main/resources/binary.yaml
@@ -34,12 +34,14 @@ paths:
             type: string
             format: binary
             x-scala-type: Array[Byte]
+            x-java-type: byte[]
           required: true
       responses:
         '200':
           schema:
             type: file
             x-scala-type: Array[Byte]
+            x-java-type: byte[]
   /fooChunk:
     post:
       operationId: fooChunk
@@ -50,9 +52,11 @@ paths:
             type: string
             format: binary
             x-scala-type: fs2.Chunk[Byte]
+            x-java-type: java.io.InputStream
           required: true
       responses:
         '200':
           schema:
             type: file
             x-scala-type: fs2.Chunk[Byte]
+            x-java-type: java.io.InputStream

--- a/modules/sample/src/main/resources/random-content-types.yaml
+++ b/modules/sample/src/main/resources/random-content-types.yaml
@@ -1,0 +1,39 @@
+openapi: 3.0.2
+info:
+  title: Test for "non-REST" content types
+  version: 1.0.0
+paths:
+  /foo:
+    post:
+      x-jvm-package: randomContentTypes
+      operationId: doFoo
+      requestBody:
+        required: true
+        content:
+          image/png:
+            schema:
+              type: string
+              format: binary
+      responses:
+        200:
+          content:
+            application/x-pem-file:
+              schema:
+                type: string
+  /bar:
+    post:
+      x-jvm-package: randomContentTypes
+      operationId: doBar
+      requestBody:
+        required: true
+        content:
+          application/sdp:
+            schema:
+              type: string
+      responses:
+        200:
+          content:
+            image/jpeg:
+              schema:
+                type: string
+                format: binary


### PR DESCRIPTION
From the most important commit message:

    This adds generic `TextContent` and `BinaryContent` classes that represent
    arbitrary content-types outside of our main directly-supported types
    (like application/json, text/plain, etc.).  The goal here is to
    transparently support arbitrary text and binary types.
    
    For example, imagine an API that handles document storage.  The API
    would likely make use of JSON for handling metadata about documents, but
    there could be endpoints that return the documents themselves.  It would
    be nice if we could support, say, application/pdf documents without
    having to special case every possible document type.
    
    The classification of text vs. binary when it comes to the application/
    registry is a bit fuzzy, since there's no encoding information attached
    to the content-type string itself.  There are a few things we can be
    sure about: if the type ends in "+json" or "+xml", then it's going to be
    text.  I've also hard-coded a few possibly-useful content-types that are
    known to be text.  Otherwise, things in application/ are assumed to be
    binary.  If there are other types that should be text, and people ask
    for them, adding support is a one-line addition.
    
    One wart: I've explicitly listed application/xml in
    `ContentType.unapply()` as unsupported (so `unapply()` will return `None`),
    because accepting it will break codegen for existing specs that have
    (for example) both application/json and application/xml listed as
    content types for a particular response.  At some point if we decide to
    actually support XML (whether as a first-class citizen, or just passing
    it through as a `String`, or using scala-xml's `NodeSeq`, etc.), we can add
    it back.

In addition, I've fixed up a bunch of issues with Java AHC client and DW server issues around content types and request/response bodies, and made it work properly with this new code.  The other frameworks should continue to output what they used to.

One interesting change is that was required to get this all to work: I've implemented https://github.com/twilio/guardrail/issues/251 finally (which supersedes https://github.com/twilio/guardrail/pull/318).  I decided to take the compromise position and use `InputStream` for request and response bodies that are solely binary data, but continue to use `File` on the server side for multipart/form-data.  This should give us much better usability and performance for the cases where it's safe to do so, but avoid unbounded memory buffering for binary data in the server multipart case.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
