### PR TITLE
Fix Java enum usage as Jersey @*Param

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
@@ -189,10 +189,10 @@ object JacksonGenerator {
             )
           )
 
-        val parseMethod = new MethodDeclaration(
+        val fromStringMethod = new MethodDeclaration(
           new NodeList(publicModifier, staticModifier),
           enumType,
-          "parse"
+          "fromString"
         ).addMarkerAnnotation("JsonCreator")
           .addParameter(new Parameter(new NodeList(finalModifier), STRING_TYPE, new SimpleName("name")))
           .setBody(
@@ -228,6 +228,21 @@ object JacksonGenerator {
             )
           )
 
+        val compatParseMethod = new MethodDeclaration(
+          new NodeList(publicModifier, staticModifier),
+          enumType,
+          "parse"
+        ).addMarkerAnnotation("Deprecated")
+          .setJavadocComment("@deprecated See {@link #fromString(String)}")
+          .addParameter(new Parameter(new NodeList(finalModifier), STRING_TYPE, new SimpleName("name")))
+          .setBody(
+            new BlockStmt(
+              new NodeList(
+                new ReturnStmt(new MethodCallExpr("fromString", new NameExpr("name")))
+              )
+            )
+          )
+
         val staticInitializer = new InitializerDeclaration(
           true,
           new BlockStmt(
@@ -257,7 +272,8 @@ object JacksonGenerator {
             nameField,
             constructor,
             getNameMethod,
-            parseMethod
+            fromStringMethod,
+            compatParseMethod
           )
         )
 


### PR DESCRIPTION
Jersey will look for a magic `fromString(String)` method in order to parse a string into an enum.  Renamed `parse()` to `fromString()` and added a `@Deprecated` compat version of `parse()`.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
