### PR TITLE
Thread through required/nullable state

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/CirceProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/CirceProtocolGenerator.scala
@@ -115,7 +115,7 @@ object CirceProtocolGenerator {
           .getOrElse(Target.pure(List.empty))
           .map(_.toList)
 
-      case TransformProperty(clsName, name, property, meta, needCamelSnakeConversion, concreteTypes, isRequired, isCustomType, defaultValue) =>
+      case TransformProperty(clsName, name, property, meta, needCamelSnakeConversion, concreteTypes, requirement, isCustomType, defaultValue) =>
         Target.log.function(s"transformProperty") {
           for {
             _ <- Target.log.debug(s"Args: (${clsName}, ${name}, ...)")
@@ -154,8 +154,8 @@ object CirceProtocolGenerator {
                 (t"${customTpe.getOrElse(t"Map")}[String, $innerType]", Option.empty)
             }
 
-            (finalDeclType, finalDefaultValue) = Option(isRequired)
-              .filterNot(_ == false)
+            (finalDeclType, finalDefaultValue) = Option(requirement)
+              .filterNot(req => req == PropertyRequirement.Optional || req == PropertyRequirement.OptionalNullable)
               .fold[(Type, Option[Term])](
                 (t"Option[${tpe}]", Some(defaultValue.fold[Term](q"None")(t => q"Option($t)")))
               )(Function.const((tpe, defaultValue)) _)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
@@ -764,7 +764,7 @@ object JacksonGenerator {
           )
           .getOrElse(Target.pure(List.empty[(String, Tracker[Schema[_]])]))
 
-      case TransformProperty(clsName, name, property, meta, needCamelSnakeConversion, concreteTypes, isRequired, isCustomType, defaultValue) =>
+      case TransformProperty(clsName, name, property, meta, needCamelSnakeConversion, concreteTypes, requirement, isCustomType, defaultValue) =>
         Target.log.function("transformProperty") {
           val readOnlyKey = Option(name).filter(_ => Option(property.getReadOnly).contains(true))
           val emptyToNull = (property match {
@@ -814,8 +814,8 @@ object JacksonGenerator {
                 Target.log.warning(s"Can't generate default value for class $clsName and property $name.") >> Target.pure(None)
               case None => Target.pure(None)
             }
-            (finalDeclType, finalDefaultValue) <- Option(isRequired)
-              .filterNot(_ == false)
+            (finalDeclType, finalDefaultValue) <- Option(requirement)
+              .filterNot(req => req == PropertyRequirement.Optional || req == PropertyRequirement.OptionalNullable)
               .fold[Target[(Type, Option[Expression])]](
                 (
                   safeParseType(s"Optional<${tpe}>"),

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerm.scala
@@ -6,6 +6,14 @@ import com.twilio.guardrail.core.Tracker
 import com.twilio.guardrail.languages.LA
 import com.twilio.guardrail.{ ProtocolParameter, StaticDefns, SuperClass }
 
+sealed trait PropertyRequirement
+object PropertyRequirement {
+  case object Required         extends PropertyRequirement
+  case object RequiredNullable extends PropertyRequirement
+  case object Optional         extends PropertyRequirement
+  case object OptionalNullable extends PropertyRequirement
+}
+
 sealed trait ModelProtocolTerm[L <: LA, T]
 case class ExtractProperties[L <: LA](swagger: Tracker[Schema[_]]) extends ModelProtocolTerm[L, List[(String, Tracker[Schema[_]])]]
 case class TransformProperty[L <: LA](
@@ -15,7 +23,7 @@ case class TransformProperty[L <: LA](
     meta: ResolvedType[L],
     needCamelSnakeConversion: Boolean,
     concreteTypes: List[PropMeta[L]],
-    isRequired: Boolean,
+    requirement: PropertyRequirement,
     isCustomType: Boolean,
     defaultValue: Option[L#Term]
 ) extends ModelProtocolTerm[L, ProtocolParameter[L]]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerms.scala
@@ -15,12 +15,12 @@ class ModelProtocolTerms[L <: LA, F[_]](implicit I: InjectK[ModelProtocolTerm[L,
       name: String,
       prop: Schema[_],
       meta: ResolvedType[L],
-      isRequired: Boolean,
+      requirement: PropertyRequirement,
       isCustomType: Boolean,
       defaultValue: Option[L#Term]
   ): Free[F, ProtocolParameter[L]] =
     Free.inject[ModelProtocolTerm[L, ?], F](
-      TransformProperty[L](clsName, name, prop, meta, needCamelSnakeConversion, concreteTypes, isRequired, isCustomType, defaultValue)
+      TransformProperty[L](clsName, name, prop, meta, needCamelSnakeConversion, concreteTypes, requirement, isCustomType, defaultValue)
     )
   def renderDTOClass(clsName: String, terms: List[ProtocolParameter[L]], parents: List[SuperClass[L]] = Nil): Free[F, L#ClassDefinition] =
     Free.inject[ModelProtocolTerm[L, ?], F](RenderDTOClass[L](clsName, terms, parents))


### PR DESCRIPTION
Threads through the info necessary to fix https://github.com/twilio/guardrail/issues/315 (though it does not actually attempt to fix it yet; current behavior is maintained).

Verified with a temp git repo in each of the `sample-*` dirs that generated output remains unchanged with these commits.

Note that the name of this branch lies, as I dropped the `always-camelsnake` bit after submitting.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
