### PR TITLE
Rendering syntax for generated files inside Future

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
@@ -13,11 +13,15 @@ import com.twilio.guardrail.languages.ScalaLanguage
 import com.twilio.guardrail.terms._
 import java.nio.charset.StandardCharsets
 import java.nio.file.Path
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 import scala.meta._
 
 object ScalaGenerator {
-  private def sourceToBytes(source: Source): Array[Byte] = (GENERATED_CODE_COMMENT + source.syntax).getBytes(StandardCharsets.UTF_8)
+  private def sourceToBytes(source: Source): Future[Array[Byte]] = Future {
+    (GENERATED_CODE_COMMENT + source.syntax).getBytes(StandardCharsets.UTF_8)
+  }
 
   object ScalaInterp extends (ScalaTerm[ScalaLanguage, ?] ~> Target) {
     // TODO: Very interesting bug. 2.11.12 barfs if these two definitions are

--- a/modules/codegen/src/test/scala/codegen/WritePackageSpec.scala
+++ b/modules/codegen/src/test/scala/codegen/WritePackageSpec.scala
@@ -15,6 +15,8 @@ import io.swagger.parser.OpenAPIParser
 import io.swagger.v3.parser.core.models.ParseOptions
 
 import scala.meta._
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 
 class WritePackageSpec extends FunSuite with Matchers {
   val parseOpts = new ParseOptions
@@ -67,7 +69,7 @@ class WritePackageSpec extends FunSuite with Matchers {
   def extractPackage(path: Path, results: List[WriteTree]): Term.Ref = {
     val Some(source"""package ${fooPkg }
     ..${stats }
-    """) = results.find(_.path == path).headOption.map(_.contents).map(x => new String(x).parse[Source].get)
+    """) = results.find(_.path == path).headOption.map(_.contents).map(x => new String(Await.result(x, Duration.Inf)).parse[Source].get)
     fooPkg
   }
 

--- a/modules/codegen/src/test/scala/com/twilio/guardrail/core/WriteTreeSuite.scala
+++ b/modules/codegen/src/test/scala/com/twilio/guardrail/core/WriteTreeSuite.scala
@@ -4,6 +4,7 @@ import com.twilio.guardrail.WriteTree
 import org.scalatest.FunSuite
 import java.nio.file.Files
 import org.scalatest.Matchers
+import scala.concurrent.Future
 
 class WriteTreeSuite extends FunSuite with Matchers {
   test("Ensure that even if we don't overwrite output files, the path is returned") {
@@ -12,8 +13,8 @@ class WriteTreeSuite extends FunSuite with Matchers {
 
     val contents = "example contents".getBytes
 
-    val (firstLog, firstPath)   = WriteTree.unsafeWriteTreeLogged(WriteTree(path, contents)).run
-    val (secondLog, secondPath) = WriteTree.unsafeWriteTreeLogged(WriteTree(path, contents)).run
+    val (firstLog, firstPath)   = WriteTree.unsafeWriteTreeLogged(WriteTree(path, Future.successful(contents))).run
+    val (secondLog, secondPath) = WriteTree.unsafeWriteTreeLogged(WriteTree(path, Future.successful(contents))).run
 
     val _1 = firstLog shouldBe (Nil)
     val _2 = secondLog shouldBe (Nil)


### PR DESCRIPTION
After doing some performance analysis, it seems as though a nontrivial amount of time is spent churning in scalameta's syntax renderer.

As a stopgap, we can thread the rendering function at the very least. There may be more gains possible by contributing back to scalameta (with the hope of having configurable syntax backends that don't flatten `for` comprehensions onto a single line!)

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
