### PR TITLE
Re-enable logger

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/CLI.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/CLI.scala
@@ -84,19 +84,19 @@ trait CLICommon {
     // code is included into all other build tools.
     val coreArgs = C.parseArgs(newArgs).map(NonEmptyList.fromList(_))
 
+    implicit val logLevel: LogLevel = level
+      .flatMap(level => LogLevels.members.find(_.level == level.toLowerCase))
+      .getOrElse(LogLevels.Warning)
+
     val result = coreArgs
       .foldMap(interpreter)
       .flatMap({ args =>
         guardrailRunner(args.map(language -> _).toMap)
       })
 
-    implicit val logLevel: LogLevel = level
-      .flatMap(level => LogLevels.members.find(_.level == level.toLowerCase))
-      .getOrElse(LogLevels.Warning)
-
     val fallback = List.empty[Path]
     import CLICommon.unsafePrintHelp
-    val /*(logger,*/ paths /*)*/ = result
+    val paths = result
       .fold(
         {
           case MissingArg(args, Error.ArgName(arg)) =>
@@ -144,7 +144,7 @@ trait CLICommon {
         identity
       )
 
-    // println(logger.show)
+    println(result.logEntries.show)
 
     if (paths.isEmpty) {
       CommandLineResult.failure

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/CoreTarget.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/CoreTarget.scala
@@ -6,81 +6,83 @@ import cats.{ Applicative, Eval, MonadError, Traverse }
 
 object CoreTarget extends LogAbstraction {
   implicit val coreTargetInstances = new MonadError[CoreTarget, Error] with Traverse[CoreTarget] {
-    def pure[A](x: A): CoreTarget[A] = new CoreTargetValue(x)
+    def pure[A](x: A): CoreTarget[A] = new CoreTargetValue(x, StructuredLogger.Empty)
 
     def handleErrorWith[A](fa: CoreTarget[A])(f: com.twilio.guardrail.Error => CoreTarget[A]): CoreTarget[A] = fa match {
-      case ct @ CoreTargetValue(_) => ct
-      case CoreTargetError(err)    => f(err)
+      case ct @ CoreTargetValue(_, _) => ct
+      case CoreTargetError(err, el)   => f(err).prependLogger(el)
     }
-    def raiseError[A](e: com.twilio.guardrail.Error): CoreTarget[A] = new CoreTargetError(e)
+    def raiseError[A](e: com.twilio.guardrail.Error): CoreTarget[A] = new CoreTargetError(e, StructuredLogger.Empty)
 
     def flatMap[A, B](fa: CoreTarget[A])(f: A => CoreTarget[B]): CoreTarget[B] = fa match {
-      case CoreTargetValue(a)        => f(a)
-      case ct @ CoreTargetError(err) => new CoreTargetError(err)
+      case CoreTargetValue(a, al)   => f(a).prependLogger(al)
+      case CoreTargetError(err, el) => new CoreTargetError(err, el)
     }
     def tailRecM[A, B](a: A)(f: A => CoreTarget[Either[A, B]]): CoreTarget[B] =
       f(a) match {
-        case CoreTargetError(err) =>
-          new CoreTargetError(err)
-        case CoreTargetValue(e) =>
+        case CoreTargetError(err, el) =>
+          new CoreTargetError(err, el)
+        case CoreTargetValue(e, el) =>
           e match {
-            case Left(b)  => tailRecM(b)(f)
-            case Right(a) => new CoreTargetValue(a)
+            case Left(b)  => tailRecM(b)(f).prependLogger(el)
+            case Right(a) => new CoreTargetValue(a, el)
           }
       }
 
     def foldLeft[A, B](fa: CoreTarget[A], b: B)(f: (B, A) => B): B = fa match {
-      case CoreTargetValue(a) => f(b, a)
-      case CoreTargetError(_) => b
+      case CoreTargetValue(a, _) => f(b, a)
+      case CoreTargetError(_, _) => b
     }
 
     def foldRight[A, B](fa: CoreTarget[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] = fa match {
-      case CoreTargetValue(a) => f(a, lb)
-      case CoreTargetError(_) => lb
+      case CoreTargetValue(a, _) => f(a, lb)
+      case CoreTargetError(_, _) => lb
     }
 
     def traverse[G[_], A, B](fa: CoreTarget[A])(f: A => G[B])(implicit G: Applicative[G]): G[CoreTarget[B]] = fa match {
-      case CoreTargetValue(a) => G.ap(G.pure(CoreTarget.pure[B](_)))(f(a))
-      case CoreTargetError(e) => G.pure[CoreTarget[B]](new CoreTargetError(e))
+      case CoreTargetValue(a, al) => G.ap(G.pure[B => CoreTarget[B]](new CoreTargetValue[B](_, al)))(f(a))
+      case CoreTargetError(e, el) => G.pure[CoreTarget[B]](new CoreTargetError(e, el))
     }
   }
 
   type F[A] = CoreTarget[A]
   val A                                                     = Applicative[CoreTarget]
-  def pushLogger(value: StructuredLogger): CoreTarget[Unit] = new CoreTargetValue(()) // IndexedStateT.modify(_ |+| value))
+  def pushLogger(value: StructuredLogger): CoreTarget[Unit] = new CoreTargetValue((), value)
   def pure[T](x: T): CoreTarget[T]                          = x.pure[CoreTarget]
   def fromOption[T](x: Option[T], default: => Error): CoreTarget[T] =
-    x.fold[CoreTarget[T]](new CoreTargetError(default))(new CoreTargetValue[T](_))
+    x.fold[CoreTarget[T]](new CoreTargetError(default, StructuredLogger.Empty))(new CoreTargetValue[T](_, StructuredLogger.Empty))
   @deprecated("Use raiseError instead", "v0.41.2")
-  def error[T](x: Error): CoreTarget[T]      = new CoreTargetError(x)
-  def raiseError[T](x: Error): CoreTarget[T] = new CoreTargetError(x)
+  def error[T](x: Error): CoreTarget[T]      = new CoreTargetError(x, StructuredLogger.Empty)
+  def raiseError[T](x: Error): CoreTarget[T] = new CoreTargetError(x, StructuredLogger.Empty)
   @SuppressWarnings(Array("org.wartremover.warts.Throw"))
   def unsafeExtract[T](x: CoreTarget[T]): T =
     x.valueOr({ err =>
       throw new Exception(err.toString)
     })
-  //.runEmptyA
 }
 
-sealed abstract class CoreTarget[A] {
+sealed abstract class CoreTarget[A](val logEntries: StructuredLogger) {
   def valueOr[AA >: A](fallback: Error => AA): AA
   def fold[B](fail: Error => B, pass: A => B): B
   def leftFlatMap[AA >: A](f: Error => CoreTarget[AA]): CoreTarget[AA]
+  def prependLogger(lastLogs: StructuredLogger): CoreTarget[A]
 }
 
 object CoreTargetValue {
-  def unapply[A](x: CoreTargetValue[A]): Option[A] = Some(x.value)
+  def unapply[A](x: CoreTargetValue[A]): Option[(A, StructuredLogger)] = Some((x.value, x.logEntries))
 }
-class CoreTargetValue[A](val value: A) extends CoreTarget[A] {
+class CoreTargetValue[A](val value: A, logEntries: StructuredLogger) extends CoreTarget[A](logEntries) {
   def valueOr[AA >: A](fallback: Error => AA): AA                      = value
   def fold[B](fail: Error => B, pass: A => B): B                       = pass(value)
-  def leftFlatMap[AA >: A](f: Error => CoreTarget[AA]): CoreTarget[AA] = new CoreTargetValue(value)
+  def leftFlatMap[AA >: A](f: Error => CoreTarget[AA]): CoreTarget[AA] = new CoreTargetValue(value, logEntries)
+  def prependLogger(lastLogs: StructuredLogger): CoreTarget[A]         = new CoreTargetValue(value, lastLogs |+| logEntries)
 }
 object CoreTargetError {
-  def unapply[A](x: CoreTargetError[A]): Option[Error] = Some(x.error)
+  def unapply[A](x: CoreTargetError[A]): Option[(Error, StructuredLogger)] = Some((x.error, x.logEntries))
 }
-class CoreTargetError[A](val error: Error) extends CoreTarget[A] {
+class CoreTargetError[A](val error: Error, logEntries: StructuredLogger) extends CoreTarget[A](logEntries) {
   def valueOr[AA >: A](fallback: Error => AA): AA                      = fallback(error)
   def fold[B](fail: Error => B, pass: A => B): B                       = fail(error)
-  def leftFlatMap[AA >: A](f: Error => CoreTarget[AA]): CoreTarget[AA] = f(error)
+  def leftFlatMap[AA >: A](f: Error => CoreTarget[AA]): CoreTarget[AA] = f(error).prependLogger(logEntries)
+  def prependLogger(lastLogs: StructuredLogger): CoreTarget[A]         = new CoreTargetError(error, lastLogs |+| logEntries)
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/CoreTarget.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/CoreTarget.scala
@@ -46,7 +46,7 @@ object CoreTarget extends LogAbstraction {
   }
 
   type F[A] = CoreTarget[A]
-  val A                                                     = Applicative[CoreTarget]
+  val A                                                     = coreTargetInstances
   def pushLogger(value: StructuredLogger): CoreTarget[Unit] = new CoreTargetValue((), value)
   def pure[T](x: T): CoreTarget[T]                          = x.pure[CoreTarget]
   def fromOption[T](x: Option[T], default: => Error): CoreTarget[T] =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Target.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Target.scala
@@ -85,7 +85,7 @@ object TargetValue {
 }
 class TargetValue[A](val value: A, logEntries: StructuredLogger) extends Target[A](logEntries) {
   def valueOr[AA >: A](fallback: Error => AA): AA          = value
-  def toCoreTarget: CoreTarget[A]                          = new CoreTargetValue(value)
+  def toCoreTarget: CoreTarget[A]                          = new CoreTargetValue(value, logEntries)
   def map[B](f: A => B): Target[B]                         = new TargetValue(f(value), logEntries)
   def flatMap[B](f: A => Target[B]): Target[B]             = f(value).prependLogger(logEntries)
   def recover[AA >: A](f: Error => AA): Target[AA]         = new TargetValue(value, logEntries)
@@ -97,10 +97,10 @@ object TargetError {
 }
 class TargetError[A](val error: Error, logEntries: StructuredLogger) extends Target[A](logEntries) {
   def valueOr[AA >: A](fallback: Error => AA): AA          = fallback(error)
-  def toCoreTarget: CoreTarget[A]                          = new CoreTargetError(error)
+  def toCoreTarget: CoreTarget[A]                          = new CoreTargetError(error, logEntries)
   def map[B](f: A => B): Target[B]                         = new TargetError(error, logEntries)
   def flatMap[B](f: A => Target[B]): Target[B]             = new TargetError(error, logEntries)
-  def recover[AA >: A](f: Error => AA): Target[AA]         = new TargetValue(f(error), StructuredLogger.Empty)
+  def recover[AA >: A](f: Error => AA): Target[AA]         = new TargetValue(f(error), logEntries)
   def fold[B](fail: Error => B, pass: A => B): B           = fail(error)
   def prependLogger(lastLogs: StructuredLogger): Target[A] = new TargetError(error, lastLogs |+| logEntries)
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Target.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Target.scala
@@ -30,7 +30,6 @@ object Target extends LogAbstraction {
     x.valueOr({ err =>
       throw new Exception(err.toString)
     })
-  // .runEmptyA
 
   implicit val targetInstances = new MonadError[Target, Error] with Traverse[Target] {
     def pure[A](x: A): Target[A] = Target.A.pure(x)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Target.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Target.scala
@@ -73,8 +73,6 @@ object Target extends LogAbstraction {
 sealed abstract class Target[A](val logEntries: StructuredLogger) {
   def valueOr[AA >: A](fallback: Error => AA): AA
   def toCoreTarget: CoreTarget[A]
-  def map[B](f: A => B): Target[B]
-  def flatMap[B](f: A => Target[B]): Target[B]
   def recover[AA >: A](f: Error => AA): Target[AA]
   def fold[B](fail: Error => B, pass: A => B): B
   def prependLogger(lastLogs: StructuredLogger): Target[A]
@@ -85,8 +83,6 @@ object TargetValue {
 class TargetValue[A](val value: A, logEntries: StructuredLogger) extends Target[A](logEntries) {
   def valueOr[AA >: A](fallback: Error => AA): AA          = value
   def toCoreTarget: CoreTarget[A]                          = new CoreTargetValue(value, logEntries)
-  def map[B](f: A => B): Target[B]                         = new TargetValue(f(value), logEntries)
-  def flatMap[B](f: A => Target[B]): Target[B]             = f(value).prependLogger(logEntries)
   def recover[AA >: A](f: Error => AA): Target[AA]         = new TargetValue(value, logEntries)
   def fold[B](fail: Error => B, pass: A => B): B           = pass(value)
   def prependLogger(lastLogs: StructuredLogger): Target[A] = new TargetValue(value, lastLogs |+| logEntries)
@@ -97,8 +93,6 @@ object TargetError {
 class TargetError[A](val error: Error, logEntries: StructuredLogger) extends Target[A](logEntries) {
   def valueOr[AA >: A](fallback: Error => AA): AA          = fallback(error)
   def toCoreTarget: CoreTarget[A]                          = new CoreTargetError(error, logEntries)
-  def map[B](f: A => B): Target[B]                         = new TargetError(error, logEntries)
-  def flatMap[B](f: A => Target[B]): Target[B]             = new TargetError(error, logEntries)
   def recover[AA >: A](f: Error => AA): Target[AA]         = new TargetValue(f(error), logEntries)
   def fold[B](fail: Error => B, pass: A => B): B           = fail(error)
   def prependLogger(lastLogs: StructuredLogger): Target[A] = new TargetError(error, lastLogs |+| logEntries)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Target.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Target.scala
@@ -4,26 +4,27 @@ import com.twilio.swagger.core.StructuredLogger
 import cats.{ Applicative, MonadError }
 import cats.Traverse
 import cats.Eval
+import cats.implicits._
 
 object Target extends LogAbstraction {
   type F[A] = Target[A]
   val A = new Applicative[Target] {
-    def pure[A](x: A): Target[A] = new TargetValue(x)
+    def pure[A](x: A): Target[A] = new TargetValue(x, StructuredLogger.Empty)
     def ap[A, B](ff: Target[A => B])(fa: Target[A]): Target[B] =
       (ff, fa) match {
-        case (TargetValue(f), TargetValue(a)) => new TargetValue(f(a))
-        case (TargetError(err), _)            => new TargetError(err)
-        case (_, TargetError(err))            => new TargetError(err)
+        case (TargetValue(f, fl), TargetValue(a, al)) => new TargetValue(f(a), fl |+| al)
+        case (TargetError(err, la), _)                => new TargetError(err, la)
+        case (fst, TargetError(err, la))              => new TargetError(err, la).prependLogger(fst.logEntries)
       }
   }
-  def pushLogger(value: StructuredLogger): Target[Unit] = new TargetValue(()) // IndexedStateT.modify(_ |+| value))
+  def pushLogger(value: StructuredLogger): Target[Unit] = new TargetValue((), value)
   def pure[T](x: T): Target[T]                          = A.pure(x)
   @deprecated("Use raiseError instead", "v0.41.2")
   def error[T](x: String): Target[T]          = raiseError(x)
-  def raiseError[T](x: String): Target[T]     = new TargetError(UserError(x))
-  def raiseException[T](x: String): Target[T] = new TargetError(RuntimeFailure(x))
+  def raiseError[T](x: String): Target[T]     = new TargetError(UserError(x), StructuredLogger.Empty)
+  def raiseException[T](x: String): Target[T] = new TargetError(RuntimeFailure(x), StructuredLogger.Empty)
   def fromOption[T](x: Option[T], default: => String): Target[T] =
-    x.fold[Target[T]](new TargetError(UserError(default)))(new TargetValue(_))
+    x.fold[Target[T]](new TargetError(UserError(default), StructuredLogger.Empty))(new TargetValue(_, StructuredLogger.Empty))
   @SuppressWarnings(Array("org.wartremover.warts.Throw"))
   def unsafeExtract[T](x: Target[T]): T =
     x.valueOr({ err =>
@@ -35,68 +36,71 @@ object Target extends LogAbstraction {
     def pure[A](x: A): Target[A] = Target.A.pure(x)
 
     def handleErrorWith[A](fa: Target[A])(f: Error => Target[A]): Target[A] = fa match {
-      case fa @ TargetValue(_) => fa
-      case TargetError(err)    => f(err)
+      case fa @ TargetValue(_, _) => fa
+      case TargetError(err, sl)   => f(err).prependLogger(sl)
     }
-    def raiseError[A](e: Error): Target[A] = new TargetError(e)
+    def raiseError[A](e: Error): Target[A] = new TargetError(e, StructuredLogger.Empty)
 
     def flatMap[A, B](fa: Target[A])(f: A => Target[B]): Target[B] = fa match {
-      case TargetValue(a)   => f(a)
-      case TargetError(err) => new TargetError(err)
+      case TargetValue(a, la)   => f(a).prependLogger(la)
+      case TargetError(err, la) => new TargetError(err, la)
     }
     def tailRecM[A, B](a: A)(f: A => Target[Either[A, B]]): Target[B] =
       f(a) match {
-        case TargetError(err) =>
-          new TargetError(err)
-        case TargetValue(e) =>
+        case TargetError(err, la) =>
+          new TargetError(err, la)
+        case TargetValue(e, la) =>
           e match {
-            case Left(b)  => tailRecM(b)(f)
-            case Right(a) => new TargetValue(a)
+            case Left(b)  => tailRecM(b)(f).prependLogger(la)
+            case Right(a) => new TargetValue(a, la)
           }
       }
 
     def foldLeft[A, B](fa: Target[A], b: B)(f: (B, A) => B): B = fa match {
-      case TargetValue(a) => f(b, a)
-      case TargetError(_) => b
+      case TargetValue(a, _) => f(b, a)
+      case TargetError(_, _) => b
     }
     def foldRight[A, B](fa: Target[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] = fa match {
-      case TargetValue(a) => f(a, lb)
-      case TargetError(_) => lb
+      case TargetValue(a, _) => f(a, lb)
+      case TargetError(_, _) => lb
     }
     def traverse[G[_], A, B](fa: Target[A])(f: A => G[B])(implicit G: Applicative[G]): G[Target[B]] = fa match {
-      case TargetValue(a) => G.ap(G.pure(Target.pure[B](_)))(f(a))
-      case TargetError(e) => G.pure[Target[B]](new TargetError(e))
+      case TargetValue(a, la) => G.ap(G.pure[B => Target[B]](new TargetValue[B](_, la)))(f(a))
+      case TargetError(e, la) => G.pure[Target[B]](new TargetError(e, la))
     }
   }
 }
 
-sealed abstract class Target[A] {
+sealed abstract class Target[A](val logEntries: StructuredLogger) {
   def valueOr[AA >: A](fallback: Error => AA): AA
   def toCoreTarget: CoreTarget[A]
   def map[B](f: A => B): Target[B]
   def flatMap[B](f: A => Target[B]): Target[B]
   def recover[AA >: A](f: Error => AA): Target[AA]
   def fold[B](fail: Error => B, pass: A => B): B
+  def prependLogger(lastLogs: StructuredLogger): Target[A]
 }
 object TargetValue {
-  def unapply[A](x: TargetValue[A]): Option[A] = Some(x.value)
+  def unapply[A](x: TargetValue[A]): Option[(A, StructuredLogger)] = Some((x.value, x.logEntries))
 }
-class TargetValue[A](val value: A) extends Target[A] {
-  def valueOr[AA >: A](fallback: Error => AA): AA  = value
-  def toCoreTarget: CoreTarget[A]                  = new CoreTargetValue(value)
-  def map[B](f: A => B): Target[B]                 = new TargetValue(f(value))
-  def flatMap[B](f: A => Target[B]): Target[B]     = f(value)
-  def recover[AA >: A](f: Error => AA): Target[AA] = new TargetValue(value)
-  def fold[B](fail: Error => B, pass: A => B): B   = pass(value)
+class TargetValue[A](val value: A, logEntries: StructuredLogger) extends Target[A](logEntries) {
+  def valueOr[AA >: A](fallback: Error => AA): AA          = value
+  def toCoreTarget: CoreTarget[A]                          = new CoreTargetValue(value)
+  def map[B](f: A => B): Target[B]                         = new TargetValue(f(value), logEntries)
+  def flatMap[B](f: A => Target[B]): Target[B]             = f(value).prependLogger(logEntries)
+  def recover[AA >: A](f: Error => AA): Target[AA]         = new TargetValue(value, logEntries)
+  def fold[B](fail: Error => B, pass: A => B): B           = pass(value)
+  def prependLogger(lastLogs: StructuredLogger): Target[A] = new TargetValue(value, lastLogs |+| logEntries)
 }
 object TargetError {
-  def unapply[A](x: TargetError[A]): Option[Error] = Some(x.error)
+  def unapply[A](x: TargetError[A]): Option[(Error, StructuredLogger)] = Some((x.error, x.logEntries))
 }
-class TargetError[A](val error: Error) extends Target[A] {
-  def valueOr[AA >: A](fallback: Error => AA): AA  = fallback(error)
-  def toCoreTarget: CoreTarget[A]                  = new CoreTargetError(error)
-  def map[B](f: A => B): Target[B]                 = new TargetError(error)
-  def flatMap[B](f: A => Target[B]): Target[B]     = new TargetError(error)
-  def recover[AA >: A](f: Error => AA): Target[AA] = new TargetValue(f(error))
-  def fold[B](fail: Error => B, pass: A => B): B   = fail(error)
+class TargetError[A](val error: Error, logEntries: StructuredLogger) extends Target[A](logEntries) {
+  def valueOr[AA >: A](fallback: Error => AA): AA          = fallback(error)
+  def toCoreTarget: CoreTarget[A]                          = new CoreTargetError(error)
+  def map[B](f: A => B): Target[B]                         = new TargetError(error, logEntries)
+  def flatMap[B](f: A => Target[B]): Target[B]             = new TargetError(error, logEntries)
+  def recover[AA >: A](f: Error => AA): Target[AA]         = new TargetValue(f(error), StructuredLogger.Empty)
+  def fold[B](fail: Error => B, pass: A => B): B           = fail(error)
+  def prependLogger(lastLogs: StructuredLogger): Target[A] = new TargetError(error, lastLogs |+| logEntries)
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/core/StructuredLogger.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/core/StructuredLogger.scala
@@ -1,6 +1,6 @@
 package com.twilio.swagger.core
 
-import cats.data.NonEmptyVector
+import cats.data.{ Chain, NonEmptyChain }
 import cats.implicits._
 import cats.{ Monoid, Order, Show }
 
@@ -35,45 +35,45 @@ object LogLevels {
 }
 
 sealed trait StructuredLogEntry
-sealed case class StructuredLogBlock(lines: NonEmptyVector[(LogLevel, String)]) extends StructuredLogEntry
-sealed case class StructuredLoggerPush(next: String)                            extends StructuredLogEntry
-case object StructuredLoggerPop                                                 extends StructuredLogEntry
-case object StructuredLoggerReset                                               extends StructuredLogEntry
+sealed case class StructuredLogBlock(lines: NonEmptyChain[(LogLevel, String)]) extends StructuredLogEntry
+sealed case class StructuredLoggerPush(next: String)                           extends StructuredLogEntry
+case object StructuredLoggerPop                                                extends StructuredLogEntry
+case object StructuredLoggerReset                                              extends StructuredLogEntry
 
-case class StructuredLogger(entries: Vector[StructuredLogEntry])
+case class StructuredLogger(entries: Chain[StructuredLogEntry])
 
 object StructuredLogger extends StructuredLoggerInstances {
-  def push(next: String): StructuredLogger = StructuredLogger(StructuredLoggerPush(next).pure[Vector])
-  def pop: StructuredLogger                = StructuredLogger(StructuredLoggerPop.pure[Vector])
-  def reset: StructuredLogger              = StructuredLogger(StructuredLoggerReset.pure[Vector])
-  object Empty extends StructuredLogger(Vector.empty)
+  def push(next: String): StructuredLogger = StructuredLogger(StructuredLoggerPush(next).pure[Chain])
+  def pop: StructuredLogger                = StructuredLogger(StructuredLoggerPop.pure[Chain])
+  def reset: StructuredLogger              = StructuredLogger(StructuredLoggerReset.pure[Chain])
+  object Empty extends StructuredLogger(Chain.empty)
 }
 sealed trait StructuredLoggerInstances extends StructuredLoggerLowPriority {
   implicit object StructuredLoggerMonoid extends Monoid[StructuredLogger] {
-    def empty                                             = StructuredLogger(Vector.empty)
-    def combine(x: StructuredLogger, y: StructuredLogger) = StructuredLogger(Monoid[Vector[StructuredLogEntry]].combine(x.entries, y.entries))
+    def empty                                             = StructuredLogger(Chain.empty)
+    def combine(x: StructuredLogger, y: StructuredLogger) = StructuredLogger(Monoid[Chain[StructuredLogEntry]].combine(x.entries, y.entries))
   }
   class ShowStructuredLogger(desiredLevel: LogLevel) extends Show[StructuredLogger] {
     def show(value: StructuredLogger): String =
       value.entries
-        .foldLeft((Vector.empty[(LogLevel, NonEmptyVector[String], String)], Vector.empty[String]))({
+        .foldLeft((Chain.empty[(LogLevel, NonEmptyChain[String], String)], Chain.empty[String]))({
           case ((acc, newHistory), StructuredLoggerPop) =>
-            (acc, newHistory.take(newHistory.length - 1))
+            (acc, newHistory.initLast.fold[Chain[String]](Chain.empty)(_._1))
           case ((acc, newHistory), StructuredLoggerPush(name)) =>
             (acc, newHistory :+ name)
           case ((acc, newHistory), StructuredLoggerReset) =>
-            (acc, Vector.empty)
+            (acc, Chain.empty)
           case ((acc, newHistory), StructuredLogBlock(lines)) =>
-            val newAcc = acc ++ lines
+            val newAcc: Chain[(LogLevel, NonEmptyChain[String], String)] = acc ++ lines
                     .filter(_._1 >= desiredLevel)
                     .map({
                       case (level, message) =>
-                        (level, NonEmptyVector.fromVector(newHistory).getOrElse(NonEmptyVector("<root>", Vector.empty)), message)
+                        (level, NonEmptyChain.fromChain[String](newHistory).getOrElse(NonEmptyChain("<root>")), message)
                     })
             (newAcc, newHistory)
         })
         ._1
-        .foldLeft((Vector.empty[String], Vector.empty[String]))({
+        .foldLeft((Chain.empty[String], Chain.empty[String]))({
           case ((lastHistory, messages), (level, history, message)) =>
             val showFullHistory = true
             def makePrefix(history: Vector[String]): String =
@@ -86,26 +86,28 @@ sealed trait StructuredLoggerInstances extends StructuredLoggerLowPriority {
                    }) + " " + b
               }
 
-            val commonPrefixLength = history.length - lastHistory.zip(history.toList).takeWhile(((_: String) == (_: String)).tupled).length
+            val historyVec         = history.toChain.toVector
+            val commonPrefixLength = historyVec.length - lastHistory.toVector.zip(historyVec).takeWhile(((_: String) == (_: String)).tupled).length
             val histories = if (!showFullHistory) {
-              (1 until commonPrefixLength).map(i => s"${level.show} ${makePrefix(history.toVector.take(i))}")
+              (1 until commonPrefixLength).map(i => s"${level.show} ${makePrefix(historyVec.take(i))}")
             } else Nil
-            val prefix    = s"${level.show} ${makePrefix(history.toVector)}: "
+            val prefix    = s"${level.show} ${makePrefix(historyVec)}: "
             val formatted = (message.linesIterator.take(1).map(prefix + _) ++ message.linesIterator.drop(1).map((" " * prefix.length) + _)).mkString("\n")
-            (history.toVector, (messages ++ histories) ++ Vector(formatted))
+            (history.toChain, (messages ++ Chain.fromSeq(histories)) ++ Chain(formatted))
         })
         ._2
+        .toVector
         .mkString("\n")
   }
 
   def debug(message: String): StructuredLogger =
-    StructuredLogger(Vector(StructuredLogBlock(NonEmptyVector.one((LogLevels.Debug, message)))))
+    StructuredLogger(Chain(StructuredLogBlock(NonEmptyChain.one((LogLevels.Debug, message)))))
   def info(message: String): StructuredLogger =
-    StructuredLogger(Vector(StructuredLogBlock(NonEmptyVector.one((LogLevels.Info, message)))))
+    StructuredLogger(Chain(StructuredLogBlock(NonEmptyChain.one((LogLevels.Info, message)))))
   def warning(message: String): StructuredLogger =
-    StructuredLogger(Vector(StructuredLogBlock(NonEmptyVector.one((LogLevels.Warning, message)))))
+    StructuredLogger(Chain(StructuredLogBlock(NonEmptyChain.one((LogLevels.Warning, message)))))
   def error(message: String): StructuredLogger =
-    StructuredLogger(Vector(StructuredLogBlock(NonEmptyVector.one((LogLevels.Error, message)))))
+    StructuredLogger(Chain(StructuredLogBlock(NonEmptyChain.one((LogLevels.Error, message)))))
 }
 
 trait StructuredLoggerLowPriority { self: StructuredLoggerInstances =>

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/core/StructuredLogger.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/core/StructuredLogger.scala
@@ -46,6 +46,7 @@ object StructuredLogger extends StructuredLoggerInstances {
   def push(next: String): StructuredLogger = StructuredLogger(StructuredLoggerPush(next).pure[Vector])
   def pop: StructuredLogger                = StructuredLogger(StructuredLoggerPop.pure[Vector])
   def reset: StructuredLogger              = StructuredLogger(StructuredLoggerReset.pure[Vector])
+  object Empty extends StructuredLogger(Vector.empty)
 }
 sealed trait StructuredLoggerInstances extends StructuredLoggerLowPriority {
   implicit object StructuredLoggerMonoid extends Monoid[StructuredLogger] {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
@@ -1,8 +1,7 @@
 package com.twilio.guardrail.generators.Java
 
 import cats.data.NonEmptyList
-import cats.instances.list._
-import cats.syntax.traverse._
+import cats.implicits._
 import cats.~>
 import com.github.javaparser.StaticJavaParser
 import com.github.javaparser.ast.{ ImportDeclaration, NodeList }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardGenerator.scala
@@ -1,6 +1,7 @@
 package com.twilio.guardrail.generators.Java
 
 import cats.~>
+import cats.implicits._
 import com.github.javaparser.ast.expr._
 import com.twilio.guardrail.Target
 import com.twilio.guardrail.generators.syntax.Java._

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
@@ -2,9 +2,7 @@ package com.twilio.guardrail.generators.Java
 
 import cats.data.NonEmptyList
 import cats.~>
-import cats.instances.list._
-import cats.syntax.flatMap._
-import cats.syntax.traverse._
+import cats.implicits._
 import com.github.javaparser.StaticJavaParser
 import com.github.javaparser.ast.Modifier._
 import com.github.javaparser.ast.Modifier.Keyword._

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvcGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvcGenerator.scala
@@ -1,6 +1,7 @@
 package com.twilio.guardrail.generators.Java
 
 import cats.~>
+import cats.implicits._
 import com.github.javaparser.ast.expr.Name
 import com.twilio.guardrail.Target
 import com.twilio.guardrail.generators.syntax.Java.{ safeParseName, safeParseType }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvcServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvcServerGenerator.scala
@@ -2,9 +2,7 @@ package com.twilio.guardrail.generators.Java
 
 import cats.data.NonEmptyList
 import cats.~>
-import cats.instances.list._
-import cats.syntax.flatMap._
-import cats.syntax.traverse._
+import cats.implicits._
 import com.github.javaparser.StaticJavaParser
 import com.github.javaparser.ast.Modifier._
 import com.github.javaparser.ast.Modifier.Keyword._

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
@@ -1,9 +1,7 @@
 package com.twilio.guardrail.generators
 
 import cats.~>
-import cats.instances.list._
-import cats.instances.option._
-import cats.syntax.traverse._
+import cats.implicits._
 import com.github.javaparser.ast._
 import com.github.javaparser.ast.Modifier._
 import com.github.javaparser.ast.`type`.{ ClassOrInterfaceType, PrimitiveType, Type, VoidType, ArrayType => AstArrayType }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaModule.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaModule.scala
@@ -4,6 +4,7 @@ package generators
 import com.twilio.guardrail.languages.ScalaLanguage
 import cats.data.NonEmptyList
 import cats.arrow.FunctionK
+import cats.implicits._
 import com.twilio.guardrail.circe.CirceVersion
 
 object ScalaModule extends AbstractModule[ScalaLanguage] {

--- a/modules/codegen/src/test/scala/support/SwaggerSpecRunner.scala
+++ b/modules/codegen/src/test/scala/support/SwaggerSpecRunner.scala
@@ -92,21 +92,15 @@ trait SwaggerSpecRunner extends EitherValues {
       Sc: ScalaTerms[L, CodegenApplication[L, ?]],
       Sw: SwaggerTerms[L, CodegenApplication[L, ?]]
   ): (StructuredLogger, Error) =
-    (
-      StructuredLogger(Vector.empty),
-      Common
-        .prepareDefinitions[L, CodegenApplication[L, ?]](
-          kind,
-          context,
-          Tracker(swagger),
-          List.empty
-        )
-        .foldMap(framework) match {
-        case TargetError(err, _) => err
-        case _                   => ???
-      }
-    )
-  //.value
-  //.runEmpty
-  //.map(_.map(_.left.value))
+    Common
+      .prepareDefinitions[L, CodegenApplication[L, ?]](
+        kind,
+        context,
+        Tracker(swagger),
+        List.empty
+      )
+      .foldMap(framework) match {
+      case TargetError(err, la) => (la, err)
+      case _                    => ???
+    }
 }

--- a/modules/codegen/src/test/scala/support/SwaggerSpecRunner.scala
+++ b/modules/codegen/src/test/scala/support/SwaggerSpecRunner.scala
@@ -102,8 +102,8 @@ trait SwaggerSpecRunner extends EitherValues {
           List.empty
         )
         .foldMap(framework) match {
-        case TargetError(err) => err
-        case _                => ???
+        case TargetError(err, _) => err
+        case _                   => ???
       }
     )
   //.value


### PR DESCRIPTION
After flattening Target and CoreTarget into sealed abstract classes, it seems as though StructuredLogger can be reintroduced without significant performance penalties.

After ten iterations of running `sbt resetSample runScalaExample` in a bash `for` loop:

| master | this branch |
| ------ | ----------- |
| 0m55.430s | 0m50.572s |
| 0m56.836s | 0m53.420s |
| 1m0.381s  | 0m54.534s |
| 1m2.485s  | 0m56.867s |
| 1m2.684s  | 0m57.790s |
| 1m3.166s  | 0m59.800s |
| 1m3.836s  | 1m0.645s  |
| 1m5.988s  | 1m1.785s  |
| 1m6.346s  | 1m2.181s  |
| 1m8.693s  | 1m2.570s  |


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
