### PR TITLE
Tagless final pt2

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ClientGenerator.scala
@@ -32,7 +32,7 @@ object ClientGenerator {
   )(
       protocolElems: List[StrictProtocolElems[L]],
       securitySchemes: Map[String, SecurityScheme[L]]
-  )(implicit C: ClientTerms[L, Free[F, ?]], Fw: FrameworkTerms[L, F], Sc: ScalaTerms[L, Free[F, ?]], Sw: SwaggerTerms[L, F]): Free[F, Clients[L]] = {
+  )(implicit C: ClientTerms[L, Free[F, ?]], Fw: FrameworkTerms[L, F], Sc: ScalaTerms[L, Free[F, ?]], Sw: SwaggerTerms[L, Free[F, ?]]): Free[F, Clients[L]] = {
     import C._
     import Sw._
     for {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ClientGenerator.scala
@@ -1,7 +1,6 @@
 package com.twilio.guardrail
 
 import cats.data.NonEmptyList
-import cats.free.Free
 import cats.implicits._
 import com.twilio.guardrail.languages.LA
 import com.twilio.guardrail.protocol.terms.client.ClientTerms
@@ -32,7 +31,7 @@ object ClientGenerator {
   )(
       protocolElems: List[StrictProtocolElems[L]],
       securitySchemes: Map[String, SecurityScheme[L]]
-  )(implicit C: ClientTerms[L, Free[F, ?]], Fw: FrameworkTerms[L, F], Sc: ScalaTerms[L, Free[F, ?]], Sw: SwaggerTerms[L, Free[F, ?]]): Free[F, Clients[L]] = {
+  )(implicit C: ClientTerms[L, F], Fw: FrameworkTerms[L, F], Sc: ScalaTerms[L, F], Sw: SwaggerTerms[L, F]): F[Clients[L]] = {
     import C._
     import Sw._
     for {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -24,7 +24,7 @@ object Common {
   def prepareDefinitions[L <: LA, F[_]](kind: CodegenTarget, context: Context, swagger: Tracker[OpenAPI], dtoPackage: List[String])(
       implicit
       C: ClientTerms[L, Free[F, ?]],
-      R: ArrayProtocolTerms[L, F],
+      R: ArrayProtocolTerms[L, Free[F, ?]],
       E: EnumProtocolTerms[L, F],
       Fw: FrameworkTerms[L, F],
       M: ModelProtocolTerms[L, F],

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -32,7 +32,7 @@ object Common {
       S: ProtocolSupportTerms[L, F],
       Sc: ScalaTerms[L, Free[F, ?]],
       Se: ServerTerms[L, F],
-      Sw: SwaggerTerms[L, F]
+      Sw: SwaggerTerms[L, Free[F, ?]]
   ): Free[F, (ProtocolDefinitions[L], CodegenDefinitions[L])] = {
     import Fw._
     import Sc._

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -26,7 +26,7 @@ object Common {
       C: ClientTerms[L, Free[F, ?]],
       R: ArrayProtocolTerms[L, Free[F, ?]],
       E: EnumProtocolTerms[L, Free[F, ?]],
-      Fw: FrameworkTerms[L, F],
+      Fw: FrameworkTerms[L, Free[F, ?]],
       M: ModelProtocolTerms[L, Free[F, ?]],
       Pol: PolyProtocolTerms[L, Free[F, ?]],
       S: ProtocolSupportTerms[L, F],
@@ -87,7 +87,7 @@ object Common {
         case CodegenTarget.Client =>
           for {
             clientMeta <- ClientGenerator
-              .fromSwagger[L, F](context, frameworkImports)(serverUrls, basePath, groupedRoutes)(protocolElems, securitySchemes)
+              .fromSwagger[L, Free[F, ?]](context, frameworkImports)(serverUrls, basePath, groupedRoutes)(protocolElems, securitySchemes)
             Clients(clients, supportDefinitions) = clientMeta
             frameworkImplicits <- getFrameworkImplicits()
           } yield CodegenDefinitions[L](clients, List.empty, supportDefinitions, frameworkImplicits)
@@ -110,7 +110,7 @@ object Common {
       pkgName: List[String],
       dtoPackage: List[String],
       customImports: List[L#Import]
-  )(implicit Sc: ScalaTerms[L, Free[F, ?]], Fw: FrameworkTerms[L, F]): Free[F, List[WriteTree]] = {
+  )(implicit Sc: ScalaTerms[L, F], Fw: FrameworkTerms[L, F]): F[List[WriteTree]] = {
     import Fw._
     import Sc._
 
@@ -148,7 +148,7 @@ object Common {
       ).mapN(_ ++ _)
 
       implicits <- renderImplicits(pkgPath, pkgName, frameworkImports, protocolImports, customImports)
-      frameworkImplicitsFile <- frameworkImplicits.fold(Free.pure[F, Option[WriteTree]](None))({
+      frameworkImplicitsFile <- frameworkImplicits.fold(Option.empty[WriteTree].pure[F])({
         case (name, defn) => renderFrameworkImplicits(pkgPath, pkgName, frameworkImports, protocolImports, defn, name).map(Option.apply)
       })
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -28,7 +28,7 @@ object Common {
       E: EnumProtocolTerms[L, Free[F, ?]],
       Fw: FrameworkTerms[L, F],
       M: ModelProtocolTerms[L, Free[F, ?]],
-      Pol: PolyProtocolTerms[L, F],
+      Pol: PolyProtocolTerms[L, Free[F, ?]],
       S: ProtocolSupportTerms[L, F],
       Sc: ScalaTerms[L, Free[F, ?]],
       Se: ServerTerms[L, F],

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -27,7 +27,7 @@ object Common {
       R: ArrayProtocolTerms[L, Free[F, ?]],
       E: EnumProtocolTerms[L, Free[F, ?]],
       Fw: FrameworkTerms[L, F],
-      M: ModelProtocolTerms[L, F],
+      M: ModelProtocolTerms[L, Free[F, ?]],
       Pol: PolyProtocolTerms[L, F],
       S: ProtocolSupportTerms[L, F],
       Sc: ScalaTerms[L, Free[F, ?]],

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -2,7 +2,6 @@ package com.twilio.guardrail
 
 import _root_.io.swagger.v3.oas.models.OpenAPI
 import cats.data.NonEmptyList
-import cats.free.Free
 import cats.implicits._
 import cats.Id
 import com.twilio.guardrail.core.Tracker
@@ -23,17 +22,17 @@ object Common {
 
   def prepareDefinitions[L <: LA, F[_]](kind: CodegenTarget, context: Context, swagger: Tracker[OpenAPI], dtoPackage: List[String])(
       implicit
-      C: ClientTerms[L, Free[F, ?]],
-      R: ArrayProtocolTerms[L, Free[F, ?]],
-      E: EnumProtocolTerms[L, Free[F, ?]],
-      Fw: FrameworkTerms[L, Free[F, ?]],
-      M: ModelProtocolTerms[L, Free[F, ?]],
-      Pol: PolyProtocolTerms[L, Free[F, ?]],
+      C: ClientTerms[L, F],
+      R: ArrayProtocolTerms[L, F],
+      E: EnumProtocolTerms[L, F],
+      Fw: FrameworkTerms[L, F],
+      M: ModelProtocolTerms[L, F],
+      Pol: PolyProtocolTerms[L, F],
       S: ProtocolSupportTerms[L, F],
-      Sc: ScalaTerms[L, Free[F, ?]],
-      Se: ServerTerms[L, Free[F, ?]],
-      Sw: SwaggerTerms[L, Free[F, ?]]
-  ): Free[F, (ProtocolDefinitions[L], CodegenDefinitions[L])] = {
+      Sc: ScalaTerms[L, F],
+      Se: ServerTerms[L, F],
+      Sw: SwaggerTerms[L, F]
+  ): F[(ProtocolDefinitions[L], CodegenDefinitions[L])] = {
     import Fw._
     import Sc._
     import Sw._
@@ -87,7 +86,7 @@ object Common {
         case CodegenTarget.Client =>
           for {
             clientMeta <- ClientGenerator
-              .fromSwagger[L, Free[F, ?]](context, frameworkImports)(serverUrls, basePath, groupedRoutes)(protocolElems, securitySchemes)
+              .fromSwagger[L, F](context, frameworkImports)(serverUrls, basePath, groupedRoutes)(protocolElems, securitySchemes)
             Clients(clients, supportDefinitions) = clientMeta
             frameworkImplicits <- getFrameworkImplicits()
           } yield CodegenDefinitions[L](clients, List.empty, supportDefinitions, frameworkImplicits)
@@ -95,12 +94,12 @@ object Common {
         case CodegenTarget.Server =>
           for {
             serverMeta <- ServerGenerator
-              .fromSwagger[L, Free[F, ?]](context, basePath, frameworkImports)(groupedRoutes)(protocolElems, securitySchemes)
+              .fromSwagger[L, F](context, basePath, frameworkImports)(groupedRoutes)(protocolElems, securitySchemes)
             Servers(servers, supportDefinitions) = serverMeta
             frameworkImplicits <- getFrameworkImplicits()
           } yield CodegenDefinitions[L](List.empty, servers, supportDefinitions, frameworkImplicits)
         case CodegenTarget.Models =>
-          Free.pure[F, CodegenDefinitions[L]](CodegenDefinitions[L](List.empty, List.empty, List.empty, Option.empty))
+          CodegenDefinitions[L](List.empty, List.empty, List.empty, Option.empty).pure[F]
       }
     } yield (proto, codegen))
   }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -25,7 +25,7 @@ object Common {
       implicit
       C: ClientTerms[L, Free[F, ?]],
       R: ArrayProtocolTerms[L, Free[F, ?]],
-      E: EnumProtocolTerms[L, F],
+      E: EnumProtocolTerms[L, Free[F, ?]],
       Fw: FrameworkTerms[L, F],
       M: ModelProtocolTerms[L, F],
       Pol: PolyProtocolTerms[L, F],

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -31,7 +31,7 @@ object Common {
       Pol: PolyProtocolTerms[L, Free[F, ?]],
       S: ProtocolSupportTerms[L, F],
       Sc: ScalaTerms[L, Free[F, ?]],
-      Se: ServerTerms[L, F],
+      Se: ServerTerms[L, Free[F, ?]],
       Sw: SwaggerTerms[L, Free[F, ?]]
   ): Free[F, (ProtocolDefinitions[L], CodegenDefinitions[L])] = {
     import Fw._
@@ -95,7 +95,7 @@ object Common {
         case CodegenTarget.Server =>
           for {
             serverMeta <- ServerGenerator
-              .fromSwagger[L, F](context, basePath, frameworkImports)(groupedRoutes)(protocolElems, securitySchemes)
+              .fromSwagger[L, Free[F, ?]](context, basePath, frameworkImports)(groupedRoutes)(protocolElems, securitySchemes)
             Servers(servers, supportDefinitions) = serverMeta
             frameworkImplicits <- getFrameworkImplicits()
           } yield CodegenDefinitions[L](List.empty, servers, supportDefinitions, frameworkImplicits)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolElems.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolElems.scala
@@ -45,7 +45,7 @@ object ProtocolElems {
   def resolve[L <: LA, F[_]](
       elems: List[ProtocolElems[L]],
       limit: Int = 10
-  )(implicit Sc: ScalaTerms[L, Free[F, ?]], Sw: SwaggerTerms[L, F], P: ProtocolSupportTerms[L, F]): Free[F, List[StrictProtocolElems[L]]] = {
+  )(implicit Sc: ScalaTerms[L, Free[F, ?]], Sw: SwaggerTerms[L, Free[F, ?]], P: ProtocolSupportTerms[L, F]): Free[F, List[StrictProtocolElems[L]]] = {
     import Sc._
     import Sw._
     log.function(s"resolve(${elems.length} references)")(

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
@@ -527,7 +527,7 @@ object ProtocolGenerator {
     Free.pure(RandomType[L](clsName, tpe))
 
   def fromArray[L <: LA, F[_]](clsName: String, arr: Tracker[ArraySchema], concreteTypes: List[PropMeta[L]])(
-      implicit R: ArrayProtocolTerms[L, F],
+      implicit R: ArrayProtocolTerms[L, Free[F, ?]],
       F: FrameworkTerms[L, F],
       P: ProtocolSupportTerms[L, F],
       Sc: ScalaTerms[L, Free[F, ?]],
@@ -620,7 +620,7 @@ object ProtocolGenerator {
   def fromSwagger[L <: LA, F[_]](swagger: Tracker[OpenAPI], dtoPackage: List[String])(
       implicit E: EnumProtocolTerms[L, F],
       M: ModelProtocolTerms[L, F],
-      R: ArrayProtocolTerms[L, F],
+      R: ArrayProtocolTerms[L, Free[F, ?]],
       S: ProtocolSupportTerms[L, F],
       F: FrameworkTerms[L, F],
       P: PolyProtocolTerms[L, F],

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
@@ -189,7 +189,7 @@ object ProtocolGenerator {
       dtoPackage: List[String]
   )(
       implicit F: FrameworkTerms[L, F],
-      P: PolyProtocolTerms[L, F],
+      P: PolyProtocolTerms[L, Free[F, ?]],
       E: EnumProtocolTerms[L, Free[F, ?]],
       M: ModelProtocolTerms[L, Free[F, ?]],
       Sc: ScalaTerms[L, Free[F, ?]],
@@ -259,7 +259,7 @@ object ProtocolGenerator {
       implicit M: ModelProtocolTerms[L, Free[F, ?]],
       F: FrameworkTerms[L, F],
       E: EnumProtocolTerms[L, Free[F, ?]],
-      P: PolyProtocolTerms[L, F],
+      P: PolyProtocolTerms[L, Free[F, ?]],
       Sc: ScalaTerms[L, Free[F, ?]],
       Sw: SwaggerTerms[L, Free[F, ?]]
   ): Free[F, List[SuperClass[L]]] = {
@@ -336,7 +336,7 @@ object ProtocolGenerator {
       implicit M: ModelProtocolTerms[L, Free[F, ?]],
       F: FrameworkTerms[L, F],
       E: EnumProtocolTerms[L, Free[F, ?]],
-      P: PolyProtocolTerms[L, F],
+      P: PolyProtocolTerms[L, Free[F, ?]],
       Sc: ScalaTerms[L, Free[F, ?]],
       Sw: SwaggerTerms[L, Free[F, ?]]
   ): Free[F, Either[String, ClassDefinition[L]]] = {
@@ -392,7 +392,7 @@ object ProtocolGenerator {
       implicit M: ModelProtocolTerms[L, Free[F, ?]],
       F: FrameworkTerms[L, F],
       E: EnumProtocolTerms[L, Free[F, ?]],
-      P: PolyProtocolTerms[L, F],
+      P: PolyProtocolTerms[L, Free[F, ?]],
       Sc: ScalaTerms[L, Free[F, ?]],
       Sw: SwaggerTerms[L, Free[F, ?]]
   ): Free[F, (List[ProtocolParameter[L]], List[NestedProtocolElems[L]])] = {
@@ -623,7 +623,7 @@ object ProtocolGenerator {
       R: ArrayProtocolTerms[L, Free[F, ?]],
       S: ProtocolSupportTerms[L, F],
       F: FrameworkTerms[L, F],
-      P: PolyProtocolTerms[L, F],
+      P: PolyProtocolTerms[L, Free[F, ?]],
       Sc: ScalaTerms[L, Free[F, ?]],
       Sw: SwaggerTerms[L, Free[F, ?]]
   ): Free[F, ProtocolDefinitions[L]] = {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
@@ -110,7 +110,7 @@ object ProtocolGenerator {
       swagger: Tracker[Schema[_]],
       dtoPackage: List[String]
   )(
-      implicit E: EnumProtocolTerms[L, F],
+      implicit E: EnumProtocolTerms[L, Free[F, ?]],
       F: FrameworkTerms[L, F],
       Sc: ScalaTerms[L, Free[F, ?]],
       Sw: SwaggerTerms[L, Free[F, ?]]
@@ -190,7 +190,7 @@ object ProtocolGenerator {
   )(
       implicit F: FrameworkTerms[L, F],
       P: PolyProtocolTerms[L, F],
-      E: EnumProtocolTerms[L, F],
+      E: EnumProtocolTerms[L, Free[F, ?]],
       M: ModelProtocolTerms[L, F],
       Sc: ScalaTerms[L, Free[F, ?]],
       Sw: SwaggerTerms[L, Free[F, ?]]
@@ -258,7 +258,7 @@ object ProtocolGenerator {
   )(
       implicit M: ModelProtocolTerms[L, F],
       F: FrameworkTerms[L, F],
-      E: EnumProtocolTerms[L, F],
+      E: EnumProtocolTerms[L, Free[F, ?]],
       P: PolyProtocolTerms[L, F],
       Sc: ScalaTerms[L, Free[F, ?]],
       Sw: SwaggerTerms[L, Free[F, ?]]
@@ -335,7 +335,7 @@ object ProtocolGenerator {
   )(
       implicit M: ModelProtocolTerms[L, F],
       F: FrameworkTerms[L, F],
-      E: EnumProtocolTerms[L, F],
+      E: EnumProtocolTerms[L, Free[F, ?]],
       P: PolyProtocolTerms[L, F],
       Sc: ScalaTerms[L, Free[F, ?]],
       Sw: SwaggerTerms[L, Free[F, ?]]
@@ -391,7 +391,7 @@ object ProtocolGenerator {
   )(
       implicit M: ModelProtocolTerms[L, F],
       F: FrameworkTerms[L, F],
-      E: EnumProtocolTerms[L, F],
+      E: EnumProtocolTerms[L, Free[F, ?]],
       P: PolyProtocolTerms[L, F],
       Sc: ScalaTerms[L, Free[F, ?]],
       Sw: SwaggerTerms[L, Free[F, ?]]
@@ -618,7 +618,7 @@ object ProtocolGenerator {
   }
 
   def fromSwagger[L <: LA, F[_]](swagger: Tracker[OpenAPI], dtoPackage: List[String])(
-      implicit E: EnumProtocolTerms[L, F],
+      implicit E: EnumProtocolTerms[L, Free[F, ?]],
       M: ModelProtocolTerms[L, F],
       R: ArrayProtocolTerms[L, Free[F, ?]],
       S: ProtocolSupportTerms[L, F],

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
@@ -191,7 +191,7 @@ object ProtocolGenerator {
       implicit F: FrameworkTerms[L, F],
       P: PolyProtocolTerms[L, F],
       E: EnumProtocolTerms[L, Free[F, ?]],
-      M: ModelProtocolTerms[L, F],
+      M: ModelProtocolTerms[L, Free[F, ?]],
       Sc: ScalaTerms[L, Free[F, ?]],
       Sw: SwaggerTerms[L, Free[F, ?]]
   ): Free[F, ProtocolElems[L]] = {
@@ -256,7 +256,7 @@ object ProtocolGenerator {
       concreteTypes: List[PropMeta[L]],
       dtoPackage: List[String]
   )(
-      implicit M: ModelProtocolTerms[L, F],
+      implicit M: ModelProtocolTerms[L, Free[F, ?]],
       F: FrameworkTerms[L, F],
       E: EnumProtocolTerms[L, Free[F, ?]],
       P: PolyProtocolTerms[L, F],
@@ -333,7 +333,7 @@ object ProtocolGenerator {
       definitions: List[(String, Tracker[Schema[_]])],
       dtoPackage: List[String]
   )(
-      implicit M: ModelProtocolTerms[L, F],
+      implicit M: ModelProtocolTerms[L, Free[F, ?]],
       F: FrameworkTerms[L, F],
       E: EnumProtocolTerms[L, Free[F, ?]],
       P: PolyProtocolTerms[L, F],
@@ -389,7 +389,7 @@ object ProtocolGenerator {
       definitions: List[(String, Tracker[Schema[_]])],
       dtoPackage: List[String]
   )(
-      implicit M: ModelProtocolTerms[L, F],
+      implicit M: ModelProtocolTerms[L, Free[F, ?]],
       F: FrameworkTerms[L, F],
       E: EnumProtocolTerms[L, Free[F, ?]],
       P: PolyProtocolTerms[L, F],
@@ -619,7 +619,7 @@ object ProtocolGenerator {
 
   def fromSwagger[L <: LA, F[_]](swagger: Tracker[OpenAPI], dtoPackage: List[String])(
       implicit E: EnumProtocolTerms[L, Free[F, ?]],
-      M: ModelProtocolTerms[L, F],
+      M: ModelProtocolTerms[L, Free[F, ?]],
       R: ArrayProtocolTerms[L, Free[F, ?]],
       S: ProtocolSupportTerms[L, F],
       F: FrameworkTerms[L, F],

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
@@ -31,7 +31,7 @@ object ServerGenerator {
   )(
       protocolElems: List[StrictProtocolElems[L]],
       securitySchemes: Map[String, SecurityScheme[L]]
-  )(implicit Fw: FrameworkTerms[L, F], Sc: ScalaTerms[L, Free[F, ?]], S: ServerTerms[L, F], Sw: SwaggerTerms[L, Free[F, ?]]): Free[F, Servers[L]] = {
+  )(implicit Fw: FrameworkTerms[L, Free[F, ?]], Sc: ScalaTerms[L, Free[F, ?]], S: ServerTerms[L, F], Sw: SwaggerTerms[L, Free[F, ?]]): Free[F, Servers[L]] = {
     import S._
     import Sw._
 
@@ -51,7 +51,7 @@ object ServerGenerator {
                   operationId         <- getOperationId(operation)
                   responses           <- Responses.getResponses(operationId, operation, protocolElems)
                   responseDefinitions <- generateResponseDefinitions(operationId, responses, protocolElems)
-                  parameters          <- route.getParameters[L, F](protocolElems)
+                  parameters          <- route.getParameters[L, Free[F, ?]](protocolElems)
                   tracingField        <- buildTracingFields(operation, className, context.tracing)
                 } yield (responseDefinitions, (operationId, tracingField, route, parameters, responses))
             }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
@@ -31,7 +31,7 @@ object ServerGenerator {
   )(
       protocolElems: List[StrictProtocolElems[L]],
       securitySchemes: Map[String, SecurityScheme[L]]
-  )(implicit Fw: FrameworkTerms[L, F], Sc: ScalaTerms[L, Free[F, ?]], S: ServerTerms[L, F], Sw: SwaggerTerms[L, F]): Free[F, Servers[L]] = {
+  )(implicit Fw: FrameworkTerms[L, F], Sc: ScalaTerms[L, Free[F, ?]], S: ServerTerms[L, F], Sw: SwaggerTerms[L, Free[F, ?]]): Free[F, Servers[L]] = {
     import S._
     import Sw._
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
@@ -1,6 +1,5 @@
 package com.twilio.guardrail
 
-import cats.free.Free
 import cats.instances.all._
 import cats.syntax.all._
 import com.twilio.guardrail.generators.ScalaParameter
@@ -31,7 +30,7 @@ object ServerGenerator {
   )(
       protocolElems: List[StrictProtocolElems[L]],
       securitySchemes: Map[String, SecurityScheme[L]]
-  )(implicit Fw: FrameworkTerms[L, Free[F, ?]], Sc: ScalaTerms[L, Free[F, ?]], S: ServerTerms[L, F], Sw: SwaggerTerms[L, Free[F, ?]]): Free[F, Servers[L]] = {
+  )(implicit Fw: FrameworkTerms[L, F], Sc: ScalaTerms[L, F], S: ServerTerms[L, F], Sw: SwaggerTerms[L, F]): F[Servers[L]] = {
     import S._
     import Sw._
 
@@ -51,7 +50,7 @@ object ServerGenerator {
                   operationId         <- getOperationId(operation)
                   responses           <- Responses.getResponses(operationId, operation, protocolElems)
                   responseDefinitions <- generateResponseDefinitions(operationId, responses, protocolElems)
-                  parameters          <- route.getParameters[L, Free[F, ?]](protocolElems)
+                  parameters          <- route.getParameters[L, F](protocolElems)
                   tracingField        <- buildTracingFields(operation, className, context.tracing)
                 } yield (responseDefinitions, (operationId, tracingField, route, parameters, responses))
             }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
@@ -143,11 +143,17 @@ class CoreTermInterp[L <: LA](
           swagger =>
             try {
               val Sw = SwaggerTerms.swaggerTerm[L, CodegenApplication[L, ?]]
+              val Sc = ScalaTerms.scalaTerm[L, CodegenApplication[L, ?]]
               val program = for {
                 _                  <- Sw.log.debug("Running guardrail codegen")
-                definitionsPkgName <- ScalaTerms.scalaTerm[L, CodegenApplication[L, ?]].fullyQualifyPackageName(pkgName)
+                definitionsPkgName <- Sc.fullyQualifyPackageName(pkgName)
                 (proto, codegen) <- Common
-                  .prepareDefinitions[L, CodegenApplication[L, ?]](kind, context, Tracker(swagger), definitionsPkgName ++ ("definitions" :: dtoPackage))
+                  .prepareDefinitions[L, Free[CodegenApplication[L, ?], ?]](
+                    kind,
+                    context,
+                    Tracker(swagger),
+                    definitionsPkgName ++ ("definitions" :: dtoPackage)
+                  )
                 result <- Common
                   .writePackage[L, Free[CodegenApplication[L, ?], ?]](proto, codegen, context)(Paths.get(outputPath), pkgName, dtoPackage, customImports)
               } yield result

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
@@ -5,6 +5,7 @@ import cats.data.{ NonEmptyList, State }
 // Issue #496: Injected StructuredLogger too slow import cats.free.{ Free, GuardrailFreeHacks }
 import cats.implicits._
 import cats.{ FlatMap, Monad, ~> }
+import cats.free.Free
 import com.twilio.guardrail.languages.LA
 import com.twilio.guardrail.terms._
 import java.nio.file.Paths
@@ -148,7 +149,7 @@ class CoreTermInterp[L <: LA](
                 (proto, codegen) <- Common
                   .prepareDefinitions[L, CodegenApplication[L, ?]](kind, context, Tracker(swagger), definitionsPkgName ++ ("definitions" :: dtoPackage))
                 result <- Common
-                  .writePackage[L, CodegenApplication[L, ?]](proto, codegen, context)(Paths.get(outputPath), pkgName, dtoPackage, customImports)
+                  .writePackage[L, Free[CodegenApplication[L, ?], ?]](proto, codegen, context)(Paths.get(outputPath), pkgName, dtoPackage, customImports)
               } yield result
               // Issue #496: Injected StructuredLogger too slow
               // GuardrailFreeHacks.injectLogs(program, Set("LogPush", "LogPop", "LogDebug", "LogInfo", "LogWarning", "LogError"), Sw.log.push, Sw.log.pop, Free.pure(()))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/AkkaHttpClientGenerator.scala
@@ -20,7 +20,7 @@ import java.net.URI
 object AkkaHttpClientGenerator {
 
   object ClientTermInterp extends ClientTerms[ScalaLanguage, Target] with FunctionK[ClientTerm[ScalaLanguage, ?], Target] {
-    implicit def ClientTermsMonad: Monad[Target] = Target.targetInstances
+    implicit def MonadF: Monad[Target] = Target.targetInstances
 
     type L = ScalaLanguage
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/EndpointsClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/EndpointsClientGenerator.scala
@@ -18,7 +18,7 @@ import scala.meta._
 
 object EndpointsClientGenerator {
   object ClientTermInterp extends ClientTerms[ScalaLanguage, Target] with FunctionK[ClientTerm[ScalaLanguage, ?], Target] {
-    implicit def ClientTermsMonad: Monad[Target] = Target.targetInstances
+    implicit def MonadF: Monad[Target] = Target.targetInstances
 
     type L    = ScalaLanguage
     type F[A] = Target[A]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Http4sClientGenerator.scala
@@ -23,7 +23,7 @@ object Http4sClientGenerator {
     type L    = ScalaLanguage
     type F[A] = Target[A]
 
-    implicit def ClientTermsMonad: Monad[Target] = Target.targetInstances
+    implicit def MonadF: Monad[Target] = Target.targetInstances
 
     def splitOperationParts(operationId: String): (List[String], String) = {
       val parts = operationId.split('.')

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
@@ -403,7 +403,7 @@ object AsyncHttpClientClientGenerator {
     }
 
   object ClientTermInterp extends (ClientTerm[JavaLanguage, ?] ~> Target) {
-    implicit def ClientTermsMonad: Monad[Target] = Target.targetInstances
+    implicit def MonadF: Monad[Target] = Target.targetInstances
 
     type L    = JavaLanguage
     type F[A] = Target[A]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaParameter.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaParameter.scala
@@ -50,143 +50,149 @@ object ScalaParameter {
 
   def fromParameter[L <: LA, F[_]](
       protocolElems: List[StrictProtocolElems[L]]
-  )(implicit Fw: FrameworkTerms[L, F], Sc: ScalaTerms[L, Free[F, ?]], Sw: SwaggerTerms[L, F]): Tracker[Parameter] => Free[F, ScalaParameter[L]] = { parameter =>
-    import Fw._
-    import Sc._
-    import Sw._
+  )(implicit Fw: FrameworkTerms[L, F], Sc: ScalaTerms[L, Free[F, ?]], Sw: SwaggerTerms[L, Free[F, ?]]): Tracker[Parameter] => Free[F, ScalaParameter[L]] = {
+    parameter =>
+      import Fw._
+      import Sc._
+      import Sw._
 
-    def paramMeta(param: Tracker[Parameter]): Free[F, SwaggerUtil.ResolvedType[L]] = {
-      def getDefault[U <: Parameter: Default.GetDefault](_type: String, fmt: Tracker[Option[String]], p: Tracker[U]): Free[F, Option[L#Term]] =
-        (_type, fmt.get) match {
-          case ("string", None) =>
-            Default(p).extract[String].traverse(litString(_))
-          case ("number", Some("float")) =>
-            Default(p).extract[Float].traverse(litFloat(_))
-          case ("number", Some("double")) =>
-            Default(p).extract[Double].traverse(litDouble(_))
-          case ("integer", Some("int32")) =>
-            Default(p).extract[Int].traverse(litInt(_))
-          case ("integer", Some("int64")) =>
-            Default(p).extract[Long].traverse(litLong(_))
-          case ("boolean", None) =>
-            Default(p).extract[Boolean].traverse(litBoolean(_))
-          case x => Free.pure(Option.empty[L#Term])
+      def paramMeta(param: Tracker[Parameter]): Free[F, SwaggerUtil.ResolvedType[L]] = {
+        def getDefault[U <: Parameter: Default.GetDefault](_type: String, fmt: Tracker[Option[String]], p: Tracker[U]): Free[F, Option[L#Term]] =
+          (_type, fmt.get) match {
+            case ("string", None) =>
+              Default(p).extract[String].traverse(litString(_))
+            case ("number", Some("float")) =>
+              Default(p).extract[Float].traverse(litFloat(_))
+            case ("number", Some("double")) =>
+              Default(p).extract[Double].traverse(litDouble(_))
+            case ("integer", Some("int32")) =>
+              Default(p).extract[Int].traverse(litInt(_))
+            case ("integer", Some("int64")) =>
+              Default(p).extract[Long].traverse(litLong(_))
+            case ("boolean", None) =>
+              Default(p).extract[Boolean].traverse(litBoolean(_))
+            case x => Free.pure(Option.empty[L#Term])
+          }
+
+        def resolveParam(param: Tracker[Parameter], typeFetcher: Tracker[Parameter] => Free[F, Tracker[String]]): Free[F, ResolvedType[L]] =
+          for {
+            tpeName <- typeFetcher(param)
+            schema = param.downField("schema", _.getSchema)
+            fmt    = schema.flatDownField("format", _.getFormat)
+            customParamTypeName  <- SwaggerUtil.customTypeName(param)
+            customSchemaTypeName <- schema.get.flatTraverse(SwaggerUtil.customTypeName(_: Schema[_]))
+            customTypeName = customSchemaTypeName.orElse(customParamTypeName)
+            res <- (SwaggerUtil.typeName[L, F](tpeName.map(Option(_)), fmt, customTypeName), getDefault(tpeName.unwrapTracker, fmt, param))
+              .mapN(SwaggerUtil.Resolved[L](_, None, _, Some(tpeName.unwrapTracker), fmt.get))
+          } yield res
+
+        def paramHasRefSchema(p: Parameter): Boolean = Option(p.getSchema).exists(s => Option(s.get$ref()).nonEmpty)
+
+        param
+          .refine[Free[F, SwaggerUtil.ResolvedType[L]]]({ case r: Parameter if r.isRef => r })(
+            r => getRefParameterRef(r).map(_.get).map(SwaggerUtil.Deferred(_))
+          )
+          .orRefine({ case r: Parameter if paramHasRefSchema(r) => r })(r => getSimpleRef(r.downField("schema", _.getSchema)).map(SwaggerUtil.Deferred(_)))
+          .orRefine({ case x: Parameter if x.isInBody => x })(
+            x =>
+              getBodyParameterSchema(x)
+                .flatMap(x => SwaggerUtil.modelMetaType[L, F](x))
+          )
+          .orRefine({ case x: Parameter if x.isInHeader => x })(x => resolveParam(x, getHeaderParameterType))
+          .orRefine({ case x: Parameter if x.isInPath => x })(x => resolveParam(x, getPathParameterType))
+          .orRefine({ case x: Parameter if x.isInQuery => x })(x => resolveParam(x, getQueryParameterType))
+          .orRefine({ case x: Parameter if x.isInCookies => x })(x => resolveParam(x, getCookieParameterType))
+          .orRefine({ case x: Parameter if x.isInFormData => x })(x => resolveParam(x, getFormParameterType))
+          .orRefineFallback(fallbackParameterHandler(_))
+      }
+
+      log.function(s"fromParameter")(for {
+        _                                                                        <- log.debug(parameter.unwrapTracker.showNotNull)
+        meta                                                                     <- paramMeta(parameter)
+        SwaggerUtil.Resolved(paramType, _, baseDefaultValue, rawType, rawFormat) <- SwaggerUtil.ResolvedType.resolve[L, Free[F, ?]](meta, protocolElems)
+
+        required = Option[java.lang.Boolean](parameter.get.getRequired()).fold(false)(identity)
+        declType <- if (!required) {
+          liftOptionalType(paramType)
+        } else {
+          Free.pure[F, L#Type](paramType)
         }
 
-      def resolveParam(param: Tracker[Parameter], typeFetcher: Tracker[Parameter] => Free[F, Tracker[String]]): Free[F, ResolvedType[L]] =
-        for {
-          tpeName <- typeFetcher(param)
-          schema = param.downField("schema", _.getSchema)
-          fmt    = schema.flatDownField("format", _.getFormat)
-          customParamTypeName  <- SwaggerUtil.customTypeName(param)
-          customSchemaTypeName <- schema.get.flatTraverse(SwaggerUtil.customTypeName(_: Schema[_]))
-          customTypeName = customSchemaTypeName.orElse(customParamTypeName)
-          res <- (SwaggerUtil.typeName[L, F](tpeName.map(Option(_)), fmt, customTypeName), getDefault(tpeName.unwrapTracker, fmt, param))
-            .mapN(SwaggerUtil.Resolved[L](_, None, _, Some(tpeName.unwrapTracker), fmt.get))
-        } yield res
+        enumDefaultValue <- extractTypeName(paramType).flatMap(_.fold(baseDefaultValue.traverse(Free.pure[F, L#Term] _)) { tpe =>
+          protocolElems
+            .flatTraverse({
+              case x @ EnumDefinition(_, _tpeName, _, _, _, _) =>
+                for {
+                  areEqual <- typeNamesEqual(tpe, _tpeName)
+                } yield if (areEqual) List(x) else List.empty[EnumDefinition[L]]
+              case _ => Free.pure[F, List[EnumDefinition[L]]](List.empty)
+            })
+            .flatMap(_.headOption.fold[Free[F, Option[L#Term]]](baseDefaultValue.traverse(Free.pure _)) { x =>
+              baseDefaultValue.traverse(lookupEnumDefaultValue(tpe, _, x.elems).flatMap(widenTermSelect))
+            })
+        })
 
-      def paramHasRefSchema(p: Parameter): Boolean = Option(p.getSchema).exists(s => Option(s.get$ref()).nonEmpty)
+        defaultValue <- if (!required) {
+          (enumDefaultValue.traverse(liftOptionalTerm), emptyOptionalTerm().map(Option.apply _)).mapN(_.orElse(_))
+        } else {
+          Free.pure[F, Option[L#Term]](enumDefaultValue)
+        }
 
-      param
-        .refine[Free[F, SwaggerUtil.ResolvedType[L]]]({ case r: Parameter if r.isRef => r })(r => getRefParameterRef(r).map(_.get).map(SwaggerUtil.Deferred(_)))
-        .orRefine({ case r: Parameter if paramHasRefSchema(r) => r })(r => getSimpleRef(r.downField("schema", _.getSchema)).map(SwaggerUtil.Deferred(_)))
-        .orRefine({ case x: Parameter if x.isInBody => x })(
-          x =>
-            getBodyParameterSchema(x)
-              .flatMap(x => SwaggerUtil.modelMetaType[L, F](x))
+        name <- getParameterName(parameter.get)
+
+        paramName <- pureTermName(name.toCamelCase)
+        param     <- pureMethodParameter(paramName, declType, defaultValue)
+
+        ftpe       <- fileType(None)
+        isFileType <- typesEqual(paramType, ftpe)
+      } yield {
+        new ScalaParameter[L](
+          Option(parameter.get.getIn),
+          param,
+          paramName,
+          RawParameterName(name),
+          declType,
+          RawParameterType(rawType, rawFormat),
+          required,
+          FileHashAlgorithm(parameter.get),
+          isFileType
         )
-        .orRefine({ case x: Parameter if x.isInHeader => x })(x => resolveParam(x, getHeaderParameterType))
-        .orRefine({ case x: Parameter if x.isInPath => x })(x => resolveParam(x, getPathParameterType))
-        .orRefine({ case x: Parameter if x.isInQuery => x })(x => resolveParam(x, getQueryParameterType))
-        .orRefine({ case x: Parameter if x.isInCookies => x })(x => resolveParam(x, getCookieParameterType))
-        .orRefine({ case x: Parameter if x.isInFormData => x })(x => resolveParam(x, getFormParameterType))
-        .orRefineFallback(fallbackParameterHandler(_))
-    }
-
-    log.function(s"fromParameter")(for {
-      _                                                                        <- log.debug(parameter.unwrapTracker.showNotNull)
-      meta                                                                     <- paramMeta(parameter)
-      SwaggerUtil.Resolved(paramType, _, baseDefaultValue, rawType, rawFormat) <- SwaggerUtil.ResolvedType.resolve[L, F](meta, protocolElems)
-
-      required = Option[java.lang.Boolean](parameter.get.getRequired()).fold(false)(identity)
-      declType <- if (!required) {
-        liftOptionalType(paramType)
-      } else {
-        Free.pure[F, L#Type](paramType)
-      }
-
-      enumDefaultValue <- extractTypeName(paramType).flatMap(_.fold(baseDefaultValue.traverse(Free.pure[F, L#Term] _)) { tpe =>
-        protocolElems
-          .flatTraverse({
-            case x @ EnumDefinition(_, _tpeName, _, _, _, _) =>
-              for {
-                areEqual <- typeNamesEqual(tpe, _tpeName)
-              } yield if (areEqual) List(x) else List.empty[EnumDefinition[L]]
-            case _ => Free.pure[F, List[EnumDefinition[L]]](List.empty)
-          })
-          .flatMap(_.headOption.fold[Free[F, Option[L#Term]]](baseDefaultValue.traverse(Free.pure _)) { x =>
-            baseDefaultValue.traverse(lookupEnumDefaultValue(tpe, _, x.elems).flatMap(widenTermSelect))
-          })
       })
-
-      defaultValue <- if (!required) {
-        (enumDefaultValue.traverse(liftOptionalTerm), emptyOptionalTerm().map(Option.apply _)).mapN(_.orElse(_))
-      } else {
-        Free.pure[F, Option[L#Term]](enumDefaultValue)
-      }
-
-      name <- getParameterName(parameter.get)
-
-      paramName <- pureTermName(name.toCamelCase)
-      param     <- pureMethodParameter(paramName, declType, defaultValue)
-
-      ftpe       <- fileType(None)
-      isFileType <- typesEqual(paramType, ftpe)
-    } yield {
-      new ScalaParameter[L](
-        Option(parameter.get.getIn),
-        param,
-        paramName,
-        RawParameterName(name),
-        declType,
-        RawParameterType(rawType, rawFormat),
-        required,
-        FileHashAlgorithm(parameter.get),
-        isFileType
-      )
-    })
   }
 
   def fromParameters[L <: LA, F[_]](
       protocolElems: List[StrictProtocolElems[L]]
-  )(implicit Fw: FrameworkTerms[L, F], Sc: ScalaTerms[L, Free[F, ?]], Sw: SwaggerTerms[L, F]): List[Tracker[Parameter]] => Free[F, List[ScalaParameter[L]]] = {
-    params =>
-      import Sc._
-      for {
-        parameters <- params.traverse(fromParameter(protocolElems))
-        counts     <- parameters.traverse(param => extractTermName(param.paramName)).map(_.groupBy(identity).mapValues(_.length))
-        result <- parameters.traverse { param =>
-          extractTermName(param.paramName).flatMap { name =>
-            if (counts.getOrElse(name, 0) > 1) {
-              pureTermName(param.argName.value).flatMap { escapedName =>
-                alterMethodParameterName(param.param, escapedName).map { newParam =>
-                  new ScalaParameter[L](
-                    param.in,
-                    newParam,
-                    escapedName,
-                    param.argName,
-                    param.argType,
-                    param.rawType,
-                    param.required,
-                    param.hashAlgorithm,
-                    param.isFile
-                  )
-                }
+  )(
+      implicit Fw: FrameworkTerms[L, F],
+      Sc: ScalaTerms[L, Free[F, ?]],
+      Sw: SwaggerTerms[L, Free[F, ?]]
+  ): List[Tracker[Parameter]] => Free[F, List[ScalaParameter[L]]] = { params =>
+    import Sc._
+    for {
+      parameters <- params.traverse(fromParameter(protocolElems))
+      counts     <- parameters.traverse(param => extractTermName(param.paramName)).map(_.groupBy(identity).mapValues(_.length))
+      result <- parameters.traverse { param =>
+        extractTermName(param.paramName).flatMap { name =>
+          if (counts.getOrElse(name, 0) > 1) {
+            pureTermName(param.argName.value).flatMap { escapedName =>
+              alterMethodParameterName(param.param, escapedName).map { newParam =>
+                new ScalaParameter[L](
+                  param.in,
+                  newParam,
+                  escapedName,
+                  param.argName,
+                  param.argType,
+                  param.rawType,
+                  param.required,
+                  param.hashAlgorithm,
+                  param.isFile
+                )
               }
-            } else Free.pure[F, ScalaParameter[L]](param)
-          }
+            }
+          } else Free.pure[F, ScalaParameter[L]](param)
         }
-      } yield result
+      }
+    } yield result
   }
 
   /**

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaParameter.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaParameter.scala
@@ -11,7 +11,6 @@ import com.twilio.guardrail.shims._
 import com.twilio.guardrail.terms.{ ScalaTerms, SwaggerTerms }
 import com.twilio.guardrail.terms.framework.FrameworkTerms
 import cats.implicits._
-import cats.free.Free
 import com.twilio.guardrail.SwaggerUtil.ResolvedType
 
 case class RawParameterName private[generators] (value: String)
@@ -50,123 +49,116 @@ object ScalaParameter {
 
   def fromParameter[L <: LA, F[_]](
       protocolElems: List[StrictProtocolElems[L]]
-  )(implicit Fw: FrameworkTerms[L, F], Sc: ScalaTerms[L, Free[F, ?]], Sw: SwaggerTerms[L, Free[F, ?]]): Tracker[Parameter] => Free[F, ScalaParameter[L]] = {
-    parameter =>
-      import Fw._
-      import Sc._
-      import Sw._
+  )(implicit Fw: FrameworkTerms[L, F], Sc: ScalaTerms[L, F], Sw: SwaggerTerms[L, F]): Tracker[Parameter] => F[ScalaParameter[L]] = { parameter =>
+    import Fw._
+    import Sc._
+    import Sw._
 
-      def paramMeta(param: Tracker[Parameter]): Free[F, SwaggerUtil.ResolvedType[L]] = {
-        def getDefault[U <: Parameter: Default.GetDefault](_type: String, fmt: Tracker[Option[String]], p: Tracker[U]): Free[F, Option[L#Term]] =
-          (_type, fmt.get) match {
-            case ("string", None) =>
-              Default(p).extract[String].traverse(litString(_))
-            case ("number", Some("float")) =>
-              Default(p).extract[Float].traverse(litFloat(_))
-            case ("number", Some("double")) =>
-              Default(p).extract[Double].traverse(litDouble(_))
-            case ("integer", Some("int32")) =>
-              Default(p).extract[Int].traverse(litInt(_))
-            case ("integer", Some("int64")) =>
-              Default(p).extract[Long].traverse(litLong(_))
-            case ("boolean", None) =>
-              Default(p).extract[Boolean].traverse(litBoolean(_))
-            case x => Free.pure(Option.empty[L#Term])
-          }
+    def paramMeta(param: Tracker[Parameter]): F[SwaggerUtil.ResolvedType[L]] = {
+      def getDefault[U <: Parameter: Default.GetDefault](_type: String, fmt: Tracker[Option[String]], p: Tracker[U]): F[Option[L#Term]] =
+        (_type, fmt.get) match {
+          case ("string", None) =>
+            Default(p).extract[String].traverse(litString(_))
+          case ("number", Some("float")) =>
+            Default(p).extract[Float].traverse(litFloat(_))
+          case ("number", Some("double")) =>
+            Default(p).extract[Double].traverse(litDouble(_))
+          case ("integer", Some("int32")) =>
+            Default(p).extract[Int].traverse(litInt(_))
+          case ("integer", Some("int64")) =>
+            Default(p).extract[Long].traverse(litLong(_))
+          case ("boolean", None) =>
+            Default(p).extract[Boolean].traverse(litBoolean(_))
+          case x => Option.empty[L#Term].pure[F]
+        }
 
-        def resolveParam(param: Tracker[Parameter], typeFetcher: Tracker[Parameter] => Free[F, Tracker[String]]): Free[F, ResolvedType[L]] =
-          for {
-            tpeName <- typeFetcher(param)
-            schema = param.downField("schema", _.getSchema)
-            fmt    = schema.flatDownField("format", _.getFormat)
-            customParamTypeName  <- SwaggerUtil.customTypeName(param)
-            customSchemaTypeName <- schema.get.flatTraverse(SwaggerUtil.customTypeName(_: Schema[_]))
-            customTypeName = customSchemaTypeName.orElse(customParamTypeName)
-            res <- (SwaggerUtil.typeName[L, F](tpeName.map(Option(_)), fmt, customTypeName), getDefault(tpeName.unwrapTracker, fmt, param))
-              .mapN(SwaggerUtil.Resolved[L](_, None, _, Some(tpeName.unwrapTracker), fmt.get))
-          } yield res
+      def resolveParam(param: Tracker[Parameter], typeFetcher: Tracker[Parameter] => F[Tracker[String]]): F[ResolvedType[L]] =
+        for {
+          tpeName <- typeFetcher(param)
+          schema = param.downField("schema", _.getSchema)
+          fmt    = schema.flatDownField("format", _.getFormat)
+          customParamTypeName  <- SwaggerUtil.customTypeName(param)
+          customSchemaTypeName <- schema.get.flatTraverse(SwaggerUtil.customTypeName(_: Schema[_]))
+          customTypeName = customSchemaTypeName.orElse(customParamTypeName)
+          res <- (SwaggerUtil.typeName[L, F](tpeName.map(Option(_)), fmt, customTypeName), getDefault(tpeName.unwrapTracker, fmt, param))
+            .mapN(SwaggerUtil.Resolved[L](_, None, _, Some(tpeName.unwrapTracker), fmt.get))
+        } yield res
 
-        def paramHasRefSchema(p: Parameter): Boolean = Option(p.getSchema).exists(s => Option(s.get$ref()).nonEmpty)
+      def paramHasRefSchema(p: Parameter): Boolean = Option(p.getSchema).exists(s => Option(s.get$ref()).nonEmpty)
 
-        param
-          .refine[Free[F, SwaggerUtil.ResolvedType[L]]]({ case r: Parameter if r.isRef => r })(
-            r => getRefParameterRef(r).map(_.get).map(SwaggerUtil.Deferred(_))
-          )
-          .orRefine({ case r: Parameter if paramHasRefSchema(r) => r })(r => getSimpleRef(r.downField("schema", _.getSchema)).map(SwaggerUtil.Deferred(_)))
-          .orRefine({ case x: Parameter if x.isInBody => x })(
-            x =>
-              getBodyParameterSchema(x)
-                .flatMap(x => SwaggerUtil.modelMetaType[L, F](x))
-          )
-          .orRefine({ case x: Parameter if x.isInHeader => x })(x => resolveParam(x, getHeaderParameterType))
-          .orRefine({ case x: Parameter if x.isInPath => x })(x => resolveParam(x, getPathParameterType))
-          .orRefine({ case x: Parameter if x.isInQuery => x })(x => resolveParam(x, getQueryParameterType))
-          .orRefine({ case x: Parameter if x.isInCookies => x })(x => resolveParam(x, getCookieParameterType))
-          .orRefine({ case x: Parameter if x.isInFormData => x })(x => resolveParam(x, getFormParameterType))
-          .orRefineFallback(fallbackParameterHandler(_))
+      param
+        .refine[F[SwaggerUtil.ResolvedType[L]]]({ case r: Parameter if r.isRef => r })(r => getRefParameterRef(r).map(_.get).map(SwaggerUtil.Deferred(_)))
+        .orRefine({ case r: Parameter if paramHasRefSchema(r) => r })(r => getSimpleRef(r.downField("schema", _.getSchema)).map(SwaggerUtil.Deferred(_)))
+        .orRefine({ case x: Parameter if x.isInBody => x })(
+          x =>
+            getBodyParameterSchema(x)
+              .flatMap(x => SwaggerUtil.modelMetaType[L, F](x))
+        )
+        .orRefine({ case x: Parameter if x.isInHeader => x })(x => resolveParam(x, getHeaderParameterType))
+        .orRefine({ case x: Parameter if x.isInPath => x })(x => resolveParam(x, getPathParameterType))
+        .orRefine({ case x: Parameter if x.isInQuery => x })(x => resolveParam(x, getQueryParameterType))
+        .orRefine({ case x: Parameter if x.isInCookies => x })(x => resolveParam(x, getCookieParameterType))
+        .orRefine({ case x: Parameter if x.isInFormData => x })(x => resolveParam(x, getFormParameterType))
+        .orRefineFallback(fallbackParameterHandler(_))
+    }
+
+    log.function(s"fromParameter")(for {
+      _                                                                        <- log.debug(parameter.unwrapTracker.showNotNull)
+      meta                                                                     <- paramMeta(parameter)
+      SwaggerUtil.Resolved(paramType, _, baseDefaultValue, rawType, rawFormat) <- SwaggerUtil.ResolvedType.resolve[L, F](meta, protocolElems)
+
+      required = Option[java.lang.Boolean](parameter.get.getRequired()).fold(false)(identity)
+      declType <- if (!required) {
+        liftOptionalType(paramType)
+      } else {
+        paramType.pure[F]
       }
 
-      log.function(s"fromParameter")(for {
-        _                                                                        <- log.debug(parameter.unwrapTracker.showNotNull)
-        meta                                                                     <- paramMeta(parameter)
-        SwaggerUtil.Resolved(paramType, _, baseDefaultValue, rawType, rawFormat) <- SwaggerUtil.ResolvedType.resolve[L, Free[F, ?]](meta, protocolElems)
-
-        required = Option[java.lang.Boolean](parameter.get.getRequired()).fold(false)(identity)
-        declType <- if (!required) {
-          liftOptionalType(paramType)
-        } else {
-          Free.pure[F, L#Type](paramType)
-        }
-
-        enumDefaultValue <- extractTypeName(paramType).flatMap(_.fold(baseDefaultValue.traverse(Free.pure[F, L#Term] _)) { tpe =>
-          protocolElems
-            .flatTraverse({
-              case x @ EnumDefinition(_, _tpeName, _, _, _, _) =>
-                for {
-                  areEqual <- typeNamesEqual(tpe, _tpeName)
-                } yield if (areEqual) List(x) else List.empty[EnumDefinition[L]]
-              case _ => Free.pure[F, List[EnumDefinition[L]]](List.empty)
-            })
-            .flatMap(_.headOption.fold[Free[F, Option[L#Term]]](baseDefaultValue.traverse(Free.pure _)) { x =>
-              baseDefaultValue.traverse(lookupEnumDefaultValue(tpe, _, x.elems).flatMap(widenTermSelect))
-            })
-        })
-
-        defaultValue <- if (!required) {
-          (enumDefaultValue.traverse(liftOptionalTerm), emptyOptionalTerm().map(Option.apply _)).mapN(_.orElse(_))
-        } else {
-          Free.pure[F, Option[L#Term]](enumDefaultValue)
-        }
-
-        name <- getParameterName(parameter.get)
-
-        paramName <- pureTermName(name.toCamelCase)
-        param     <- pureMethodParameter(paramName, declType, defaultValue)
-
-        ftpe       <- fileType(None)
-        isFileType <- typesEqual(paramType, ftpe)
-      } yield {
-        new ScalaParameter[L](
-          Option(parameter.get.getIn),
-          param,
-          paramName,
-          RawParameterName(name),
-          declType,
-          RawParameterType(rawType, rawFormat),
-          required,
-          FileHashAlgorithm(parameter.get),
-          isFileType
-        )
+      enumDefaultValue <- extractTypeName(paramType).flatMap(_.fold(baseDefaultValue.traverse(_.pure[F])) { tpe =>
+        protocolElems
+          .flatTraverse({
+            case x @ EnumDefinition(_, _tpeName, _, _, _, _) =>
+              for {
+                areEqual <- typeNamesEqual(tpe, _tpeName)
+              } yield if (areEqual) List(x) else List.empty[EnumDefinition[L]]
+            case _ => List.empty[EnumDefinition[L]].pure[F]
+          })
+          .flatMap(_.headOption.fold[F[Option[L#Term]]](baseDefaultValue.traverse(_.pure[F])) { x =>
+            baseDefaultValue.traverse(lookupEnumDefaultValue(tpe, _, x.elems).flatMap(widenTermSelect))
+          })
       })
+
+      defaultValue <- if (!required) {
+        (enumDefaultValue.traverse(liftOptionalTerm), emptyOptionalTerm().map(Option.apply _)).mapN(_.orElse(_))
+      } else {
+        enumDefaultValue.pure[F]
+      }
+
+      name <- getParameterName(parameter.get)
+
+      paramName <- pureTermName(name.toCamelCase)
+      param     <- pureMethodParameter(paramName, declType, defaultValue)
+
+      ftpe       <- fileType(None)
+      isFileType <- typesEqual(paramType, ftpe)
+    } yield {
+      new ScalaParameter[L](
+        Option(parameter.get.getIn),
+        param,
+        paramName,
+        RawParameterName(name),
+        declType,
+        RawParameterType(rawType, rawFormat),
+        required,
+        FileHashAlgorithm(parameter.get),
+        isFileType
+      )
+    })
   }
 
   def fromParameters[L <: LA, F[_]](
       protocolElems: List[StrictProtocolElems[L]]
-  )(
-      implicit Fw: FrameworkTerms[L, F],
-      Sc: ScalaTerms[L, Free[F, ?]],
-      Sw: SwaggerTerms[L, Free[F, ?]]
-  ): List[Tracker[Parameter]] => Free[F, List[ScalaParameter[L]]] = { params =>
+  )(implicit Fw: FrameworkTerms[L, F], Sc: ScalaTerms[L, F], Sw: SwaggerTerms[L, F]): List[Tracker[Parameter]] => F[List[ScalaParameter[L]]] = { params =>
     import Sc._
     for {
       parameters <- params.traverse(fromParameter(protocolElems))
@@ -189,7 +181,7 @@ object ScalaParameter {
                 )
               }
             }
-          } else Free.pure[F, ScalaParameter[L]](param)
+          } else param.pure[F]
         }
       }
     } yield result

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
@@ -18,7 +18,10 @@ package guardrail {
   )
 }
 
-trait MonadChain6 {
+trait MonadChain7 {
+  implicit def monadForModelProtocolTerms[L <: LA, F[_]](implicit ev: ModelProtocolTerms[L, F]): Monad[F] = ev.MonadF
+}
+trait MonadChain6 extends MonadChain7 {
   implicit def monadForEnumProtocolTerms[L <: LA, F[_]](implicit ev: EnumProtocolTerms[L, F]): Monad[F] = ev.MonadF
 }
 trait MonadChain5 extends MonadChain6 {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
@@ -6,7 +6,7 @@ import com.twilio.guardrail.languages.LA
 import com.twilio.guardrail.protocol.terms.client.{ ClientTerm, ClientTerms }
 import com.twilio.guardrail.protocol.terms.protocol._
 import com.twilio.guardrail.protocol.terms.server.ServerTerm
-import com.twilio.guardrail.terms.framework.FrameworkTerm
+import com.twilio.guardrail.terms.framework.{ FrameworkTerm, FrameworkTerms }
 import com.twilio.guardrail.terms.{ CoreTerms, ScalaTerm, ScalaTerms, SwaggerTerm, SwaggerTerms }
 
 package guardrail {
@@ -18,7 +18,10 @@ package guardrail {
   )
 }
 
-trait MonadChain8 {
+trait MonadChain9 {
+  implicit def monadForFrameworkTerms[L <: LA, F[_]](implicit ev: FrameworkTerms[L, F]): Monad[F] = ev.MonadF
+}
+trait MonadChain8 extends MonadChain9 {
   implicit def monadForPolyProtocolTerms[L <: LA, F[_]](implicit ev: PolyProtocolTerms[L, F]): Monad[F] = ev.MonadF
 }
 trait MonadChain7 extends MonadChain8 {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
@@ -1,12 +1,13 @@
 package com.twilio
 
+import cats.Monad
 import cats.data.EitherK
 import com.twilio.guardrail.languages.LA
-import com.twilio.guardrail.protocol.terms.client.ClientTerm
+import com.twilio.guardrail.protocol.terms.client.{ ClientTerm, ClientTerms }
 import com.twilio.guardrail.protocol.terms.protocol._
 import com.twilio.guardrail.protocol.terms.server.ServerTerm
 import com.twilio.guardrail.terms.framework.FrameworkTerm
-import com.twilio.guardrail.terms.{ ScalaTerm, SwaggerTerm }
+import com.twilio.guardrail.terms.{ CoreTerms, ScalaTerm, ScalaTerms, SwaggerTerm }
 
 package guardrail {
   case class CodegenDefinitions[L <: LA](
@@ -17,7 +18,17 @@ package guardrail {
   )
 }
 
-package object guardrail {
+trait MonadChain3 {
+  implicit def monadForScala[L <: LA, F[_]](implicit ev: ScalaTerms[L, F]): Monad[F] = ev.MonadF
+}
+trait MonadChain2 extends MonadChain3 {
+  implicit def monadForCore[L <: LA, F[_]](implicit ev: CoreTerms[L, F]): Monad[F] = ev.MonadF
+}
+trait MonadChain1 extends MonadChain2 {
+  implicit def monadForClient[L <: LA, F[_]](implicit ev: ClientTerms[L, F]): Monad[F] = ev.MonadF
+}
+
+package object guardrail extends MonadChain1 {
   type DefinitionPM[L <: LA, T]    = EitherK[ProtocolSupportTerm[L, ?], ModelProtocolTerm[L, ?], T]
   type DefinitionPME[L <: LA, T]   = EitherK[EnumProtocolTerm[L, ?], DefinitionPM[L, ?], T]
   type DefinitionPMEA[L <: LA, T]  = EitherK[ArrayProtocolTerm[L, ?], DefinitionPME[L, ?], T]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
@@ -18,7 +18,10 @@ package guardrail {
   )
 }
 
-trait MonadChain4 {
+trait MonadChain5 {
+  implicit def monadForArray[L <: LA, F[_]](implicit ev: ArrayProtocolTerms[L, F]): Monad[F] = ev.MonadF
+}
+trait MonadChain4 extends MonadChain5 {
   implicit def monadForSwagger[L <: LA, F[_]](implicit ev: SwaggerTerms[L, F]): Monad[F] = ev.MonadF
 }
 trait MonadChain3 extends MonadChain4 {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
@@ -18,7 +18,10 @@ package guardrail {
   )
 }
 
-trait MonadChain5 {
+trait MonadChain6 {
+  implicit def monadForEnumProtocolTerms[L <: LA, F[_]](implicit ev: EnumProtocolTerms[L, F]): Monad[F] = ev.MonadF
+}
+trait MonadChain5 extends MonadChain6 {
   implicit def monadForArray[L <: LA, F[_]](implicit ev: ArrayProtocolTerms[L, F]): Monad[F] = ev.MonadF
 }
 trait MonadChain4 extends MonadChain5 {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
@@ -18,7 +18,10 @@ package guardrail {
   )
 }
 
-trait MonadChain10 {
+trait MonadChain11 {
+  implicit def monadForProtocolSupportTerms[L <: LA, F[_]](implicit ev: ProtocolSupportTerms[L, F]): Monad[F] = ev.MonadF
+}
+trait MonadChain10 extends MonadChain11 {
   implicit def monadForServerTerms[L <: LA, F[_]](implicit ev: ServerTerms[L, F]): Monad[F] = ev.MonadF
 }
 trait MonadChain9 extends MonadChain10 {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
@@ -5,7 +5,7 @@ import cats.data.EitherK
 import com.twilio.guardrail.languages.LA
 import com.twilio.guardrail.protocol.terms.client.{ ClientTerm, ClientTerms }
 import com.twilio.guardrail.protocol.terms.protocol._
-import com.twilio.guardrail.protocol.terms.server.ServerTerm
+import com.twilio.guardrail.protocol.terms.server.{ ServerTerm, ServerTerms }
 import com.twilio.guardrail.terms.framework.{ FrameworkTerm, FrameworkTerms }
 import com.twilio.guardrail.terms.{ CoreTerms, ScalaTerm, ScalaTerms, SwaggerTerm, SwaggerTerms }
 
@@ -18,7 +18,10 @@ package guardrail {
   )
 }
 
-trait MonadChain9 {
+trait MonadChain10 {
+  implicit def monadForServerTerms[L <: LA, F[_]](implicit ev: ServerTerms[L, F]): Monad[F] = ev.MonadF
+}
+trait MonadChain9 extends MonadChain10 {
   implicit def monadForFrameworkTerms[L <: LA, F[_]](implicit ev: FrameworkTerms[L, F]): Monad[F] = ev.MonadF
 }
 trait MonadChain8 extends MonadChain9 {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
@@ -7,7 +7,7 @@ import com.twilio.guardrail.protocol.terms.client.{ ClientTerm, ClientTerms }
 import com.twilio.guardrail.protocol.terms.protocol._
 import com.twilio.guardrail.protocol.terms.server.ServerTerm
 import com.twilio.guardrail.terms.framework.FrameworkTerm
-import com.twilio.guardrail.terms.{ CoreTerms, ScalaTerm, ScalaTerms, SwaggerTerm }
+import com.twilio.guardrail.terms.{ CoreTerms, ScalaTerm, ScalaTerms, SwaggerTerm, SwaggerTerms }
 
 package guardrail {
   case class CodegenDefinitions[L <: LA](
@@ -18,7 +18,10 @@ package guardrail {
   )
 }
 
-trait MonadChain3 {
+trait MonadChain4 {
+  implicit def monadForSwagger[L <: LA, F[_]](implicit ev: SwaggerTerms[L, F]): Monad[F] = ev.MonadF
+}
+trait MonadChain3 extends MonadChain4 {
   implicit def monadForScala[L <: LA, F[_]](implicit ev: ScalaTerms[L, F]): Monad[F] = ev.MonadF
 }
 trait MonadChain2 extends MonadChain3 {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
@@ -18,7 +18,10 @@ package guardrail {
   )
 }
 
-trait MonadChain7 {
+trait MonadChain8 {
+  implicit def monadForPolyProtocolTerms[L <: LA, F[_]](implicit ev: PolyProtocolTerms[L, F]): Monad[F] = ev.MonadF
+}
+trait MonadChain7 extends MonadChain8 {
   implicit def monadForModelProtocolTerms[L <: LA, F[_]](implicit ev: ModelProtocolTerms[L, F]): Monad[F] = ev.MonadF
 }
 trait MonadChain6 extends MonadChain7 {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/Responses.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/Responses.scala
@@ -26,7 +26,7 @@ object Responses {
   def getResponses[L <: LA, F[_]](operationId: String, operation: Tracker[Operation], protocolElems: List[StrictProtocolElems[L]])(
       implicit Fw: FrameworkTerms[L, F],
       Sc: ScalaTerms[L, Free[F, ?]],
-      Sw: SwaggerTerms[L, F]
+      Sw: SwaggerTerms[L, Free[F, ?]]
   ): Free[F, Responses[L]] = Sw.log.function("getResponses") {
     import Fw._
     import Sc._
@@ -45,7 +45,7 @@ object Responses {
                   } yield schema).traverse { prop =>
                     for {
                       meta     <- SwaggerUtil.propMeta[L, F](prop)
-                      resolved <- SwaggerUtil.ResolvedType.resolve[L, F](meta, protocolElems)
+                      resolved <- SwaggerUtil.ResolvedType.resolve[L, Free[F, ?]](meta, protocolElems)
                       SwaggerUtil.Resolved(baseType, _, baseDefaultValue, _, _) = resolved
 
                     } yield (baseType, baseDefaultValue)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientTerms.scala
@@ -11,7 +11,7 @@ import com.twilio.guardrail.{ RenderedClientOperation, StaticDefns, StrictProtoc
 import java.net.URI
 
 abstract class ClientTerms[L <: LA, F[_]] {
-  implicit def ClientTermsMonad: Monad[F]
+  implicit def MonadF: Monad[F]
   def generateClientOperation(className: List[String], tracing: Boolean, securitySchemes: Map[String, SecurityScheme[L]], parameters: ScalaParameters[L])(
       route: RouteMeta,
       methodName: String,
@@ -43,7 +43,7 @@ abstract class ClientTerms[L <: LA, F[_]] {
 
 object ClientTerms {
   implicit def enumTerms[L <: LA, F[_]](implicit I: InjectK[ClientTerm[L, ?], F]): ClientTerms[L, Free[F, ?]] = new ClientTerms[L, Free[F, ?]] {
-    def ClientTermsMonad = Free.catsFreeMonadForFree
+    def MonadF = Free.catsFreeMonadForFree
     def generateClientOperation(className: List[String], tracing: Boolean, securitySchemes: Map[String, SecurityScheme[L]], parameters: ScalaParameters[L])(
         route: RouteMeta,
         methodName: String,

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientTerms.scala
@@ -11,7 +11,7 @@ import com.twilio.guardrail.{ RenderedClientOperation, StaticDefns, StrictProtoc
 import java.net.URI
 
 abstract class ClientTerms[L <: LA, F[_]] {
-  implicit def MonadF: Monad[F]
+  def MonadF: Monad[F]
   def generateClientOperation(className: List[String], tracing: Boolean, securitySchemes: Map[String, SecurityScheme[L]], parameters: ScalaParameters[L])(
       route: RouteMeta,
       methodName: String,

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ArrayProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ArrayProtocolTerms.scala
@@ -1,16 +1,20 @@
 package com.twilio.guardrail.protocol.terms.protocol
 
-import cats.InjectK
+import cats.{ InjectK, Monad }
 import cats.free.Free
 import com.twilio.guardrail.languages.LA
 import com.twilio.guardrail.SwaggerUtil
 
-class ArrayProtocolTerms[L <: LA, F[_]](implicit I: InjectK[ArrayProtocolTerm[L, ?], F]) {
-  def extractArrayType(arr: SwaggerUtil.ResolvedType[L], concreteTypes: List[PropMeta[L]]): Free[F, L#Type] =
-    Free.inject[ArrayProtocolTerm[L, ?], F](ExtractArrayType[L](arr, concreteTypes))
+abstract class ArrayProtocolTerms[L <: LA, F[_]] {
+  def MonadF: Monad[F]
+  def extractArrayType(arr: SwaggerUtil.ResolvedType[L], concreteTypes: List[PropMeta[L]]): F[L#Type]
 }
 
 object ArrayProtocolTerms {
-  implicit def arrayProtocolTerms[L <: LA, F[_]](implicit I: InjectK[ArrayProtocolTerm[L, ?], F]): ArrayProtocolTerms[L, F] =
-    new ArrayProtocolTerms[L, F]
+  implicit def arrayProtocolTerms[L <: LA, F[_]](implicit I: InjectK[ArrayProtocolTerm[L, ?], F]): ArrayProtocolTerms[L, Free[F, ?]] =
+    new ArrayProtocolTerms[L, Free[F, ?]] {
+      def MonadF = Free.catsFreeMonadForFree
+      def extractArrayType(arr: SwaggerUtil.ResolvedType[L], concreteTypes: List[PropMeta[L]]): Free[F, L#Type] =
+        Free.inject[ArrayProtocolTerm[L, ?], F](ExtractArrayType[L](arr, concreteTypes))
+    }
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/EnumProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/EnumProtocolTerms.scala
@@ -1,35 +1,46 @@
 package com.twilio.guardrail.protocol.terms.protocol
 
 import _root_.io.swagger.v3.oas.models.media.Schema
-import cats.InjectK
+import cats.{ InjectK, Monad }
 import cats.free.Free
 import com.twilio.guardrail.StaticDefns
 import com.twilio.guardrail.languages.LA
 
-class EnumProtocolTerms[L <: LA, F[_]](implicit I: InjectK[EnumProtocolTerm[L, ?], F]) {
-  def extractEnum(swagger: Schema[_]): Free[F, Either[String, List[String]]] =
-    Free.inject[EnumProtocolTerm[L, ?], F](ExtractEnum[L](swagger))
-  def renderMembers(clsName: String, elems: List[(String, L#TermName, L#TermSelect)]): Free[F, Option[L#ObjectDefinition]] =
-    Free.inject[EnumProtocolTerm[L, ?], F](RenderMembers[L](clsName, elems))
-  def encodeEnum(clsName: String): Free[F, Option[L#ValueDefinition]] =
-    Free.inject[EnumProtocolTerm[L, ?], F](EncodeEnum[L](clsName))
-  def decodeEnum(clsName: String): Free[F, Option[L#ValueDefinition]] =
-    Free.inject[EnumProtocolTerm[L, ?], F](DecodeEnum[L](clsName))
-  def renderClass(clsName: String, tpe: L#Type, elems: List[(String, L#TermName, L#TermSelect)]): Free[F, L#ClassDefinition] =
-    Free.inject[EnumProtocolTerm[L, ?], F](RenderClass[L](clsName, tpe, elems))
+abstract class EnumProtocolTerms[L <: LA, F[_]] {
+  def MonadF: Monad[F]
+  def extractEnum(swagger: Schema[_]): F[Either[String, List[String]]]
+  def renderMembers(clsName: String, elems: List[(String, L#TermName, L#TermSelect)]): F[Option[L#ObjectDefinition]]
+  def encodeEnum(clsName: String): F[Option[L#ValueDefinition]]
+  def decodeEnum(clsName: String): F[Option[L#ValueDefinition]]
+  def renderClass(clsName: String, tpe: L#Type, elems: List[(String, L#TermName, L#TermSelect)]): F[L#ClassDefinition]
   def renderStaticDefns(
       clsName: String,
       members: Option[L#ObjectDefinition],
       accessors: List[L#TermName],
       encoder: Option[L#ValueDefinition],
       decoder: Option[L#ValueDefinition]
-  ): Free[F, StaticDefns[L]] =
-    Free.inject[EnumProtocolTerm[L, ?], F](RenderStaticDefns[L](clsName, members, accessors, encoder, decoder))
-  def buildAccessor(clsName: String, termName: String): Free[F, L#TermSelect] =
-    Free.inject[EnumProtocolTerm[L, ?], F](BuildAccessor[L](clsName, termName))
+  ): F[StaticDefns[L]]
+  def buildAccessor(clsName: String, termName: String): F[L#TermSelect]
 }
 
 object EnumProtocolTerms {
-  implicit def enumProtocolTerms[L <: LA, F[_]](implicit I: InjectK[EnumProtocolTerm[L, ?], F]): EnumProtocolTerms[L, F] =
-    new EnumProtocolTerms[L, F]
+  implicit def enumProtocolTerms[L <: LA, F[_]](implicit I: InjectK[EnumProtocolTerm[L, ?], F]): EnumProtocolTerms[L, Free[F, ?]] =
+    new EnumProtocolTerms[L, Free[F, ?]] {
+      def MonadF                                                                 = Free.catsFreeMonadForFree
+      def extractEnum(swagger: Schema[_]): Free[F, Either[String, List[String]]] = Free.inject[EnumProtocolTerm[L, ?], F](ExtractEnum[L](swagger))
+      def renderMembers(clsName: String, elems: List[(String, L#TermName, L#TermSelect)]): Free[F, Option[L#ObjectDefinition]] =
+        Free.inject[EnumProtocolTerm[L, ?], F](RenderMembers[L](clsName, elems))
+      def encodeEnum(clsName: String): Free[F, Option[L#ValueDefinition]] = Free.inject[EnumProtocolTerm[L, ?], F](EncodeEnum[L](clsName))
+      def decodeEnum(clsName: String): Free[F, Option[L#ValueDefinition]] = Free.inject[EnumProtocolTerm[L, ?], F](DecodeEnum[L](clsName))
+      def renderClass(clsName: String, tpe: L#Type, elems: List[(String, L#TermName, L#TermSelect)]): Free[F, L#ClassDefinition] =
+        Free.inject[EnumProtocolTerm[L, ?], F](RenderClass[L](clsName, tpe, elems))
+      def renderStaticDefns(
+          clsName: String,
+          members: Option[L#ObjectDefinition],
+          accessors: List[L#TermName],
+          encoder: Option[L#ValueDefinition],
+          decoder: Option[L#ValueDefinition]
+      ): Free[F, StaticDefns[L]]                                                  = Free.inject[EnumProtocolTerm[L, ?], F](RenderStaticDefns[L](clsName, members, accessors, encoder, decoder))
+      def buildAccessor(clsName: String, termName: String): Free[F, L#TermSelect] = Free.inject[EnumProtocolTerm[L, ?], F](BuildAccessor[L](clsName, termName))
+    }
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerms.scala
@@ -1,52 +1,79 @@
 package com.twilio.guardrail.protocol.terms.protocol
 
 import io.swagger.v3.oas.models.media.Schema
-import cats.InjectK
+import cats.{ InjectK, Monad }
 import cats.free.Free
 import com.twilio.guardrail.{ ProtocolParameter, StaticDefns, SuperClass }
 import com.twilio.guardrail.core.Tracker
 import com.twilio.guardrail.languages.LA
 import com.twilio.guardrail.SwaggerUtil.ResolvedType
 
-class ModelProtocolTerms[L <: LA, F[_]](implicit I: InjectK[ModelProtocolTerm[L, ?], F]) {
-  def extractProperties(swagger: Tracker[Schema[_]]): Free[F, List[(String, Tracker[Schema[_]])]] =
-    Free.inject[ModelProtocolTerm[L, ?], F](ExtractProperties[L](swagger))
-  def transformProperty(clsName: String, needCamelSnakeConversion: Boolean, concreteTypes: List[PropMeta[L]])(
+abstract class ModelProtocolTerms[L <: LA, F[_]] {
+  def MonadF: Monad[F]
+  def extractProperties(swagger: Tracker[Schema[_]]): F[List[(String, Tracker[Schema[_]])]]
+  def transformProperty(
+      clsName: String,
+      needCamelSnakeConversion: Boolean,
+      concreteTypes: List[PropMeta[L]]
+  )(
       name: String,
       prop: Schema[_],
       meta: ResolvedType[L],
       requirement: PropertyRequirement,
       isCustomType: Boolean,
       defaultValue: Option[L#Term]
-  ): Free[F, ProtocolParameter[L]] =
-    Free.inject[ModelProtocolTerm[L, ?], F](
-      TransformProperty[L](clsName, name, prop, meta, needCamelSnakeConversion, concreteTypes, requirement, isCustomType, defaultValue)
-    )
-  def renderDTOClass(clsName: String, terms: List[ProtocolParameter[L]], parents: List[SuperClass[L]] = Nil): Free[F, L#ClassDefinition] =
-    Free.inject[ModelProtocolTerm[L, ?], F](RenderDTOClass[L](clsName, terms, parents))
+  ): F[ProtocolParameter[L]]
+  def renderDTOClass(clsName: String, terms: List[ProtocolParameter[L]], parents: List[SuperClass[L]] = Nil): F[L#ClassDefinition]
   def encodeModel(
       clsName: String,
       needCamelSnakeConversion: Boolean,
       params: List[ProtocolParameter[L]],
       parents: List[SuperClass[L]] = Nil
-  ): Free[F, Option[L#ValueDefinition]] =
-    Free.inject[ModelProtocolTerm[L, ?], F](EncodeModel[L](clsName, needCamelSnakeConversion, params, parents))
+  ): F[Option[L#ValueDefinition]]
   def decodeModel(
       clsName: String,
       needCamelSnakeConversion: Boolean,
       params: List[ProtocolParameter[L]],
       parents: List[SuperClass[L]] = Nil
-  ): Free[F, Option[L#ValueDefinition]] =
-    Free.inject[ModelProtocolTerm[L, ?], F](DecodeModel[L](clsName, needCamelSnakeConversion, params, parents))
-  def renderDTOStaticDefns(
-      clsName: String,
-      deps: List[L#TermName],
-      encoder: Option[L#ValueDefinition],
-      decoder: Option[L#ValueDefinition]
-  ): Free[F, StaticDefns[L]] =
-    Free.inject[ModelProtocolTerm[L, ?], F](RenderDTOStaticDefns[L](clsName, deps, encoder, decoder))
+  ): F[Option[L#ValueDefinition]]
+  def renderDTOStaticDefns(clsName: String, deps: List[L#TermName], encoder: Option[L#ValueDefinition], decoder: Option[L#ValueDefinition]): F[StaticDefns[L]]
 }
 object ModelProtocolTerms {
-  implicit def modelProtocolTerm[L <: LA, F[_]](implicit I: InjectK[ModelProtocolTerm[L, ?], F]): ModelProtocolTerms[L, F] =
-    new ModelProtocolTerms[L, F]
+  implicit def modelProtocolTerm[L <: LA, F[_]](implicit I: InjectK[ModelProtocolTerm[L, ?], F]): ModelProtocolTerms[L, Free[F, ?]] =
+    new ModelProtocolTerms[L, Free[F, ?]] {
+      def MonadF = Free.catsFreeMonadForFree
+      def extractProperties(swagger: Tracker[Schema[_]]): Free[F, List[(String, Tracker[Schema[_]])]] =
+        Free.inject[ModelProtocolTerm[L, ?], F](ExtractProperties[L](swagger))
+      def transformProperty(clsName: String, needCamelSnakeConversion: Boolean, concreteTypes: List[PropMeta[L]])(
+          name: String,
+          prop: Schema[_],
+          meta: ResolvedType[L],
+          requirement: PropertyRequirement,
+          isCustomType: Boolean,
+          defaultValue: Option[L#Term]
+      ): Free[F, ProtocolParameter[L]] =
+        Free.inject[ModelProtocolTerm[L, ?], F](
+          TransformProperty[L](clsName, name, prop, meta, needCamelSnakeConversion, concreteTypes, requirement, isCustomType, defaultValue)
+        )
+      def renderDTOClass(clsName: String, terms: List[ProtocolParameter[L]], parents: List[SuperClass[L]] = Nil): Free[F, L#ClassDefinition] =
+        Free.inject[ModelProtocolTerm[L, ?], F](RenderDTOClass[L](clsName, terms, parents))
+      def encodeModel(
+          clsName: String,
+          needCamelSnakeConversion: Boolean,
+          params: List[ProtocolParameter[L]],
+          parents: List[SuperClass[L]] = Nil
+      ): Free[F, Option[L#ValueDefinition]] = Free.inject[ModelProtocolTerm[L, ?], F](EncodeModel[L](clsName, needCamelSnakeConversion, params, parents))
+      def decodeModel(
+          clsName: String,
+          needCamelSnakeConversion: Boolean,
+          params: List[ProtocolParameter[L]],
+          parents: List[SuperClass[L]] = Nil
+      ): Free[F, Option[L#ValueDefinition]] = Free.inject[ModelProtocolTerm[L, ?], F](DecodeModel[L](clsName, needCamelSnakeConversion, params, parents))
+      def renderDTOStaticDefns(
+          clsName: String,
+          deps: List[L#TermName],
+          encoder: Option[L#ValueDefinition],
+          decoder: Option[L#ValueDefinition]
+      ): Free[F, StaticDefns[L]] = Free.inject[ModelProtocolTerm[L, ?], F](RenderDTOStaticDefns[L](clsName, deps, encoder, decoder))
+    }
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/PolyProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/PolyProtocolTerm.scala
@@ -1,6 +1,6 @@
 package com.twilio.guardrail.protocol.terms.protocol
 
-import cats.InjectK
+import cats.{ InjectK, Monad }
 import cats.free.Free
 import com.twilio.guardrail.{ Discriminator, ProtocolParameter, StaticDefns, SuperClass }
 import com.twilio.guardrail.core.Tracker
@@ -36,38 +36,53 @@ case class RenderADTStaticDefns[L <: LA](
     decoder: Option[L#ValueDefinition]
 ) extends PolyProtocolTerm[L, StaticDefns[L]]
 
-class PolyProtocolTerms[L <: LA, F[_]](implicit I: InjectK[PolyProtocolTerm[L, ?], F]) {
+abstract class PolyProtocolTerms[L <: LA, F[_]] {
+  def MonadF: Monad[F]
   def extractSuperClass(
       swagger: Tracker[ComposedSchema],
       definitions: List[(String, Tracker[Schema[_]])]
-  ): Free[F, List[(String, Tracker[Schema[_]], List[Tracker[Schema[_]]])]] =
-    Free.inject[PolyProtocolTerm[L, ?], F](ExtractSuperClass(swagger, definitions))
+  ): F[List[(String, Tracker[Schema[_]], List[Tracker[Schema[_]]])]]
   def renderSealedTrait(
       className: String,
       params: List[ProtocolParameter[L]],
       discriminator: Discriminator[L],
       parents: List[SuperClass[L]] = Nil,
       children: List[String] = Nil
-  ): Free[F, L#Trait] =
-    Free.inject[PolyProtocolTerm[L, ?], F](RenderSealedTrait(className, params, discriminator, parents, children))
-
-  def encodeADT(clsName: String, discriminator: Discriminator[L], children: List[String] = Nil): Free[F, Option[L#ValueDefinition]] =
-    Free.inject[PolyProtocolTerm[L, ?], F](EncodeADT(clsName, discriminator, children))
-
-  def decodeADT(clsName: String, discriminator: Discriminator[L], children: List[String] = Nil): Free[F, Option[L#ValueDefinition]] =
-    Free.inject[PolyProtocolTerm[L, ?], F](DecodeADT(clsName, discriminator, children))
-
+  ): F[L#Trait]
+  def encodeADT(clsName: String, discriminator: Discriminator[L], children: List[String] = Nil): F[Option[L#ValueDefinition]]
+  def decodeADT(clsName: String, discriminator: Discriminator[L], children: List[String] = Nil): F[Option[L#ValueDefinition]]
   def renderADTStaticDefns(
       clsName: String,
       discriminator: Discriminator[L],
       encoder: Option[L#ValueDefinition],
       decoder: Option[L#ValueDefinition]
-  ): Free[F, StaticDefns[L]] =
-    Free.inject[PolyProtocolTerm[L, ?], F](RenderADTStaticDefns(clsName, discriminator, encoder, decoder))
-
+  ): F[StaticDefns[L]]
 }
 
 object PolyProtocolTerms {
-  implicit def polyProtocolTerms[L <: LA, F[_]](implicit I: InjectK[PolyProtocolTerm[L, ?], F]): PolyProtocolTerms[L, F] =
-    new PolyProtocolTerms[L, F]()
+  implicit def polyProtocolTerms[L <: LA, F[_]](implicit I: InjectK[PolyProtocolTerm[L, ?], F]): PolyProtocolTerms[L, Free[F, ?]] =
+    new PolyProtocolTerms[L, Free[F, ?]]() {
+      def MonadF = Free.catsFreeMonadForFree
+      def extractSuperClass(
+          swagger: Tracker[ComposedSchema],
+          definitions: List[(String, Tracker[Schema[_]])]
+      ): Free[F, List[(String, Tracker[Schema[_]], List[Tracker[Schema[_]]])]] = Free.inject[PolyProtocolTerm[L, ?], F](ExtractSuperClass(swagger, definitions))
+      def renderSealedTrait(
+          className: String,
+          params: List[ProtocolParameter[L]],
+          discriminator: Discriminator[L],
+          parents: List[SuperClass[L]] = Nil,
+          children: List[String] = Nil
+      ): Free[F, L#Trait] = Free.inject[PolyProtocolTerm[L, ?], F](RenderSealedTrait(className, params, discriminator, parents, children))
+      def encodeADT(clsName: String, discriminator: Discriminator[L], children: List[String] = Nil): Free[F, Option[L#ValueDefinition]] =
+        Free.inject[PolyProtocolTerm[L, ?], F](EncodeADT(clsName, discriminator, children))
+      def decodeADT(clsName: String, discriminator: Discriminator[L], children: List[String] = Nil): Free[F, Option[L#ValueDefinition]] =
+        Free.inject[PolyProtocolTerm[L, ?], F](DecodeADT(clsName, discriminator, children))
+      def renderADTStaticDefns(
+          clsName: String,
+          discriminator: Discriminator[L],
+          encoder: Option[L#ValueDefinition],
+          decoder: Option[L#ValueDefinition]
+      ): Free[F, StaticDefns[L]] = Free.inject[PolyProtocolTerm[L, ?], F](RenderADTStaticDefns(clsName, discriminator, encoder, decoder))
+    }
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ProtocolSupportTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ProtocolSupportTerms.scala
@@ -1,20 +1,24 @@
 package com.twilio.guardrail.protocol.terms.protocol
 
-import cats.InjectK
+import cats.{ InjectK, Monad }
 import cats.free.Free
 import com.twilio.guardrail.languages.LA
 
-class ProtocolSupportTerms[L <: LA, F[_]](implicit I: InjectK[ProtocolSupportTerm[L, ?], F]) {
-  def extractConcreteTypes(models: Either[String, List[PropMeta[L]]]): Free[F, List[PropMeta[L]]] =
-    Free.inject[ProtocolSupportTerm[L, ?], F](ExtractConcreteTypes(models))
-  def protocolImports(): Free[F, List[L#Import]] =
-    Free.inject[ProtocolSupportTerm[L, ?], F](ProtocolImports())
-  def packageObjectImports(): Free[F, List[L#Import]] =
-    Free.inject[ProtocolSupportTerm[L, ?], F](PackageObjectImports())
-  def packageObjectContents(): Free[F, List[L#ValueDefinition]] =
-    Free.inject[ProtocolSupportTerm[L, ?], F](PackageObjectContents())
+abstract class ProtocolSupportTerms[L <: LA, F[_]] {
+  def MonadF: Monad[F]
+  def extractConcreteTypes(models: Either[String, List[PropMeta[L]]]): F[List[PropMeta[L]]]
+  def protocolImports(): F[List[L#Import]]
+  def packageObjectImports(): F[List[L#Import]]
+  def packageObjectContents(): F[List[L#ValueDefinition]]
 }
 object ProtocolSupportTerms {
-  implicit def protocolSupportTerms[L <: LA, F[_]](implicit I: InjectK[ProtocolSupportTerm[L, ?], F]): ProtocolSupportTerms[L, F] =
-    new ProtocolSupportTerms[L, F]
+  implicit def protocolSupportTerms[L <: LA, F[_]](implicit I: InjectK[ProtocolSupportTerm[L, ?], F]): ProtocolSupportTerms[L, Free[F, ?]] =
+    new ProtocolSupportTerms[L, Free[F, ?]] {
+      def MonadF = Free.catsFreeMonadForFree
+      def extractConcreteTypes(models: Either[String, List[PropMeta[L]]]): Free[F, List[PropMeta[L]]] =
+        Free.inject[ProtocolSupportTerm[L, ?], F](ExtractConcreteTypes(models))
+      def protocolImports(): Free[F, List[L#Import]]                = Free.inject[ProtocolSupportTerm[L, ?], F](ProtocolImports())
+      def packageObjectImports(): Free[F, List[L#Import]]           = Free.inject[ProtocolSupportTerm[L, ?], F](PackageObjectImports())
+      def packageObjectContents(): Free[F, List[L#ValueDefinition]] = Free.inject[ProtocolSupportTerm[L, ?], F](PackageObjectContents())
+    }
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/CoreTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/CoreTerms.scala
@@ -7,7 +7,7 @@ import cats.data.NonEmptyList
 import com.twilio.guardrail.languages.LA
 
 abstract class CoreTerms[L <: LA, F[_]] {
-  implicit def MonadF: Monad[F]
+  def MonadF: Monad[F]
   def getDefaultFramework: F[Option[String]]
   def extractGenerator(context: Context, defaultFramework: Option[String]): F[CodegenApplication[L, ?] ~> Target]
   def parseArgs(args: Array[String]): F[List[Args]]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerms.scala
@@ -11,7 +11,7 @@ import java.nio.file.Path
 import cats.data.NonEmptyList
 
 abstract class ScalaTerms[L <: LA, F[_]] {
-  implicit def MonadF: Monad[F]
+  def MonadF: Monad[F]
   def vendorPrefixes(): F[List[String]]
 
   def litString(value: String): F[L#Term]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
@@ -238,7 +238,7 @@ case class RouteMeta(path: Tracker[String], method: HttpMethod, operation: Track
 
   def getParameters[L <: LA, F[_]](
       protocolElems: List[StrictProtocolElems[L]]
-  )(implicit Fw: FrameworkTerms[L, F], Sc: ScalaTerms[L, Free[F, ?]], Sw: SwaggerTerms[L, F]): Free[F, ScalaParameters[L]] =
+  )(implicit Fw: FrameworkTerms[L, F], Sc: ScalaTerms[L, Free[F, ?]], Sw: SwaggerTerms[L, Free[F, ?]]): Free[F, ScalaParameters[L]] =
     for {
       a <- ScalaParameter.fromParameters(protocolElems).apply(parameters)
     } yield new ScalaParameters[L](a)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
@@ -3,7 +3,6 @@ package terms
 
 import cats.Order
 import cats.data.{ NonEmptyList, NonEmptyMap, State }
-import cats.free.Free
 import cats.implicits._
 import com.twilio.guardrail.core.implicits._
 import com.twilio.guardrail.core.{ Mappish, Tracker }
@@ -238,7 +237,7 @@ case class RouteMeta(path: Tracker[String], method: HttpMethod, operation: Track
 
   def getParameters[L <: LA, F[_]](
       protocolElems: List[StrictProtocolElems[L]]
-  )(implicit Fw: FrameworkTerms[L, F], Sc: ScalaTerms[L, Free[F, ?]], Sw: SwaggerTerms[L, Free[F, ?]]): Free[F, ScalaParameters[L]] =
+  )(implicit Fw: FrameworkTerms[L, F], Sc: ScalaTerms[L, F], Sw: SwaggerTerms[L, F]): F[ScalaParameters[L]] =
     for {
       a <- ScalaParameter.fromParameters(protocolElems).apply(parameters)
     } yield new ScalaParameters[L](a)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerms.scala
@@ -1,7 +1,7 @@
 package com.twilio.guardrail
 package terms
 
-import cats.InjectK
+import cats.{ InjectK, Monad }
 import cats.data.NonEmptyList
 import cats.free.Free
 import cats.implicits._
@@ -24,87 +24,94 @@ abstract class SwaggerLogAdapter[F[_]] {
   def error(message: String): F[Unit]
 }
 
-class SwaggerTerms[L <: LA, F[_]](implicit I: InjectK[SwaggerTerm[L, ?], F]) {
-  def extractCommonRequestBodies(components: Option[Components]): Free[F, Map[String, RequestBody]] =
-    Free.inject[SwaggerTerm[L, ?], F](ExtractCommonRequestBodies(components))
+abstract class SwaggerTerms[L <: LA, F[_]] {
+  def MonadF: Monad[F]
 
+  def extractCommonRequestBodies(components: Option[Components]): F[Map[String, RequestBody]]
   def extractOperations(
       paths: Tracker[Mappish[List, String, PathItem]],
       commonRequestBodies: Map[String, RequestBody],
       globalSecurityRequirements: Option[SecurityRequirements]
-  ): Free[F, List[RouteMeta]] =
-    Free.inject[SwaggerTerm[L, ?], F](ExtractOperations(paths, commonRequestBodies, globalSecurityRequirements))
-
-  def extractApiKeySecurityScheme(schemeName: String, securityScheme: SwSecurityScheme, tpe: Option[L#Type]): Free[F, ApiKeySecurityScheme[L]] =
-    Free.inject[SwaggerTerm[L, ?], F](ExtractApiKeySecurityScheme(schemeName, securityScheme, tpe))
-  def extractHttpSecurityScheme(schemeName: String, securityScheme: SwSecurityScheme, tpe: Option[L#Type]): Free[F, HttpSecurityScheme[L]] =
-    Free.inject[SwaggerTerm[L, ?], F](ExtractHttpSecurityScheme(schemeName, securityScheme, tpe))
-  def extractOpenIdConnectSecurityScheme(schemeName: String, securityScheme: SwSecurityScheme, tpe: Option[L#Type]): Free[F, OpenIdConnectSecurityScheme[L]] =
-    Free.inject[SwaggerTerm[L, ?], F](ExtractOpenIdConnectSecurityScheme(schemeName, securityScheme, tpe))
-  def extractOAuth2SecurityScheme(schemeName: String, securityScheme: SwSecurityScheme, tpe: Option[L#Type]): Free[F, OAuth2SecurityScheme[L]] =
-    Free.inject[SwaggerTerm[L, ?], F](ExtractOAuth2SecurityScheme(schemeName, securityScheme, tpe))
-
-  def getClassName(operation: Tracker[Operation], vendorPrefixes: List[String]): Free[F, List[String]] =
-    Free.inject[SwaggerTerm[L, ?], F](GetClassName(operation, vendorPrefixes))
-  def getParameterName(parameter: Parameter): Free[F, String] =
-    Free.inject[SwaggerTerm[L, ?], F](GetParameterName(parameter))
-  def getBodyParameterSchema(parameter: Tracker[Parameter]): Free[F, Tracker[Schema[_]]] =
-    Free.inject[SwaggerTerm[L, ?], F](GetBodyParameterSchema(parameter))
-
-  def getHeaderParameterType(parameter: Tracker[Parameter]): Free[F, Tracker[String]] = Free.inject[SwaggerTerm[L, ?], F](GetHeaderParameterType(parameter))
-  def getPathParameterType(parameter: Tracker[Parameter]): Free[F, Tracker[String]]   = Free.inject[SwaggerTerm[L, ?], F](GetPathParameterType(parameter))
-  def getQueryParameterType(parameter: Tracker[Parameter]): Free[F, Tracker[String]]  = Free.inject[SwaggerTerm[L, ?], F](GetQueryParameterType(parameter))
-  def getCookieParameterType(parameter: Tracker[Parameter]): Free[F, Tracker[String]] = Free.inject[SwaggerTerm[L, ?], F](GetCookieParameterType(parameter))
-  def getFormParameterType(parameter: Tracker[Parameter]): Free[F, Tracker[String]]   = Free.inject[SwaggerTerm[L, ?], F](GetFormParameterType(parameter))
-  def getRefParameterRef(parameter: Tracker[Parameter]): Free[F, Tracker[String]]     = Free.inject[SwaggerTerm[L, ?], F](GetRefParameterRef(parameter))
-
-  def getSerializableParameterType(parameter: Tracker[Parameter]): Free[F, Tracker[String]] =
-    Free.inject[SwaggerTerm[L, ?], F](GetSerializableParameterType(parameter))
-  def fallbackParameterHandler(parameter: Tracker[Parameter]): Free[F, SwaggerUtil.ResolvedType[L]] =
-    Free.inject[SwaggerTerm[L, ?], F](FallbackParameterHandler(parameter))
-
-  def getOperationId(operation: Tracker[Operation]): Free[F, String] =
-    Free.inject[SwaggerTerm[L, ?], F](GetOperationId(operation))
-
-  def getResponses(operationId: String, operation: Tracker[Operation]): Free[F, NonEmptyList[(String, Tracker[ApiResponse])]] =
-    Free.inject[SwaggerTerm[L, ?], F](GetResponses(operationId, operation))
-
-  def getSimpleRef(ref: Tracker[Option[Schema[_]]]): Free[F, String] =
-    Free.inject[SwaggerTerm[L, ?], F](GetSimpleRef(ref))
-
-  def getItems(arr: Tracker[ArraySchema]): Free[F, Tracker[Schema[_]]] =
-    Free.inject[SwaggerTerm[L, ?], F](GetItems(arr))
-
-  def getType(model: Tracker[Schema[_]]): Free[F, Tracker[String]] =
-    Free.inject[SwaggerTerm[L, ?], F](GetType(model))
-
-  def fallbackPropertyTypeHandler(prop: Tracker[Schema[_]]): Free[F, L#Type] =
-    Free.inject[SwaggerTerm[L, ?], F](FallbackPropertyTypeHandler(prop))
-
-  def resolveType(name: String, protocolElems: List[StrictProtocolElems[L]]): Free[F, StrictProtocolElems[L]] =
-    Free.inject[SwaggerTerm[L, ?], F](ResolveType(name, protocolElems))
-  def fallbackResolveElems(lazyElems: List[LazyProtocolElems[L]]): Free[F, List[StrictProtocolElems[L]]] =
-    Free.inject[SwaggerTerm[L, ?], F](FallbackResolveElems(lazyElems))
-
-  def log: SwaggerLogAdapter[Free[F, ?]] = new SwaggerLogAdapter[Free[F, ?]] {
-    def function[A](name: String): Free[F, A] => Free[F, A] = { func =>
-      (push(name) *> func) <* pop
-    }
-    def push(name: String): Free[F, Unit] =
-      Free.inject[SwaggerTerm[L, ?], F](LogPush[L](name))
-    def pop: Free[F, Unit] =
-      Free.inject[SwaggerTerm[L, ?], F](LogPop[L]())
-    def debug(message: String): Free[F, Unit] =
-      Free.inject[SwaggerTerm[L, ?], F](LogDebug[L](message))
-    def info(message: String): Free[F, Unit] =
-      Free.inject[SwaggerTerm[L, ?], F](LogInfo[L](message))
-    def warning(message: String): Free[F, Unit] =
-      Free.inject[SwaggerTerm[L, ?], F](LogWarning[L](message))
-    def error(message: String): Free[F, Unit] =
-      Free.inject[SwaggerTerm[L, ?], F](LogError[L](message))
-  }
+  ): F[List[RouteMeta]]
+  def extractApiKeySecurityScheme(schemeName: String, securityScheme: SwSecurityScheme, tpe: Option[L#Type]): F[ApiKeySecurityScheme[L]]
+  def extractHttpSecurityScheme(schemeName: String, securityScheme: SwSecurityScheme, tpe: Option[L#Type]): F[HttpSecurityScheme[L]]
+  def extractOpenIdConnectSecurityScheme(schemeName: String, securityScheme: SwSecurityScheme, tpe: Option[L#Type]): F[OpenIdConnectSecurityScheme[L]]
+  def extractOAuth2SecurityScheme(schemeName: String, securityScheme: SwSecurityScheme, tpe: Option[L#Type]): F[OAuth2SecurityScheme[L]]
+  def getClassName(operation: Tracker[Operation], vendorPrefixes: List[String]): F[List[String]]
+  def getParameterName(parameter: Parameter): F[String]
+  def getBodyParameterSchema(parameter: Tracker[Parameter]): F[Tracker[Schema[_]]]
+  def getHeaderParameterType(parameter: Tracker[Parameter]): F[Tracker[String]]
+  def getPathParameterType(parameter: Tracker[Parameter]): F[Tracker[String]]
+  def getQueryParameterType(parameter: Tracker[Parameter]): F[Tracker[String]]
+  def getCookieParameterType(parameter: Tracker[Parameter]): F[Tracker[String]]
+  def getFormParameterType(parameter: Tracker[Parameter]): F[Tracker[String]]
+  def getRefParameterRef(parameter: Tracker[Parameter]): F[Tracker[String]]
+  def getSerializableParameterType(parameter: Tracker[Parameter]): F[Tracker[String]]
+  def fallbackParameterHandler(parameter: Tracker[Parameter]): F[SwaggerUtil.ResolvedType[L]]
+  def getOperationId(operation: Tracker[Operation]): F[String]
+  def getResponses(operationId: String, operation: Tracker[Operation]): F[NonEmptyList[(String, Tracker[ApiResponse])]]
+  def getSimpleRef(ref: Tracker[Option[Schema[_]]]): F[String]
+  def getItems(arr: Tracker[ArraySchema]): F[Tracker[Schema[_]]]
+  def getType(model: Tracker[Schema[_]]): F[Tracker[String]]
+  def fallbackPropertyTypeHandler(prop: Tracker[Schema[_]]): F[L#Type]
+  def resolveType(name: String, protocolElems: List[StrictProtocolElems[L]]): F[StrictProtocolElems[L]]
+  def fallbackResolveElems(lazyElems: List[LazyProtocolElems[L]]): F[List[StrictProtocolElems[L]]]
+  def log: SwaggerLogAdapter[F]
 }
 object SwaggerTerms {
-  implicit def swaggerTerm[L <: LA, F[_]](implicit I: InjectK[SwaggerTerm[L, ?], F]): SwaggerTerms[L, F] =
-    new SwaggerTerms[L, F]
+  implicit def swaggerTerm[L <: LA, F[_]](implicit I: InjectK[SwaggerTerm[L, ?], F]): SwaggerTerms[L, Free[F, ?]] = new SwaggerTerms[L, Free[F, ?]] {
+    def MonadF = Free.catsFreeMonadForFree
+    def extractCommonRequestBodies(components: Option[Components]): Free[F, Map[String, RequestBody]] =
+      Free.inject[SwaggerTerm[L, ?], F](ExtractCommonRequestBodies(components))
+    def extractOperations(
+        paths: Tracker[Mappish[List, String, PathItem]],
+        commonRequestBodies: Map[String, RequestBody],
+        globalSecurityRequirements: Option[SecurityRequirements]
+    ): Free[F, List[RouteMeta]] = Free.inject[SwaggerTerm[L, ?], F](ExtractOperations(paths, commonRequestBodies, globalSecurityRequirements))
+    def extractApiKeySecurityScheme(schemeName: String, securityScheme: SwSecurityScheme, tpe: Option[L#Type]): Free[F, ApiKeySecurityScheme[L]] =
+      Free.inject[SwaggerTerm[L, ?], F](ExtractApiKeySecurityScheme(schemeName, securityScheme, tpe))
+    def extractHttpSecurityScheme(schemeName: String, securityScheme: SwSecurityScheme, tpe: Option[L#Type]): Free[F, HttpSecurityScheme[L]] =
+      Free.inject[SwaggerTerm[L, ?], F](ExtractHttpSecurityScheme(schemeName, securityScheme, tpe))
+    def extractOpenIdConnectSecurityScheme(schemeName: String, securityScheme: SwSecurityScheme, tpe: Option[L#Type]): Free[F, OpenIdConnectSecurityScheme[L]] =
+      Free.inject[SwaggerTerm[L, ?], F](ExtractOpenIdConnectSecurityScheme(schemeName, securityScheme, tpe))
+    def extractOAuth2SecurityScheme(schemeName: String, securityScheme: SwSecurityScheme, tpe: Option[L#Type]): Free[F, OAuth2SecurityScheme[L]] =
+      Free.inject[SwaggerTerm[L, ?], F](ExtractOAuth2SecurityScheme(schemeName, securityScheme, tpe))
+    def getClassName(operation: Tracker[Operation], vendorPrefixes: List[String]): Free[F, List[String]] =
+      Free.inject[SwaggerTerm[L, ?], F](GetClassName(operation, vendorPrefixes))
+    def getParameterName(parameter: Parameter): Free[F, String] = Free.inject[SwaggerTerm[L, ?], F](GetParameterName(parameter))
+    def getBodyParameterSchema(parameter: Tracker[Parameter]): Free[F, Tracker[Schema[_]]] =
+      Free.inject[SwaggerTerm[L, ?], F](GetBodyParameterSchema(parameter))
+    def getHeaderParameterType(parameter: Tracker[Parameter]): Free[F, Tracker[String]] = Free.inject[SwaggerTerm[L, ?], F](GetHeaderParameterType(parameter))
+    def getPathParameterType(parameter: Tracker[Parameter]): Free[F, Tracker[String]]   = Free.inject[SwaggerTerm[L, ?], F](GetPathParameterType(parameter))
+    def getQueryParameterType(parameter: Tracker[Parameter]): Free[F, Tracker[String]]  = Free.inject[SwaggerTerm[L, ?], F](GetQueryParameterType(parameter))
+    def getCookieParameterType(parameter: Tracker[Parameter]): Free[F, Tracker[String]] = Free.inject[SwaggerTerm[L, ?], F](GetCookieParameterType(parameter))
+    def getFormParameterType(parameter: Tracker[Parameter]): Free[F, Tracker[String]]   = Free.inject[SwaggerTerm[L, ?], F](GetFormParameterType(parameter))
+    def getRefParameterRef(parameter: Tracker[Parameter]): Free[F, Tracker[String]]     = Free.inject[SwaggerTerm[L, ?], F](GetRefParameterRef(parameter))
+    def getSerializableParameterType(parameter: Tracker[Parameter]): Free[F, Tracker[String]] =
+      Free.inject[SwaggerTerm[L, ?], F](GetSerializableParameterType(parameter))
+    def fallbackParameterHandler(parameter: Tracker[Parameter]): Free[F, SwaggerUtil.ResolvedType[L]] =
+      Free.inject[SwaggerTerm[L, ?], F](FallbackParameterHandler(parameter))
+    def getOperationId(operation: Tracker[Operation]): Free[F, String] = Free.inject[SwaggerTerm[L, ?], F](GetOperationId(operation))
+    def getResponses(operationId: String, operation: Tracker[Operation]): Free[F, NonEmptyList[(String, Tracker[ApiResponse])]] =
+      Free.inject[SwaggerTerm[L, ?], F](GetResponses(operationId, operation))
+    def getSimpleRef(ref: Tracker[Option[Schema[_]]]): Free[F, String]         = Free.inject[SwaggerTerm[L, ?], F](GetSimpleRef(ref))
+    def getItems(arr: Tracker[ArraySchema]): Free[F, Tracker[Schema[_]]]       = Free.inject[SwaggerTerm[L, ?], F](GetItems(arr))
+    def getType(model: Tracker[Schema[_]]): Free[F, Tracker[String]]           = Free.inject[SwaggerTerm[L, ?], F](GetType(model))
+    def fallbackPropertyTypeHandler(prop: Tracker[Schema[_]]): Free[F, L#Type] = Free.inject[SwaggerTerm[L, ?], F](FallbackPropertyTypeHandler(prop))
+    def resolveType(name: String, protocolElems: List[StrictProtocolElems[L]]): Free[F, StrictProtocolElems[L]] =
+      Free.inject[SwaggerTerm[L, ?], F](ResolveType(name, protocolElems))
+    def fallbackResolveElems(lazyElems: List[LazyProtocolElems[L]]): Free[F, List[StrictProtocolElems[L]]] =
+      Free.inject[SwaggerTerm[L, ?], F](FallbackResolveElems(lazyElems))
+    def log: SwaggerLogAdapter[Free[F, ?]] = new SwaggerLogAdapter[Free[F, ?]] {
+      def function[A](name: String): Free[F, A] => Free[F, A] = { func =>
+        push(name) *> func <* pop
+      }
+      def push(name: String): Free[F, Unit]       = Free.inject[SwaggerTerm[L, ?], F](LogPush[L](name))
+      def pop: Free[F, Unit]                      = Free.inject[SwaggerTerm[L, ?], F](LogPop[L]())
+      def debug(message: String): Free[F, Unit]   = Free.inject[SwaggerTerm[L, ?], F](LogDebug[L](message))
+      def info(message: String): Free[F, Unit]    = Free.inject[SwaggerTerm[L, ?], F](LogInfo[L](message))
+      def warning(message: String): Free[F, Unit] = Free.inject[SwaggerTerm[L, ?], F](LogWarning[L](message))
+      def error(message: String): Free[F, Unit]   = Free.inject[SwaggerTerm[L, ?], F](LogError[L](message))
+    }
+  }
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/framework/FrameworkTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/framework/FrameworkTerms.scala
@@ -1,26 +1,29 @@
 package com.twilio.guardrail
 package terms.framework
 
-import cats.InjectK
+import cats.{ InjectK, Monad }
 import cats.free.Free
 import com.twilio.guardrail.languages.LA
 
-class FrameworkTerms[L <: LA, F[_]](implicit I: InjectK[FrameworkTerm[L, ?], F]) {
-  def getFrameworkImports(tracing: Boolean): Free[F, List[L#Import]] =
-    Free.inject[FrameworkTerm[L, ?], F](GetFrameworkImports[L](tracing))
-  def getFrameworkImplicits(): Free[F, Option[(L#TermName, L#ObjectDefinition)]] =
-    Free.inject[FrameworkTerm[L, ?], F](GetFrameworkImplicits[L]())
-  def getFrameworkDefinitions(tracing: Boolean): Free[F, List[(L#TermName, L#ClassDefinition)]] =
-    Free.inject[FrameworkTerm[L, ?], F](GetFrameworkDefinitions[L](tracing))
-  def lookupStatusCode(key: String): Free[F, (Int, L#TermName)] =
-    Free.inject[FrameworkTerm[L, ?], F](LookupStatusCode(key))
-  def fileType(format: Option[String]): Free[F, L#Type] =
-    Free.inject[FrameworkTerm[L, ?], F](FileType(format))
-  def objectType(format: Option[String]): Free[F, L#Type] =
-    Free.inject[FrameworkTerm[L, ?], F](ObjectType(format))
+abstract class FrameworkTerms[L <: LA, F[_]] {
+  def MonadF: Monad[F]
+  def getFrameworkImports(tracing: Boolean): F[List[L#Import]]
+  def getFrameworkImplicits(): F[Option[(L#TermName, L#ObjectDefinition)]]
+  def getFrameworkDefinitions(tracing: Boolean): F[List[(L#TermName, L#ClassDefinition)]]
+  def lookupStatusCode(key: String): F[(Int, L#TermName)]
+  def fileType(format: Option[String]): F[L#Type]
+  def objectType(format: Option[String]): F[L#Type]
 }
 
 object FrameworkTerms {
-  implicit def serverTerms[L <: LA, F[_]](implicit I: InjectK[FrameworkTerm[L, ?], F]): FrameworkTerms[L, F] =
-    new FrameworkTerms[L, F]
+  implicit def serverTerms[L <: LA, F[_]](implicit I: InjectK[FrameworkTerm[L, ?], F]): FrameworkTerms[L, Free[F, ?]] = new FrameworkTerms[L, Free[F, ?]] {
+    def MonadF                                                                     = Free.catsFreeMonadForFree
+    def getFrameworkImports(tracing: Boolean): Free[F, List[L#Import]]             = Free.inject[FrameworkTerm[L, ?], F](GetFrameworkImports[L](tracing))
+    def getFrameworkImplicits(): Free[F, Option[(L#TermName, L#ObjectDefinition)]] = Free.inject[FrameworkTerm[L, ?], F](GetFrameworkImplicits[L]())
+    def getFrameworkDefinitions(tracing: Boolean): Free[F, List[(L#TermName, L#ClassDefinition)]] =
+      Free.inject[FrameworkTerm[L, ?], F](GetFrameworkDefinitions[L](tracing))
+    def lookupStatusCode(key: String): Free[F, (Int, L#TermName)] = Free.inject[FrameworkTerm[L, ?], F](LookupStatusCode(key))
+    def fileType(format: Option[String]): Free[F, L#Type]         = Free.inject[FrameworkTerm[L, ?], F](FileType(format))
+    def objectType(format: Option[String]): Free[F, L#Type]       = Free.inject[FrameworkTerm[L, ?], F](ObjectType(format))
+  }
 }

--- a/modules/codegen/src/test/scala/core/issues/Issue166.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue166.scala
@@ -1,5 +1,6 @@
 package tests.core.issues
 
+import cats.free.Free
 import io.swagger.parser.OpenAPIParser
 import io.swagger.v3.parser.core.models.ParseOptions
 import com.twilio.guardrail._
@@ -44,7 +45,7 @@ class Issue166 extends FunSuite with Matchers with SwaggerSpecRunner {
     opts.setResolve(true)
     val (proto, codegen) = Target.unsafeExtract(
       Common
-        .prepareDefinitions[ScalaLanguage, CodegenApplication[ScalaLanguage, ?]](
+        .prepareDefinitions[ScalaLanguage, Free[CodegenApplication[ScalaLanguage, ?], ?]](
           CodegenTarget.Models,
           Context.empty,
           Tracker(new OpenAPIParser().readContents(swagger, new java.util.LinkedList(), opts).getOpenAPI),

--- a/modules/codegen/src/test/scala/support/SwaggerSpecRunner.scala
+++ b/modules/codegen/src/test/scala/support/SwaggerSpecRunner.scala
@@ -36,7 +36,7 @@ trait SwaggerSpecRunner extends EitherValues {
   }
 
   def runSwagger[L <: LA](swagger: OpenAPI, dtoPackage: List[String] = List.empty)(context: Context, framework: FunctionK[CodegenApplication[L, ?], Target])(
-      implicit Fw: FrameworkTerms[L, CodegenApplication[L, ?]],
+      implicit Fw: FrameworkTerms[L, Free[CodegenApplication[L, ?], ?]],
       Sc: ScalaTerms[L, Free[CodegenApplication[L, ?], ?]],
       Sw: SwaggerTerms[L, Free[CodegenApplication[L, ?], ?]]
   ): (ProtocolDefinitions[L], Clients[L], Servers[L]) = {
@@ -89,7 +89,7 @@ trait SwaggerSpecRunner extends EitherValues {
   }
 
   def runInvalidSwagger[L <: LA](swagger: OpenAPI)(context: Context, kind: CodegenTarget, framework: FunctionK[CodegenApplication[L, ?], Target])(
-      implicit Fw: FrameworkTerms[L, CodegenApplication[L, ?]],
+      implicit Fw: FrameworkTerms[L, Free[CodegenApplication[L, ?], ?]],
       Sc: ScalaTerms[L, Free[CodegenApplication[L, ?], ?]],
       Sw: SwaggerTerms[L, Free[CodegenApplication[L, ?], ?]]
   ): (StructuredLogger, Error) =

--- a/modules/codegen/src/test/scala/support/SwaggerSpecRunner.scala
+++ b/modules/codegen/src/test/scala/support/SwaggerSpecRunner.scala
@@ -38,7 +38,7 @@ trait SwaggerSpecRunner extends EitherValues {
   def runSwagger[L <: LA](swagger: OpenAPI, dtoPackage: List[String] = List.empty)(context: Context, framework: FunctionK[CodegenApplication[L, ?], Target])(
       implicit Fw: FrameworkTerms[L, CodegenApplication[L, ?]],
       Sc: ScalaTerms[L, Free[CodegenApplication[L, ?], ?]],
-      Sw: SwaggerTerms[L, CodegenApplication[L, ?]]
+      Sw: SwaggerTerms[L, Free[CodegenApplication[L, ?], ?]]
   ): (ProtocolDefinitions[L], Clients[L], Servers[L]) = {
     val /*(clientLogger,*/ (proto, CodegenDefinitions(clients, Nil, clientSupportDefs, _)) =
       Common
@@ -91,7 +91,7 @@ trait SwaggerSpecRunner extends EitherValues {
   def runInvalidSwagger[L <: LA](swagger: OpenAPI)(context: Context, kind: CodegenTarget, framework: FunctionK[CodegenApplication[L, ?], Target])(
       implicit Fw: FrameworkTerms[L, CodegenApplication[L, ?]],
       Sc: ScalaTerms[L, Free[CodegenApplication[L, ?], ?]],
-      Sw: SwaggerTerms[L, CodegenApplication[L, ?]]
+      Sw: SwaggerTerms[L, Free[CodegenApplication[L, ?], ?]]
   ): (StructuredLogger, Error) =
     Common
       .prepareDefinitions[L, CodegenApplication[L, ?]](

--- a/modules/codegen/src/test/scala/support/SwaggerSpecRunner.scala
+++ b/modules/codegen/src/test/scala/support/SwaggerSpecRunner.scala
@@ -42,7 +42,7 @@ trait SwaggerSpecRunner extends EitherValues {
   ): (ProtocolDefinitions[L], Clients[L], Servers[L]) = {
     val /*(clientLogger,*/ (proto, CodegenDefinitions(clients, Nil, clientSupportDefs, _)) =
       Common
-        .prepareDefinitions[L, CodegenApplication[L, ?]](
+        .prepareDefinitions[L, Free[CodegenApplication[L, ?], ?]](
           CodegenTarget.Client,
           context,
           Tracker(swagger),
@@ -56,7 +56,7 @@ trait SwaggerSpecRunner extends EitherValues {
 
     val /*(serverLogger,*/ (_, CodegenDefinitions(Nil, servers, serverSupportDefs, _)) =
       Common
-        .prepareDefinitions[L, CodegenApplication[L, ?]](
+        .prepareDefinitions[L, Free[CodegenApplication[L, ?], ?]](
           CodegenTarget.Server,
           context,
           Tracker(swagger),
@@ -94,7 +94,7 @@ trait SwaggerSpecRunner extends EitherValues {
       Sw: SwaggerTerms[L, Free[CodegenApplication[L, ?], ?]]
   ): (StructuredLogger, Error) =
     Common
-      .prepareDefinitions[L, CodegenApplication[L, ?]](
+      .prepareDefinitions[L, Free[CodegenApplication[L, ?], ?]](
         kind,
         context,
         Tracker(swagger),

--- a/modules/microsite/src/main/scala/DocsHelpers.scala
+++ b/modules/microsite/src/main/scala/DocsHelpers.scala
@@ -1,5 +1,6 @@
 package com.twilio.guardrail.docs
 
+import cats.free.Free
 import cats.arrow.FunctionK
 import io.swagger.parser.OpenAPIParser
 import io.swagger.v3.oas.models.OpenAPI
@@ -25,7 +26,7 @@ object DocsHelpers {
     val segments: List[Option[String]] = identifier match {
       case GeneratingAServer =>
         val (_, codegenDefinitions) = Target.unsafeExtract(
-          Common.prepareDefinitions[ScalaLanguage, CodegenApplication[ScalaLanguage, ?]](CodegenTarget.Server, Context.empty, openAPI, List("definitions"))
+          Common.prepareDefinitions[ScalaLanguage, Free[CodegenApplication[ScalaLanguage, ?], ?]](CodegenTarget.Server, Context.empty, openAPI, List("definitions"))
             .foldMap(generator)
         )
         val server = codegenDefinitions.servers.head
@@ -43,7 +44,7 @@ object DocsHelpers {
         )
       case GeneratingClients =>
         val (_, codegenDefinitions) = Target.unsafeExtract(
-          Common.prepareDefinitions[ScalaLanguage, CodegenApplication[ScalaLanguage, ?]](CodegenTarget.Client, Context.empty, openAPI, List("definitions"))
+          Common.prepareDefinitions[ScalaLanguage, Free[CodegenApplication[ScalaLanguage, ?], ?]](CodegenTarget.Client, Context.empty, openAPI, List("definitions"))
             .foldMap(generator)
         )
         codegenDefinitions.clients match {


### PR DESCRIPTION
Using scalafix to rewrite all other interfaces not covered by #591 into Tagless Final-style. This does not actually alter the interpreters themselves, that will come in (a) subsequent PR(s).

- [x] `ProtocolSupportTerm`
- [x] `ModelProtocolTerm`
- [x] `EnumProtocolTerm`
- [x] `ArrayProtocolTerm`
- [x] `PolyProtocolTerm`
- [x] `ServerTerm`
- [x] `FrameworkTerm`
- [x] `SwaggerTerm`

#### Previously, on #591 
- [x] `ClientTerm`
- [x] `ScalaTerm`

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
