### PR TITLE
Rewriting deprecated scalafix class names

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -199,6 +199,7 @@ addCommandAlias(
 resolvers += Resolver.sonatypeRepo("releases")
 addCompilerPlugin("org.typelevel" % "kind-projector"  % kindProjectorVersion cross CrossVersion.binary)
 addCompilerPlugin(scalafixSemanticdb)
+scalafixDependencies in ThisBuild += "org.scalatest" %% "autofix" % "3.1.0.0"
 scalacOptions += "-Yrangepos"
 
 publishMavenStyle := true

--- a/modules/codegen/src/test/scala/codegen/WritePackageSpec.scala
+++ b/modules/codegen/src/test/scala/codegen/WritePackageSpec.scala
@@ -9,7 +9,6 @@ import cats.implicits._
 import com.twilio.guardrail._
 import com.twilio.guardrail.core.CoreTermInterp
 import com.twilio.guardrail.languages.ScalaLanguage
-import org.scalatest.{ FunSuite, Matchers }
 
 import io.swagger.parser.OpenAPIParser
 import io.swagger.v3.parser.core.models.ParseOptions
@@ -17,8 +16,10 @@ import io.swagger.v3.parser.core.models.ParseOptions
 import scala.meta._
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class WritePackageSpec extends FunSuite with Matchers {
+class WritePackageSpec extends AnyFunSuite with Matchers {
   val parseOpts = new ParseOptions
   parseOpts.setResolve(true)
   val swagger: OpenAPI = new OpenAPIParser()

--- a/modules/codegen/src/test/scala/com/twilio/guardrail/core/WriteTreeSuite.scala
+++ b/modules/codegen/src/test/scala/com/twilio/guardrail/core/WriteTreeSuite.scala
@@ -1,12 +1,12 @@
 package com.twilio.guardrail.core
 
 import com.twilio.guardrail.WriteTree
-import org.scalatest.FunSuite
 import java.nio.file.Files
-import org.scalatest.Matchers
 import scala.concurrent.Future
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class WriteTreeSuite extends FunSuite with Matchers {
+class WriteTreeSuite extends AnyFunSuite with Matchers {
   test("Ensure that even if we don't overwrite output files, the path is returned") {
     val path = Files.createTempFile("guardrail-writeTree", ".txt")
     Files.delete(path)

--- a/modules/codegen/src/test/scala/com/twilio/guardrail/generators/syntax/JavaSyntaxTest.scala
+++ b/modules/codegen/src/test/scala/com/twilio/guardrail/generators/syntax/JavaSyntaxTest.scala
@@ -1,10 +1,11 @@
 package com.twilio.guardrail.generators.syntax
 
 import com.twilio.guardrail.generators.syntax.Java._
-import org.scalatest.{ FreeSpec, Matchers }
 import scala.util.Random
 import scala.util.{ Failure, Try }
 import com.github.javaparser.StaticJavaParser
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 object JavaSyntaxTest {
   val TEST_RESERVED_WORDS = List(
@@ -16,7 +17,7 @@ object JavaSyntaxTest {
   )
 }
 
-class JavaSyntaxTest extends FreeSpec with Matchers {
+class JavaSyntaxTest extends AnyFreeSpec with Matchers {
   import JavaSyntaxTest._
 
   "Reserved work escaper should" - {

--- a/modules/codegen/src/test/scala/core/StructuredLoggerSuite.scala
+++ b/modules/codegen/src/test/scala/core/StructuredLoggerSuite.scala
@@ -4,9 +4,10 @@ import cats.implicits._
 import com.twilio.guardrail._
 import com.twilio.guardrail.core._
 
-import org.scalatest.{ FunSuite, Matchers }
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class StructuredLoggerSuite extends FunSuite with Matchers {
+class StructuredLoggerSuite extends AnyFunSuite with Matchers {
   test("Structured Logger can nest functions") {
     Target.loggerEnabled.set(true)
     val structure =

--- a/modules/codegen/src/test/scala/core/TrackerTests.scala
+++ b/modules/codegen/src/test/scala/core/TrackerTests.scala
@@ -6,11 +6,12 @@ import com.twilio.guardrail.generators.Scala.Http4s
 import com.twilio.guardrail.{ CodegenTarget, Context, UserError }
 import cats.instances.all._
 import org.scalacheck.{ Arbitrary, Gen }
-import org.scalatest.{ FreeSpec, Matchers }
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import support.SwaggerSpecRunner
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class TrackerTests extends FreeSpec with Matchers with ScalaCheckPropertyChecks with TrackerTestExtensions with SwaggerSpecRunner {
+class TrackerTests extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks with TrackerTestExtensions with SwaggerSpecRunner {
   class Parent(val child1: List[Child1], val child2: Map[String, Child2]) { override def toString(): String = s"Parent($child1, $child2)" }
   class Child1(val grandchild: Option[Grandchild1]) extends Parent(grandchild.toList, Map.empty) { override def toString(): String = s"Child1($grandchild)" }
   class Child2                                      extends Parent(List.empty, Map.empty)        { override def toString(): String = s"Child2()"            }

--- a/modules/codegen/src/test/scala/core/issues/Issue105.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue105.scala
@@ -3,11 +3,12 @@ package tests.core.issues
 import com.twilio.guardrail.generators.Scala.AkkaHttp
 import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
 import com.twilio.guardrail.{ ClassDefinition, Context, ProtocolDefinitions }
-import org.scalatest.{ FunSuite, Matchers }
 import scala.meta._
 import support.SwaggerSpecRunner
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class Issue105 extends FunSuite with Matchers with SwaggerSpecRunner {
+class Issue105 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
   val swagger: String = s"""
     |swagger: "2.0"
     |info:

--- a/modules/codegen/src/test/scala/core/issues/Issue122.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue122.scala
@@ -3,11 +3,12 @@ package tests.core.issues
 import com.twilio.guardrail.generators.Scala.AkkaHttp
 import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
 import com.twilio.guardrail.{ Client, Clients, Context }
-import org.scalatest.{ FunSuite, Matchers }
 import scala.meta._
 import support.SwaggerSpecRunner
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class Issue122 extends FunSuite with Matchers with SwaggerSpecRunner {
+class Issue122 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
   val swagger: String = s"""
     |swagger: "2.0"
     |info:

--- a/modules/codegen/src/test/scala/core/issues/Issue126.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue126.scala
@@ -2,10 +2,11 @@ package tests.core.issues
 
 import com.twilio.guardrail.generators.Scala.AkkaHttp
 import com.twilio.guardrail.{ Context, Server, Servers }
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class Issue126 extends FunSuite with Matchers with SwaggerSpecRunner {
+class Issue126 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
   import scala.meta._
 
   val swagger: String = s"""

--- a/modules/codegen/src/test/scala/core/issues/Issue127.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue127.scala
@@ -2,12 +2,13 @@ package tests.core.issues
 
 import com.twilio.guardrail.generators.Scala.AkkaHttp
 import com.twilio.guardrail.{ Context, Server, Servers }
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class Issue127 extends FunSuite with Matchers with SwaggerSpecRunner {
+class Issue127 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
   val swagger: String = s"""
     |swagger: '2.0'
     |host: localhost:1234

--- a/modules/codegen/src/test/scala/core/issues/Issue145.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue145.scala
@@ -3,12 +3,13 @@ package core.issues
 import com.twilio.guardrail._
 import com.twilio.guardrail.generators.Scala.AkkaHttp
 import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
-import org.scalatest.{ FunSpec, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class Issue145 extends FunSpec with Matchers with SwaggerSpecRunner {
+class Issue145 extends AnyFunSpec with Matchers with SwaggerSpecRunner {
 
   describe("Generate hierarchical classes") {
 

--- a/modules/codegen/src/test/scala/core/issues/Issue165.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue165.scala
@@ -2,10 +2,11 @@ package tests.core.issues
 
 import com.twilio.guardrail.generators.Scala.Http4s
 import com.twilio.guardrail.{ Context, Server, Servers }
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class Issue165 extends FunSuite with Matchers with SwaggerSpecRunner {
+class Issue165 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
 
   import scala.meta._
 

--- a/modules/codegen/src/test/scala/core/issues/Issue166.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue166.scala
@@ -7,12 +7,13 @@ import com.twilio.guardrail._
 import com.twilio.guardrail.core.Tracker
 import com.twilio.guardrail.generators.Scala.Http4s
 import com.twilio.guardrail.languages.ScalaLanguage
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class Issue166 extends FunSuite with Matchers with SwaggerSpecRunner {
+class Issue166 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
 
   val swagger = s"""
                    |swagger: "2.0"

--- a/modules/codegen/src/test/scala/core/issues/Issue222.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue222.scala
@@ -3,10 +3,12 @@ package core.issues
 import com.twilio.guardrail.generators.Scala.Http4s
 import com.twilio.guardrail.languages.ScalaLanguage
 import com.twilio.guardrail.{ ClassDefinition, Context, ProtocolDefinitions }
-import org.scalatest.{ Assertion, FunSuite, Matchers }
+import org.scalatest.Assertion
 import support.SwaggerSpecRunner
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class Issue222 extends FunSuite with Matchers with SwaggerSpecRunner {
+class Issue222 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
 
   import scala.meta._
 

--- a/modules/codegen/src/test/scala/core/issues/Issue223.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue223.scala
@@ -2,12 +2,13 @@ package core.issues
 
 import com.twilio.guardrail.generators.Scala.Http4s
 import com.twilio.guardrail.{ ClassDefinition, Context, ProtocolDefinitions }
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class Issue223 extends FunSuite with Matchers with SwaggerSpecRunner {
+class Issue223 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
   val swagger: String = s"""
                            |swagger: "2.0"
                            |info:

--- a/modules/codegen/src/test/scala/core/issues/Issue225.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue225.scala
@@ -2,10 +2,11 @@ package core.issues
 
 import com.twilio.guardrail.generators.Scala.Http4s
 import com.twilio.guardrail.{ Context, Server, Servers }
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class Issue225 extends FunSuite with Matchers with SwaggerSpecRunner {
+class Issue225 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
 
   import scala.meta._
 

--- a/modules/codegen/src/test/scala/core/issues/Issue255.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue255.scala
@@ -2,12 +2,13 @@ package core.issues
 
 import com.twilio.guardrail.generators.Scala.Http4s
 import com.twilio.guardrail.{ ClassDefinition, Context, ProtocolDefinitions }
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class Issue255 extends FunSuite with Matchers with SwaggerSpecRunner {
+class Issue255 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
   val swagger: String = s"""
                            |swagger: "2.0"
                            |info:

--- a/modules/codegen/src/test/scala/core/issues/Issue260.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue260.scala
@@ -2,10 +2,11 @@ package core.issues
 
 import com.twilio.guardrail.generators.Scala.Http4s
 import com.twilio.guardrail.{ Context, Server, Servers }
-import org.scalatest.{ FunSpec, Matchers }
 import support.SwaggerSpecRunner
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class Issue260 extends FunSpec with Matchers with SwaggerSpecRunner {
+class Issue260 extends AnyFunSpec with Matchers with SwaggerSpecRunner {
 
   describe("LocalDate path param is generated more than once") {
 

--- a/modules/codegen/src/test/scala/core/issues/Issue370.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue370.scala
@@ -3,12 +3,13 @@ package core.issues
 import com.twilio.guardrail.generators.Scala.Http4s
 import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
 import com.twilio.guardrail.{ ClassDefinition, Context, ProtocolDefinitions }
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class Issue370 extends FunSuite with Matchers with SwaggerSpecRunner {
+class Issue370 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
   val swagger: String = s"""
                            |swagger: "2.0"
                            |info:

--- a/modules/codegen/src/test/scala/core/issues/Issue416.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue416.scala
@@ -2,10 +2,11 @@ package core.issues
 
 import com.twilio.guardrail.{ Context, Server, Servers }
 import com.twilio.guardrail.generators.Scala.Http4s
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class Issue416 extends FunSuite with Matchers with SwaggerSpecRunner {
+class Issue416 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
 
   import scala.meta._
 

--- a/modules/codegen/src/test/scala/core/issues/Issue420.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue420.scala
@@ -3,10 +3,11 @@ package core.issues
 import com.twilio.guardrail.generators.Scala.Http4s
 import com.twilio.guardrail.languages.ScalaLanguage
 import com.twilio.guardrail.{ ClassDefinition, Context, ProtocolDefinitions }
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class Issue420 extends FunSuite with Matchers with SwaggerSpecRunner {
+class Issue420 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
 
   import scala.meta._
 

--- a/modules/codegen/src/test/scala/core/issues/Issue429.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue429.scala
@@ -2,12 +2,13 @@ package core.issues
 
 import com.twilio.guardrail.generators.Scala.Http4s
 import com.twilio.guardrail.{ ClassDefinition, Context, ProtocolDefinitions }
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class Issue429 extends FunSuite with Matchers with SwaggerSpecRunner {
+class Issue429 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
   val swagger: String = s"""
     |openapi: 3.0.1
     |components:

--- a/modules/codegen/src/test/scala/core/issues/Issue43.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue43.scala
@@ -3,12 +3,13 @@ package core.issues
 import com.twilio.guardrail._
 import com.twilio.guardrail.generators.Scala.AkkaHttp
 import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
-import org.scalatest.{ FunSpec, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class Issue43 extends FunSpec with Matchers with SwaggerSpecRunner {
+class Issue43 extends AnyFunSpec with Matchers with SwaggerSpecRunner {
 
   describe("Generate hierarchical classes") {
 

--- a/modules/codegen/src/test/scala/core/issues/Issue538.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue538.scala
@@ -3,10 +3,11 @@ package core.issues
 import com.twilio.guardrail.generators.Scala.Http4s
 import com.twilio.guardrail.{ ClassDefinition, Context, ProtocolDefinitions, StaticDefns }
 import com.twilio.guardrail.languages.ScalaLanguage
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class Issue538 extends FunSuite with Matchers with SwaggerSpecRunner {
+class Issue538 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
 
   import scala.meta._
 

--- a/modules/codegen/src/test/scala/core/issues/Issue61.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue61.scala
@@ -2,12 +2,13 @@ package tests.core.issues
 
 import com.twilio.guardrail.generators.Scala.AkkaHttp
 import com.twilio.guardrail.{ Context, ProtocolDefinitions, RandomType }
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class Issue61 extends FunSuite with Matchers with SwaggerSpecRunner {
+class Issue61 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
   val swagger: String = s"""
     |swagger: "2.0"
     |info:

--- a/modules/codegen/src/test/scala/swagger/VendorExtensionTest.scala
+++ b/modules/codegen/src/test/scala/swagger/VendorExtensionTest.scala
@@ -5,11 +5,12 @@ import java.util
 import com.twilio.guardrail.extract.VendorExtension
 import io.swagger.parser.OpenAPIParser
 import io.swagger.v3.parser.core.models.ParseOptions
-import org.scalatest.{ FunSuite, Matchers }
 
 import scala.collection.JavaConverters._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class VendorExtensionTest extends FunSuite with Matchers {
+class VendorExtensionTest extends AnyFunSuite with Matchers {
 
   val spec: String = s"""
     |swagger: '2.0'

--- a/modules/codegen/src/test/scala/swagger/protocols/BigObjectSpec.scala
+++ b/modules/codegen/src/test/scala/swagger/protocols/BigObjectSpec.scala
@@ -4,12 +4,13 @@ package protocols
 import com.twilio.guardrail.generators.Scala.AkkaHttp
 import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
 import com.twilio.guardrail.{ ClassDefinition, Context, ProtocolDefinitions }
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class BigObjectSpec extends FunSuite with Matchers with SwaggerSpecRunner {
+class BigObjectSpec extends AnyFunSuite with Matchers with SwaggerSpecRunner {
 
   val swagger: String = s"""
     |swagger: "2.0"

--- a/modules/codegen/src/test/scala/tests/core/BacktickTest.scala
+++ b/modules/codegen/src/test/scala/tests/core/BacktickTest.scala
@@ -3,12 +3,13 @@ package tests.core
 import com.twilio.guardrail._
 import com.twilio.guardrail.generators.Scala.AkkaHttp
 import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class BacktickTest extends FunSuite with Matchers with SwaggerSpecRunner {
+class BacktickTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
 
   val swagger = s"""
     |swagger: "2.0"

--- a/modules/codegen/src/test/scala/tests/core/CaseConvertersTest.scala
+++ b/modules/codegen/src/test/scala/tests/core/CaseConvertersTest.scala
@@ -1,7 +1,8 @@
 package tests.core
 
 import com.twilio.guardrail.generators.syntax.RichString
-import org.scalatest.{ FreeSpec, Matchers }
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 object CaseConvertersTest {
   private case class CaseTest(raw: String, expectedPascal: String, expectedCamel: String, expectedSnake: String, expectedDashed: String) {
@@ -34,7 +35,7 @@ object CaseConvertersTest {
   )
 }
 
-class CaseConvertersTest extends FreeSpec with Matchers {
+class CaseConvertersTest extends AnyFreeSpec with Matchers {
   import CaseConvertersTest._
 
   "Pascal case converter should work" in {

--- a/modules/codegen/src/test/scala/tests/core/DereferencingAliasesSpec.scala
+++ b/modules/codegen/src/test/scala/tests/core/DereferencingAliasesSpec.scala
@@ -3,11 +3,12 @@ package tests.core
 import com.twilio.guardrail._
 import com.twilio.guardrail.generators.Scala.AkkaHttp
 import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
-import org.scalatest.{ FunSuite, Matchers }
 import scala.meta._
 import support.SwaggerSpecRunner
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class DereferencingAliasesSpec extends FunSuite with Matchers with SwaggerSpecRunner {
+class DereferencingAliasesSpec extends AnyFunSuite with Matchers with SwaggerSpecRunner {
 
   val swagger = s"""
     |swagger: "2.0"

--- a/modules/codegen/src/test/scala/tests/core/EscapeTreeSpec.scala
+++ b/modules/codegen/src/test/scala/tests/core/EscapeTreeSpec.scala
@@ -1,10 +1,10 @@
 package tests.core
 
-import org.scalatest.{ FunSuite, Matchers }
-
 import scala.meta._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class EscapeTreeSpec extends FunSuite with Matchers {
+class EscapeTreeSpec extends AnyFunSuite with Matchers {
 
   test("Assume special characters are not escaped") {
     val q"val $x = 3"                          = q"val `dashy-thing` = 3"

--- a/modules/codegen/src/test/scala/tests/core/FullyQualifiedNames.scala
+++ b/modules/codegen/src/test/scala/tests/core/FullyQualifiedNames.scala
@@ -3,12 +3,13 @@ package tests.core
 import com.twilio.guardrail.generators.Scala.Http4s
 import com.twilio.guardrail.languages.ScalaLanguage
 import com.twilio.guardrail.{ ClassDefinition, Client, Clients, Context, ProtocolDefinitions, Server, Servers }
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class FullyQualifiedNames extends FunSuite with Matchers with SwaggerSpecRunner {
+class FullyQualifiedNames extends AnyFunSuite with Matchers with SwaggerSpecRunner {
 
   val swagger =
     """

--- a/modules/codegen/src/test/scala/tests/core/PathParserSpec.scala
+++ b/modules/codegen/src/test/scala/tests/core/PathParserSpec.scala
@@ -5,12 +5,14 @@ import com.twilio.guardrail.{ SwaggerUtil, Target }
 import com.twilio.guardrail.core.{ Tracker, TrackerTestExtensions }
 import com.twilio.guardrail.generators.LanguageParameter
 import com.twilio.guardrail.generators.syntax.Scala._
-import org.scalatest.{ EitherValues, FunSuite, Matchers, OptionValues }
+import org.scalatest.{ EitherValues, OptionValues }
 import support.ScalaMetaMatchers._
 import com.twilio.guardrail.languages.ScalaLanguage
 import scala.meta._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class PathParserSpec extends FunSuite with Matchers with EitherValues with OptionValues with TrackerTestExtensions {
+class PathParserSpec extends AnyFunSuite with Matchers with EitherValues with OptionValues with TrackerTestExtensions {
 
   val args: List[LanguageParameter[ScalaLanguage]] = List(
     LanguageParameter.fromParam(param"foo: Int = 1"),

--- a/modules/codegen/src/test/scala/tests/core/RequestBodiesTest.scala
+++ b/modules/codegen/src/test/scala/tests/core/RequestBodiesTest.scala
@@ -5,11 +5,12 @@ import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration
 import com.twilio.guardrail.generators.Java.Dropwizard
 import com.twilio.guardrail.generators.syntax.Java._
 import com.twilio.guardrail.{ Clients, Context }
-import org.scalatest.{ FreeSpec, Matchers }
 import scala.collection.JavaConverters._
 import support.SwaggerSpecRunner
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class RequestBodiesTest extends FreeSpec with Matchers with SwaggerSpecRunner {
+class RequestBodiesTest extends AnyFreeSpec with Matchers with SwaggerSpecRunner {
   val openapi: String =
     """
       |openapi: 3.0.2

--- a/modules/codegen/src/test/scala/tests/core/ScalaTypesTest.scala
+++ b/modules/codegen/src/test/scala/tests/core/ScalaTypesTest.scala
@@ -3,12 +3,13 @@ package tests.core
 import com.twilio.guardrail.generators.Scala.AkkaHttp
 import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
 import com.twilio.guardrail.{ ClassDefinition, Context, ProtocolDefinitions }
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class ScalaTypesTest extends FunSuite with Matchers with SwaggerSpecRunner {
+class ScalaTypesTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
 
   val swagger: String = s"""
     |swagger: "2.0"

--- a/modules/codegen/src/test/scala/tests/core/TypesTest.scala
+++ b/modules/codegen/src/test/scala/tests/core/TypesTest.scala
@@ -3,11 +3,12 @@ package tests.core
 import com.twilio.guardrail.generators.Scala.AkkaHttp
 import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
 import com.twilio.guardrail.{ ClassDefinition, Context, ProtocolDefinitions }
-import org.scalatest.{ FunSuite, Matchers }
 import scala.meta._
 import support.SwaggerSpecRunner
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class TypesTest extends FunSuite with Matchers with SwaggerSpecRunner {
+class TypesTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
 
   test("Generate no definitions") {
     val swagger: String = s"""

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/AkkaHttpClientGeneratorTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/AkkaHttpClientGeneratorTest.scala
@@ -3,10 +3,11 @@ package tests.generators.akkaHttp
 import com.twilio.guardrail.generators.Scala.AkkaHttp
 import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
 import com.twilio.guardrail.{ Client, Clients, Context }
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class AkkaHttpClientGeneratorTest extends FunSuite with Matchers with SwaggerSpecRunner {
+class AkkaHttpClientGeneratorTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
   import scala.meta._
 
   val swagger: String = s"""

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/AkkaHttpServerTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/AkkaHttpServerTest.scala
@@ -2,10 +2,11 @@ package tests.generators.akkaHttp
 
 import com.twilio.guardrail.generators.Scala.AkkaHttp
 import com.twilio.guardrail.{ Context, Server, Servers }
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class AkkaHttpServerTest extends FunSuite with Matchers with SwaggerSpecRunner {
+class AkkaHttpServerTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
   import scala.meta._
 
   val swagger: String = s"""

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/CustomHeaderTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/CustomHeaderTest.scala
@@ -2,12 +2,13 @@ package tests.generators.akkaHttp
 
 import com.twilio.guardrail.generators.Scala.AkkaHttp
 import com.twilio.guardrail.{ Clients, Context, Server, Servers }
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 
 import scala.meta._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class CustomHeaderTest extends FunSuite with Matchers with SwaggerSpecRunner {
+class CustomHeaderTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
   val swagger: String = s"""
                            |swagger: "2.0"
                            |info:

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/DefinitionSpec.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/DefinitionSpec.scala
@@ -3,11 +3,12 @@ package tests.generators.akkaHttp
 import com.twilio.guardrail.generators.Scala.AkkaHttp
 import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
 import com.twilio.guardrail.{ ClassDefinition, Context, EnumDefinition, ProtocolDefinitions }
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 import scala.meta._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class DefinitionSpec extends FunSuite with Matchers with SwaggerSpecRunner {
+class DefinitionSpec extends AnyFunSuite with Matchers with SwaggerSpecRunner {
 
   val swagger = s"""
     |swagger: "2.0"

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/EnumTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/EnumTest.scala
@@ -3,11 +3,12 @@ package tests.generators.akkaHttp
 import com.twilio.guardrail._
 import com.twilio.guardrail.generators.Scala.AkkaHttp
 import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 import scala.meta._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class EnumTest extends FunSuite with Matchers with SwaggerSpecRunner {
+class EnumTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
 
   val swagger: String = s"""
     |swagger: "2.0"

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/PropertyExtractors.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/PropertyExtractors.scala
@@ -3,11 +3,12 @@ package tests.generators.akkaHttp
 import com.twilio.guardrail.generators.Scala.AkkaHttp
 import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
 import com.twilio.guardrail.{ ClassDefinition, Context, ProtocolDefinitions }
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 import scala.meta._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class PropertyExtractors extends FunSuite with Matchers with SwaggerSpecRunner {
+class PropertyExtractors extends AnyFunSuite with Matchers with SwaggerSpecRunner {
   val swagger: String = s"""
     |swagger: "2.0"
     |info:

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/StaticParametersTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/StaticParametersTest.scala
@@ -2,11 +2,12 @@ package tests.generators.akkaHttp
 
 import com.twilio.guardrail.generators.Scala.AkkaHttp
 import com.twilio.guardrail.{ Context, Server, Servers }
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 import scala.meta._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class StaticParametersTest extends FunSuite with Matchers with SwaggerSpecRunner {
+class StaticParametersTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
   val swagger: String = s"""
     |swagger: "2.0"
     |info:

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/AkkaHttpClientTracingTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/AkkaHttpClientTracingTest.scala
@@ -2,11 +2,12 @@ package tests.generators.akkaHttp.client
 
 import com.twilio.guardrail.generators.Scala.AkkaHttp
 import com.twilio.guardrail.{ Client, Clients, Context }
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 import scala.meta._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class AkkaHttpClientTracingTest extends FunSuite with Matchers with SwaggerSpecRunner {
+class AkkaHttpClientTracingTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
 
   test("Manage child tracing span") {
     val swagger = s"""

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/BasicTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/BasicTest.scala
@@ -3,11 +3,12 @@ package tests.generators.akkaHttp.client
 import com.twilio.guardrail._
 import com.twilio.guardrail.generators.Scala.AkkaHttp
 import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
-import org.scalatest.{ FunSuite, Matchers }
 import scala.meta._
 import support.SwaggerSpecRunner
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
+class BasicTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
   val swagger: String = s"""
     |swagger: "2.0"
     |info:

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/DefaultParametersTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/DefaultParametersTest.scala
@@ -3,10 +3,11 @@ package tests.generators.akkaHttp.client
 import com.twilio.guardrail.generators.Scala.AkkaHttp
 import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
 import com.twilio.guardrail.{ Client, Clients, Context }
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class DefaultParametersTest extends FunSuite with Matchers with SwaggerSpecRunner {
+class DefaultParametersTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
   import scala.meta._
 
   val swagger = s"""

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/FormFieldsTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/FormFieldsTest.scala
@@ -2,11 +2,12 @@ package tests.generators.akkaHttp.client
 
 import com.twilio.guardrail.generators.Scala.AkkaHttp
 import com.twilio.guardrail.{ Client, Clients, Context }
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 import scala.meta._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class FormFieldsTest extends FunSuite with Matchers with SwaggerSpecRunner {
+class FormFieldsTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
   val swagger: String = s"""
     |swagger: "2.0"
     |info:

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/HardcodedQSSpec.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/HardcodedQSSpec.scala
@@ -2,11 +2,12 @@ package tests.generators.akkaHttp.client
 
 import com.twilio.guardrail.generators.Scala.AkkaHttp
 import com.twilio.guardrail.{ Client, Clients, Context }
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 import scala.meta._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class HardcodedQSSpec extends FunSuite with Matchers with SwaggerSpecRunner {
+class HardcodedQSSpec extends AnyFunSuite with Matchers with SwaggerSpecRunner {
   val swagger: String = s"""
     |swagger: "2.0"
     |info:

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/HttpBodiesTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/HttpBodiesTest.scala
@@ -2,11 +2,12 @@ package tests.generators.akkaHttp.client
 
 import com.twilio.guardrail.generators.Scala.AkkaHttp
 import com.twilio.guardrail.{ Client, Clients, Context }
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 import scala.meta._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class HttpBodiesTest extends FunSuite with Matchers with SwaggerSpecRunner {
+class HttpBodiesTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
   val swagger: String = s"""
     |swagger: "2.0"
     |info:

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/MultipartTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/MultipartTest.scala
@@ -2,11 +2,12 @@ package tests.generators.akkaHttp.client
 
 import com.twilio.guardrail.generators.Scala.AkkaHttp
 import com.twilio.guardrail.{ Client, Clients, Context }
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 import scala.meta._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class MultipartTest extends FunSuite with Matchers with SwaggerSpecRunner {
+class MultipartTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
   val swagger: String = s"""
     |swagger: "2.0"
     |info:

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/ParamConflictsTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/ParamConflictsTest.scala
@@ -3,11 +3,12 @@ package tests.generators.akkaHttp.client
 import com.twilio.guardrail._
 import com.twilio.guardrail.generators.Scala.AkkaHttp
 import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 import scala.meta._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class ParamConflictsTest extends FunSuite with Matchers with SwaggerSpecRunner {
+class ParamConflictsTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
 
   val swagger = s"""
     |swagger: "2.0"

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/SchemeTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/SchemeTest.scala
@@ -3,11 +3,12 @@ package tests.generators.akkaHttp.client
 import com.twilio.guardrail.generators.Scala.AkkaHttp
 import com.twilio.guardrail.generators.syntax.Scala._
 import com.twilio.guardrail.{ Client, Clients, Context }
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 import scala.meta._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class SchemeTest extends FunSuite with Matchers with SwaggerSpecRunner {
+class SchemeTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
 
   val swagger: String = s"""
     |swagger: "2.0"

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/contentType/TextPlainTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/client/contentType/TextPlainTest.scala
@@ -3,11 +3,12 @@ package tests.generators.akkaHttp.client.contentType
 import com.twilio.guardrail.generators.Scala.AkkaHttp
 import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
 import com.twilio.guardrail.{ Client, Clients, Context }
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 import scala.meta._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class TextPlainTest extends FunSuite with Matchers with SwaggerSpecRunner {
+class TextPlainTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
   val swagger: String = s"""
     |swagger: "2.0"
     |info:

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
@@ -2,10 +2,11 @@ package tests.generators.akkaHttp.server
 
 import com.twilio.guardrail.generators.Scala.AkkaHttp
 import com.twilio.guardrail.{ Context, Server, Servers }
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class FormFieldsServerTest extends FunSuite with Matchers with SwaggerSpecRunner {
+class FormFieldsServerTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
   import scala.meta._
 
   val swagger: String = s"""

--- a/modules/codegen/src/test/scala/tests/generators/http4s/BasicTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/http4s/BasicTest.scala
@@ -3,11 +3,12 @@ package tests.generators.http4s
 import com.twilio.guardrail._
 import com.twilio.guardrail.generators.Scala.Http4s
 import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
 import scala.meta._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class BasicTest extends FunSuite with Matchers with SwaggerSpecRunner {
+class BasicTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
   val swagger = s"""
     |swagger: "2.0"
     |info:

--- a/modules/codegen/src/test/scala/tests/generators/http4s/client/DefaultParametersTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/http4s/client/DefaultParametersTest.scala
@@ -3,10 +3,11 @@ package tests.generators.http4s.client
 import com.twilio.guardrail.generators.Scala.Http4s
 import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
 import com.twilio.guardrail.{ Client, Clients, Context }
-import org.scalatest.{ FunSuite, Matchers }
 import support.SwaggerSpecRunner
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class DefaultParametersTest extends FunSuite with Matchers with SwaggerSpecRunner {
+class DefaultParametersTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
   import scala.meta._
 
   val swagger: String = s"""


### PR DESCRIPTION
At some point recently, scalatest started emitting warnings about deprecated classes.

Fortunately, they have a [scalafix rule](https://github.com/scalatest/autofix/tree/master/3.1.x) that basically just did all the work.

This is the associated PR.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.