### PR TITLE
Emitting OpenAPI parser warnings

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ReadSwagger.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ReadSwagger.scala
@@ -1,5 +1,7 @@
 package com.twilio.guardrail
 
+import scala.collection.JavaConverters._
+
 import java.nio.file.Path
 import java.util
 
@@ -13,9 +15,11 @@ object ReadSwagger {
     if (rs.path.toFile.exists()) {
       val opts = new ParseOptions()
       opts.setResolve(true)
+      val result = new OpenAPIParser().readLocation(rs.path.toAbsolutePath.toString, new util.LinkedList(), opts)
+      Option(result.getMessages()).foreach(_.asScala.foreach(println))
       Target
         .fromOption(
-          Option(new OpenAPIParser().readLocation(rs.path.toAbsolutePath.toString, new util.LinkedList(), opts).getOpenAPI),
+          Option(result.getOpenAPI),
           UserError(s"Spec file ${rs.path} is incorrectly formatted.")
         )
         .flatMap(rs.next(_))


### PR DESCRIPTION
Documenting initial investigatory work for integrating better error messages from OpenAPIParser

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.