### PR TITLE
Add DW test to verify character encoding of strings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,6 +62,8 @@ def sampleResource(name: String): java.io.File = file(s"modules/sample/src/main/
 val exampleCases: List[ExampleCase] = List(
   ExampleCase(sampleResource("additional-properties.yaml"), "additionalProperties"),
   ExampleCase(sampleResource("alias.yaml"), "alias"),
+  ExampleCase(sampleResource("char-encoding/char-encoding-request-stream.yaml"), "charEncoding.requestStream").frameworks(Set("dropwizard")),
+  ExampleCase(sampleResource("char-encoding/char-encoding-response-stream.yaml"), "charEncoding.responseStream").frameworks(Set("dropwizard")),
   ExampleCase(sampleResource("contentType-textPlain.yaml"), "tests.contentTypes.textPlain"),
   ExampleCase(sampleResource("custom-header-type.yaml"), "tests.customTypes.customHeader"),
   ExampleCase(sampleResource("date-time.yaml"), "dateTime"),

--- a/modules/sample-dropwizard/src/test/java/core/Dropwizard/CharacterEncodingTest.java
+++ b/modules/sample-dropwizard/src/test/java/core/Dropwizard/CharacterEncodingTest.java
@@ -1,0 +1,122 @@
+package core.Dropwizard;
+
+import charEncoding.requestStream.server.dropwizard.charEncReqStream.CharEncReqStreamHandler;
+import charEncoding.requestStream.server.dropwizard.charEncReqStream.CharEncReqStreamResource;
+import charEncoding.requestStream.server.dropwizard.definitions.Pojo;
+import charEncoding.responseStream.client.dropwizard.charEncRespStream.CharEncRespStreamClient;
+import charEncoding.responseStream.client.dropwizard.charEncRespStream.SendPojoResponse;
+import charEncoding.responseStream.client.dropwizard.charEncRespStream.SendTextPlainResponse;
+import io.dropwizard.testing.junit.ResourceTestRule;
+import org.glassfish.jersey.test.TestProperties;
+import org.glassfish.jersey.test.grizzly.GrizzlyTestContainerFactory;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CharacterEncodingTest {
+    static {
+        System.setProperty(TestProperties.CONTAINER_PORT, "0");
+    }
+
+    private static final String STRING_DATA = "áéíóúñàèìòç";
+
+    private static final int[] STRING_DATA_UTF8 = new int[] {
+            0xc3, 0xa1, 0xc3, 0xa9, 0xc3, 0xad, 0xc3, 0xb3,
+            0xc3, 0xba, 0xc3, 0xb1, 0xc3, 0xa0, 0xc3, 0xa8,
+            0xc3, 0xac, 0xc3, 0xb2, 0xc3, 0xa7
+    };
+
+    private static String testString(final InputStream stream) {
+        try {
+            final byte[] charBuf = new byte[STRING_DATA_UTF8.length];
+            for (int i = 0; i <  STRING_DATA_UTF8.length; ++i) {
+                final int input = stream.read();
+                charBuf[i] = (byte) input;
+            }
+            assertThat(charBuf).isEqualTo(Arrays.stream(STRING_DATA_UTF8).boxed().map(Integer::byteValue).toArray());
+            assertThat(stream.read()).isEqualTo(-1);  // should have hit the end
+
+            final String receivedStr = new String(charBuf, StandardCharsets.UTF_8);
+            assertThat(receivedStr).isEqualTo(STRING_DATA);
+
+            return receivedStr;
+        } catch (final IOException e) {
+            throw new UncheckedIOException(e.getMessage(), e);
+        }
+    }
+
+    private static final CharEncReqStreamHandler handler = new CharEncReqStreamHandler() {
+        @Override
+        public CompletionStage<SendFormDataResponse> sendFormData(final String str) {
+            if (STRING_DATA.equals(str)) {
+                return CompletableFuture.completedFuture(SendFormDataResponse.Ok(str));
+            } else {
+                return CompletableFuture.completedFuture(SendFormDataResponse.InternalServerError(
+                        String.format("Strings did not match: expected %s, got %s", STRING_DATA, str)));
+            }
+        }
+
+        @Override
+        public CompletionStage<SendTextPlainResponse> sendTextPlain(final InputStream stream) {
+            try {
+                return CompletableFuture.completedFuture(SendTextPlainResponse.Ok(testString(stream)));
+            } catch (final Throwable t) {
+                return CompletableFuture.completedFuture(SendTextPlainResponse.InternalServerError(t.getMessage()));
+            }
+        }
+
+        @Override
+        public CompletionStage<SendPojoResponse> sendPojo(final Pojo body) {
+            if (STRING_DATA.equals(body.getStr())) {
+                return CompletableFuture.completedFuture(SendPojoResponse.Ok(new Pojo.Builder(body.getStr()).build()));
+            } else {
+                return CompletableFuture.completedFuture(SendPojoResponse.InternalServerError(
+                        String.format("Strings did not match: expected %s, got %s", STRING_DATA, body.getStr())));
+            }
+        }
+    };
+
+    @ClassRule
+    public static ResourceTestRule resources = ResourceTestRule.builder()
+            .setTestContainerFactory(new GrizzlyTestContainerFactory())
+            .addResource(new CharEncReqStreamResource(handler))
+            .build();
+
+    private static CharEncRespStreamClient createClient() throws URISyntaxException {
+        final URI clientUri = new URI(resources.target("").getUri().toString().replaceAll("/$", ""));
+        return new CharEncRespStreamClient.Builder(clientUri).build();
+    }
+
+    @Test
+    public void testClientSendsCorrectBytesTextPlain() throws URISyntaxException, ExecutionException, InterruptedException {
+        final CharEncRespStreamClient client = createClient();
+        final SendTextPlainResponse response = client.sendTextPlain(STRING_DATA).call().toCompletableFuture().get();
+        response.fold(CharacterEncodingTest::testString, error -> {
+            throw new RuntimeException(error);
+        });
+    }
+
+    @Test
+    public void testRoundTripJson() throws URISyntaxException, ExecutionException, InterruptedException {
+        final CharEncRespStreamClient client = createClient();
+        final SendPojoResponse response = client.sendPojo(
+                new charEncoding.responseStream.client.dropwizard.definitions.Pojo.Builder(STRING_DATA).build()
+        ).call().toCompletableFuture().get();
+        response.fold(
+                pojo -> assertThat(pojo.getStr()).isEqualTo(STRING_DATA),
+                error -> { throw new RuntimeException(error); }
+        );
+    }
+}

--- a/modules/sample/src/main/resources/char-encoding/char-encoding-request-stream.yaml
+++ b/modules/sample/src/main/resources/char-encoding/char-encoding-request-stream.yaml
@@ -1,0 +1,82 @@
+openapi: 3.0.2
+info:
+  title: Character Encoding Tests (Request InputStream)
+  version: 1.0.0
+paths:
+  /formData:
+    post:
+      x-jvm-package: charEncReqStream
+      operationId: sendFormData
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              required:
+                - str
+              properties:
+                str:
+                  type: string
+      responses:
+        200:
+          content:
+            text/plain:
+              schema:
+                type: string
+        500:
+          content:
+            text/plain:
+              schema:
+                type: string
+  /textPlain:
+    post:
+      x-jvm-package: charEncReqStream
+      operationId: sendTextPlain
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: string
+              x-java-type: java.io.InputStream
+      responses:
+        200:
+          content:
+            text/plain:
+              schema:
+                type: string
+        500:
+          content:
+            text/plain:
+              schema:
+                type: string
+  /pojo:
+    post:
+      x-jvm-package: charEncReqStream
+      operationId: sendPojo
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pojo"
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pojo"
+        500:
+          content:
+            text/plain:
+              schema:
+                type: string
+components:
+  schemas:
+    Pojo:
+      type: object
+      required:
+        - str
+      properties:
+        str:
+          type: string

--- a/modules/sample/src/main/resources/char-encoding/char-encoding-response-stream.yaml
+++ b/modules/sample/src/main/resources/char-encoding/char-encoding-response-stream.yaml
@@ -1,0 +1,82 @@
+openapi: 3.0.2
+info:
+  title: Character Encoding Tests (Response InputStream)
+  version: 1.0.0
+paths:
+  /formData:
+    post:
+      x-jvm-package: charEncReqStream
+      operationId: sendFormData
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              required:
+                - str
+              properties:
+                str:
+                  type: string
+      responses:
+        200:
+          content:
+            text/plain:
+              schema:
+                type: string
+        500:
+          content:
+            text/plain:
+              schema:
+                type: string
+  /textPlain:
+    post:
+      x-jvm-package: charEncRespStream
+      operationId: sendTextPlain
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: string
+      responses:
+        200:
+          content:
+            text/plain:
+              schema:
+                type: string
+                x-java-type: java.io.InputStream
+        500:
+          content:
+            text/plain:
+              schema:
+                type: string
+  /pojo:
+    post:
+      x-jvm-package: charEncRespStream
+      operationId: sendPojo
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pojo"
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pojo"
+        500:
+          content:
+            text/plain:
+              schema:
+                type: string
+components:
+  schemas:
+    Pojo:
+      type: object
+      required:
+        - str
+      properties:
+        str:
+          type: string


### PR DESCRIPTION
I'm not sure how useful this is in general, but someone was running into character encoding issues, and I figured it was a good idea to eliminate guardrail as the cause.

Now, this doesn't _completely_ exonerate guardrail, since I had to just use `text/plain` for the body types for the test where I actually examine the bytes sent to/from the server.  Jackson (and circe) will do its own charset handling, as will the clients and servers when they marshal/unmarshal things like form params.  Unfortunately, I can't really hook into any of that at a useful level, so this is the best I can do.  I *do* verify that the strings round-trip ok for JSON & form-data, but that doesn't test that the bytes on the wire are correct.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
