### PR TITLE
 Fix missing Produces annotation when no 2xx response with body

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/shims/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/shims/package.scala
@@ -6,7 +6,7 @@ import scala.collection.JavaConverters._
 
 package object shims {
   implicit class OperationExt(operation: Operation) {
-    def consumes: Seq[String] =
+    def consumes: List[String] =
       for {
         body        <- Option(operation.getRequestBody()).toList
         content     <- Option(body.getContent()).toList
@@ -14,7 +14,7 @@ package object shims {
         if contentType != "*/*"
       } yield contentType
 
-    def produces: Seq[String] =
+    def produces: List[String] =
       for {
         responses   <- Option(operation.getResponses()).toList
         response    <- responses.asScala.values

--- a/modules/codegen/src/test/scala/tests/generators/dropwizard/server/DropwizardContentTypesTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/dropwizard/server/DropwizardContentTypesTest.scala
@@ -1,0 +1,95 @@
+package tests.generators.dropwizard.server
+
+import com.github.javaparser.ast.body.MethodDeclaration
+import com.twilio.guardrail.generators.Java.Dropwizard
+import com.twilio.guardrail.{ Context, Server, Servers }
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import scala.collection.JavaConverters._
+import support.SwaggerSpecRunner
+
+class DropwizardContentTypesTest extends AnyFreeSpec with Matchers with SwaggerSpecRunner {
+  private val swagger: String =
+    s"""
+       |openapi: 3.0.1
+       |paths:
+       |  /foo:
+       |    post:
+       |      operationId: foo
+       |      responses:
+       |        204: {}
+       |        404:
+       |          content:
+       |            application/json:
+       |              schema:
+       |                type: object
+       |  /foo-multiple:
+       |    post:
+       |      operationId: fooMultiple
+       |      responses:
+       |        204:
+       |          content:
+       |            application/json:
+       |              schema:
+       |                type: object
+       |        404:
+       |          content:
+       |            text/plain:
+       |              schema:
+       |                type: string
+       |""".stripMargin
+
+  "Produces annotation should still be added when success response has no body, but errors do" in {
+    val (
+      _,
+      _,
+      Servers(Server(_, _, _, genResource :: Nil) :: Nil, _)
+    ) = runSwaggerSpec(swagger)(Context.empty, Dropwizard)
+
+    genResource
+      .asClassOrInterfaceDeclaration()
+      .getMembers
+      .asScala
+      .collectFirst({
+        case method: MethodDeclaration if method.getNameAsString == "foo" => method
+      })
+      .get
+      .getAnnotationByName("Produces")
+      .get
+      .asSingleMemberAnnotationExpr()
+      .getMemberValue
+      .toString mustBe "MediaType.APPLICATION_JSON"
+  }
+
+  // This doesn't yet work because when the core threads through response info, we lose which content-type
+  // is associated with which response.  But I'll leave the test here to re-enable later when we fix that.
+  /*
+  "Produces annotation should have multiple members when different resposes have different content types" in {
+    val (
+      _,
+      _,
+      Servers(Server(_, _, _, genResource :: Nil) :: Nil, _)
+    ) = runSwaggerSpec(swagger)(Context.empty, Dropwizard)
+
+    val annotationArrayValues = genResource
+      .asClassOrInterfaceDeclaration()
+      .getMembers
+      .asScala
+      .collectFirst({
+        case method: MethodDeclaration if method.getNameAsString == "fooMultiple" => method
+      })
+      .get
+      .getAnnotationByName("Produces")
+      .get
+      .asSingleMemberAnnotationExpr()
+      .getMemberValue
+      .asArrayInitializerExpr()
+      .getValues
+      .toList
+
+    annotationArrayValues.length mustBe 2
+    annotationArrayValues.find(_.toString == "MediaType.APPLICATION.JSON") mustNot be(None)
+    annotationArrayValues.find(_.toString == "MediaType.TEXT_PLAIN") mustNot be(None)
+  }
+ */
+}


### PR DESCRIPTION
If an error response has a body type, even if the success response does not, we should still generate a Produces annotation for the method.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
