### PR TITLE
Propagating tracker (#619)

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/core/Tracker.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/core/Tracker.scala
@@ -152,4 +152,5 @@ object Tracker extends HighPriorityTrackerEvidence with HighPriorityTrackerSynta
 
   def apply(swagger: OpenAPI): Tracker[OpenAPI]                     = new Tracker(swagger, Vector.empty)
   def cloneHistory[A, B](tracker: Tracker[A], value: B): Tracker[B] = new Tracker(value, tracker.history)
+  def unapply[A](instance: Tracker[A]): Some[(String, A)]           = Some((instance.showHistory, instance.unwrapTracker))
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpServerGenerator.scala
@@ -352,7 +352,7 @@ object AkkaHttpServerGenerator {
     ): Target[(Option[Term], List[Stat])] = Target.log.function("formToAkka") {
       for {
         _ <- if (params.exists(_.isFile) && !consumes.exists(_.unwrapTracker == MultipartFormData)) {
-          Target.log.warning("type: file detected, automatically enabling multipart/form-data handling")
+          Target.log.warning(s"type: file detected, automatically enabling multipart/form-data handling (${consumes.showHistory})")
         } else {
           Target.pure(())
         }

--- a/modules/codegen/src/test/scala/support/SwaggerSpecRunner.scala
+++ b/modules/codegen/src/test/scala/support/SwaggerSpecRunner.scala
@@ -12,9 +12,9 @@ import com.twilio.guardrail.terms.framework.FrameworkTerms
 import com.twilio.guardrail.terms.{ LanguageTerms, SwaggerTerms }
 import scala.meta.Tree
 import org.scalactic.Equality
-import org.scalatest.EitherValues
+import org.scalatest.{ EitherValues, OptionValues }
 
-trait SwaggerSpecRunner extends EitherValues {
+trait SwaggerSpecRunner extends EitherValues with OptionValues {
   implicit def TreeEquality[A <: Tree]: Equality[A] =
     new Equality[A] {
       def areEqual(a: A, b: Any): Boolean =

--- a/modules/codegen/src/test/scala/tests/generators/dropwizard/server/DropwizardContentTypesTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/dropwizard/server/DropwizardContentTypesTest.scala
@@ -6,6 +6,7 @@ import com.twilio.guardrail.{ Context, Server, Servers }
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import scala.collection.JavaConverters._
+import scala.compat.java8.OptionConverters._
 import support.SwaggerSpecRunner
 
 class DropwizardContentTypesTest extends AnyFreeSpec with Matchers with SwaggerSpecRunner {
@@ -53,9 +54,10 @@ class DropwizardContentTypesTest extends AnyFreeSpec with Matchers with SwaggerS
       .collectFirst({
         case method: MethodDeclaration if method.getNameAsString == "foo" => method
       })
-      .get
+      .value
       .getAnnotationByName("Produces")
-      .get
+      .asScala
+      .value
       .asSingleMemberAnnotationExpr()
       .getMemberValue
       .toString mustBe "MediaType.APPLICATION_JSON"


### PR DESCRIPTION
Resolves #619

- Making `flatDownField` more general, chaining Option to any `Applicative` + `MonoidK` combo for null safety while interoperating well with other container types
- Adding `unapply` for Tracker
- Providing a better error messages for validation errors with produces/consumes in the akka-http generator

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
