### PR TITLE
Add support for releasing old versions to write-release-template.sh

### DIFF
--- a/support/write-release-template.sh
+++ b/support/write-release-template.sh
@@ -1,5 +1,15 @@
 #!/bin/env bash
 
+for remote in github upstream origin; do
+        git remote | grep "$remote" && break 2>/dev/null >&2
+        unset remote
+done
+if [ ! -z "$remote" ]; then
+        git fetch -p "$remote"
+else
+        echo "Unable to find workable remote, not fetching." >&2
+fi
+
 last_tag="$(git tag | tail -n1)"
 read -p "Last release (${last_tag}): " new_last_tag
 if [ ! -z "${new_last_tag}" ]; then

--- a/support/write-release-template.sh
+++ b/support/write-release-template.sh
@@ -35,6 +35,13 @@ fi
 
 github_api="$(mktemp)"
 
+if [ ! -z "$remote" ]; then
+        newer_prs="$(git log --merges --oneline "${current_head}...${remote}/master" | grep 'Merge pull request' | wc -l)"
+        if [ "$newer_prs" -gt 0 ]; then
+                echo "Preparing to release old version, not including $newer_prs PRs" >&2
+        fi
+fi
+
 curl --silent -o "${github_api}" "https://api.github.com/repos/twilio/guardrail/compare/${last_tag}...master"
 
 cat > "${notes_file}" <<!

--- a/support/write-release-template.sh
+++ b/support/write-release-template.sh
@@ -35,6 +35,8 @@ fi
 
 github_api="$(mktemp)"
 
+current_head="$(git rev-parse @)"
+
 if [ ! -z "$remote" ]; then
         newer_prs="$(git log --merges --oneline "${current_head}...${remote}/master" | grep 'Merge pull request' | wc -l)"
         if [ "$newer_prs" -gt 0 ]; then
@@ -42,7 +44,7 @@ if [ ! -z "$remote" ]; then
         fi
 fi
 
-curl --silent -o "${github_api}" "https://api.github.com/repos/twilio/guardrail/compare/${last_tag}...master"
+curl --silent -o "${github_api}" "https://api.github.com/repos/twilio/guardrail/compare/${last_tag}...${current_head}"
 
 cat > "${notes_file}" <<!
 TITLE


### PR DESCRIPTION
These changes were necessary to respond to https://github.com/twilio/guardrail/pull/542#issuecomment-613455200 while the major shifts to guardrail core are going on.

0.57.1 will be released shortly after, with only performance enhancements and some library upgrades.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
