### PR TITLE
Conditionally enable logger

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/CLI.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/CLI.scala
@@ -78,6 +78,8 @@ trait CLICommon {
       args.span(arg => LogLevels(arg.stripPrefix("--")).isDefined)
     val level: Option[String] = levels.lastOption.map(_.stripPrefix("--"))
 
+    level.foreach(_ => Target.loggerEnabled.set(true))
+
     // FIXME: The only reason we need the interpreter at all is to call parseArgs on it
     // This likely means the CLI should _not_ be part of CoreTerms. There's no reason
     // for it to be in there, as CLI is effectively a bespoke build tool whose unused

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Target.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Target.scala
@@ -35,13 +35,14 @@ object Target {
       case TargetValue(a, la)   => f(a).prependLogger(la)
       case TargetError(err, la) => new TargetError(err, la)
     }
+    @scala.annotation.tailrec
     def tailRecM[A, B](a: A)(f: A => Target[Either[A, B]]): Target[B] =
       f(a) match {
         case TargetError(err, la) =>
           new TargetError(err, la)
         case TargetValue(e, la) =>
           e match {
-            case Left(b)  => tailRecM(b)(f).prependLogger(la)
+            case Left(b)  => tailRecM(b)(f.map(_.prependLogger(la)))
             case Right(a) => new TargetValue(a, la)
           }
       }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Target.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Target.scala
@@ -5,9 +5,11 @@ import cats.{ Applicative, MonadError }
 import cats.Traverse
 import cats.Eval
 import cats.implicits._
+import java.util.concurrent.atomic.AtomicBoolean
 
 object Target {
-  def pushLogger(value: StructuredLogger): Target[Unit] = new TargetValue((), value)
+  val loggerEnabled                                     = new AtomicBoolean(false)
+  def pushLogger(value: StructuredLogger): Target[Unit] = new TargetValue((), if (loggerEnabled.get) value else StructuredLogger.Empty)
   def pure[T](x: T): Target[T]                          = new TargetValue(x, StructuredLogger.Empty)
 
   def raiseError[T](x: Error): Target[T]      = new TargetError(x, StructuredLogger.Empty)
@@ -42,7 +44,7 @@ object Target {
           new TargetError(err, la)
         case TargetValue(e, la) =>
           e match {
-            case Left(b)  => tailRecM(b)(f.map(_.prependLogger(la)))
+            case Left(b)  => tailRecM(b)(if (loggerEnabled.get) f.map(_.prependLogger(la)) else f)
             case Right(a) => new TargetValue(a, la)
           }
       }

--- a/modules/codegen/src/test/scala/core/StructuredLoggerSuite.scala
+++ b/modules/codegen/src/test/scala/core/StructuredLoggerSuite.scala
@@ -8,6 +8,7 @@ import org.scalatest.{ FunSuite, Matchers }
 
 class StructuredLoggerSuite extends FunSuite with Matchers {
   test("Structured Logger can nest functions") {
+    Target.loggerEnabled.set(true)
     val structure =
       Target.log.function("first") {
         Target.log.function("second") {
@@ -18,6 +19,7 @@ class StructuredLoggerSuite extends FunSuite with Matchers {
           } yield ()
         }
       }
+    Target.loggerEnabled.set(false)
     val logEntries = structure.logEntries
     val expected   = """
       |   INFO    first second: one


### PR DESCRIPTION
So, attempting to run guardrail against the 5mb spec linked in https://github.com/twilio/sbt-guardrail/issues/56 OOM'd guardrail.

For now, trying to split the difference between logging functionality and performance by only enabling the logger if the user has explicitly chosen a log level on the CLI.

This'll require support in build tools if they want logging to be enabled, which will need to get removed once the logging infrastructure has moved to something a little more efficient, like slf4j.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.