### PR TITLE
Removing tags shim

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/SwaggerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/SwaggerGenerator.scala
@@ -134,18 +134,6 @@ object SwaggerGenerator {
 
           pkg = PackageName(operation, vendorPrefixes)
             .map(_.split('.').toVector)
-            .orElse({
-              operation
-                .downField("tags", _.getTags)
-                .toNel
-                .indexedCosequence
-                .map { tags =>
-                  println(
-                    s"Warning: Using `tags` to define package membership is deprecated in favor of the `x-jvm-package` vendor extension (${tags.history})"
-                  )
-                  tags.get.toList
-                }
-            })
           opPkg     = operation.downField("operationId", _.getOperationId()).map(_.toList.flatMap(splitOperationParts(_)._1)).get
           className = pkg.map(_ ++ opPkg).getOrElse(opPkg).toList
         } yield className)


### PR DESCRIPTION
Resolving #476

Removing `tags` auto-mapping to package structure, as this has been deprecated for years.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
