### PR TITLE
Adding List and Vector to form encoder lifters, AddArg

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -93,6 +93,7 @@ val exampleCases: List[ExampleCase] = List(
   ExampleCase(sampleResource("issues/issue405.yaml"), "issues.issue405"),
   ExampleCase(sampleResource("issues/issue440.yaml"), "issues.issue440"),
   ExampleCase(sampleResource("issues/issue455.yaml"), "issues.issue455"),
+  ExampleCase(sampleResource("issues/issue622.yaml"), "issues.issue622"),
   ExampleCase(sampleResource("multipart-form-data.yaml"), "multipartFormData"),
   ExampleCase(sampleResource("petstore.json"), "examples").args("--import", "support.PositiveLong"),
   // ExampleCase(sampleResource("petstore-openapi-3.0.2.yaml"), "examples.petstore.openapi302").args("--import", "support.PositiveLong"),

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -122,8 +122,14 @@ object Common {
     val CodegenDefinitions(clients, servers, supportDefinitions, frameworkImplicits)                     = codegen
     val frameworkImplicitName                                                                            = frameworkImplicits.map(_._1)
 
-    val dtoComponents: List[String]                         = definitions ++ dtoPackage
-    val filteredDtoComponents: Option[NonEmptyList[String]] = if (protocolElems.nonEmpty) NonEmptyList.fromList(dtoComponents) else None
+    val dtoComponents: List[String] = definitions ++ dtoPackage
+
+    // Only presume ...definitions._ import is available if we have
+    // protocolElems which are not just all type aliases.
+    val filteredDtoComponents: Option[NonEmptyList[String]] =
+      NonEmptyList
+        .fromList(dtoComponents)
+        .filter(_ => protocolElems.exists({ case _: RandomType[_] => false; case _ => true }))
 
     for {
       protoOut <- protocolElems.traverse(writeProtocolDefinition(outputPath, pkgName, definitions, dtoComponents, customImports ++ protocolImports, _))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpClientGenerator.scala
@@ -48,7 +48,11 @@ object AkkaHttpClientGenerator {
     ): Target[RenderedClientOperation[ScalaLanguage]] = {
       val RouteMeta(pathStr, httpMethod, operation, securityRequirements) = route
       val containerTransformations = Map[String, Term => Term](
-        "Iterable" -> identity _
+        "Iterable"   -> identity _,
+        "List"       -> (term => q"$term.toList"),
+        "Vector"     -> (term => q"$term.toVector"),
+        "Seq"        -> (term => q"$term.toSeq"),
+        "IndexedSeq" -> (term => q"$term.toIndexedSeq")
       )
 
       def generateUrlWithParams(

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/EndpointsClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/EndpointsClientGenerator.scala
@@ -40,6 +40,10 @@ object EndpointsClientGenerator {
         responses: Responses[ScalaLanguage]
     ): Target[RenderedClientOperation[ScalaLanguage]] = {
       val RouteMeta(pathStr, httpMethod, operation, securityRequirements) = route
+      val containerTransformations = Map[String, Term => Term](
+        "Iterable" -> identity _
+      )
+
       def generateFormDataParams(parameters: List[LanguageParameter[ScalaLanguage]], needsMultipart: Boolean): Option[Term] =
         if (parameters.isEmpty) {
           None
@@ -80,18 +84,18 @@ object EndpointsClientGenerator {
 
           def liftOptionTerm(tpe: Type)(tParamName: Term, tName: RawParameterName) = {
             val lifter = tpe match {
-              case t"Iterable[$_]" => liftIterable _
-              case _               => liftTerm _
+              case t"$container[$_]" if containerTransformations.contains(container.syntax) => liftIterable _
+              case _                                                                        => liftTerm _
             }
             q"${tParamName}.toList.flatMap(${Term.Block(List(q" x => ${lifter(Term.Name("x"), tName)}"))})"
           }
 
           val lifter: Term.Param => (Term, RawParameterName) => Term = {
-            case param"$_: Option[$tpe]"        => liftOptionTerm(tpe) _
-            case param"$_: Option[$tpe] = $_"   => liftOptionTerm(tpe) _
-            case param"$_: Iterable[$tpe]"      => liftIterable _
-            case param"$_: Iterable[$tpe] = $_" => liftIterable _
-            case _                              => liftTerm _
+            case param"$_: Option[$tpe]"                                                                 => liftOptionTerm(tpe) _
+            case param"$_: Option[$tpe] = $_"                                                            => liftOptionTerm(tpe) _
+            case param"$_: $container[$tpe]" if containerTransformations.contains(container.syntax)      => liftIterable _
+            case param"$_: $container[$tpe] = $_" if containerTransformations.contains(container.syntax) => liftIterable _
+            case _                                                                                       => liftTerm _
           }
 
           val args: List[Term] = parameters.map {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/EndpointsClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/EndpointsClientGenerator.scala
@@ -41,7 +41,11 @@ object EndpointsClientGenerator {
     ): Target[RenderedClientOperation[ScalaLanguage]] = {
       val RouteMeta(pathStr, httpMethod, operation, securityRequirements) = route
       val containerTransformations = Map[String, Term => Term](
-        "Iterable" -> identity _
+        "Iterable"   -> identity _,
+        "List"       -> (term => q"$term.toList"),
+        "Vector"     -> (term => q"$term.toVector"),
+        "Seq"        -> (term => q"$term.toSeq"),
+        "IndexedSeq" -> (term => q"$term.toIndexedSeq")
       )
 
       def generateFormDataParams(parameters: List[LanguageParameter[ScalaLanguage]], needsMultipart: Boolean): Option[Term] =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sClientGenerator.scala
@@ -48,7 +48,11 @@ object Http4sClientGenerator {
     ): Target[RenderedClientOperation[ScalaLanguage]] = {
       val RouteMeta(pathStr, httpMethod, operation, securityRequirements) = route
       val containerTransformations = Map[String, Term => Term](
-        "Iterable" -> identity _
+        "Iterable"   -> identity _,
+        "List"       -> (term => q"$term.toList"),
+        "Vector"     -> (term => q"$term.toVector"),
+        "Seq"        -> (term => q"$term.toSeq"),
+        "IndexedSeq" -> (term => q"$term.toIndexedSeq")
       )
 
       def generateUrlWithParams(

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sClientGenerator.scala
@@ -47,6 +47,10 @@ object Http4sClientGenerator {
         responses: Responses[ScalaLanguage]
     ): Target[RenderedClientOperation[ScalaLanguage]] = {
       val RouteMeta(pathStr, httpMethod, operation, securityRequirements) = route
+      val containerTransformations = Map[String, Term => Term](
+        "Iterable" -> identity _
+      )
+
       def generateUrlWithParams(
           path: Tracker[String],
           pathArgs: List[LanguageParameter[ScalaLanguage]],
@@ -123,18 +127,18 @@ object Http4sClientGenerator {
 
           def liftOptionTerm(tpe: Type)(tParamName: Term, tName: RawParameterName) = {
             val lifter = tpe match {
-              case t"Iterable[$_]" => liftIterable _
-              case _               => liftTerm _
+              case t"$container[$_]" if containerTransformations.contains(container.syntax) => liftIterable _
+              case _                                                                        => liftTerm _
             }
             q"${tParamName}.toList.flatMap(${Term.Block(List(q" x => ${lifter(Term.Name("x"), tName)}"))})"
           }
 
           val lifter: Term.Param => (Term, RawParameterName) => Term = {
-            case param"$_: Option[$tpe]"      => liftOptionTerm(tpe) _
-            case param"$_: Option[$tpe] = $_" => liftOptionTerm(tpe) _
-            case param"$_: Iterable[$_]"      => liftIterable _
-            case param"$_: Iterable[$_] = $_" => liftIterable _
-            case _                            => liftTerm _
+            case param"$_: Option[$tpe]"                                                                 => liftOptionTerm(tpe) _
+            case param"$_: Option[$tpe] = $_"                                                            => liftOptionTerm(tpe) _
+            case param"$_: $container[$tpe]" if containerTransformations.contains(container.syntax)      => liftIterable _
+            case param"$_: $container[$tpe] = $_" if containerTransformations.contains(container.syntax) => liftIterable _
+            case _                                                                                       => liftTerm _
           }
 
           val args: List[Term] = parameters.map {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sServerGenerator.scala
@@ -231,7 +231,7 @@ object Http4sServerGenerator {
       params =>
         directivesFromParams(
           arg => _ => Target.pure(p"${Term.Name(s"${operationId.capitalize}${arg.argName.value.capitalize}Matcher")}(${Pat.Var(arg.paramName)})"),
-          arg => _ => Target.pure(p"${Term.Name(s"${operationId.capitalize}${arg.argName.value.capitalize}Matcher")}(${Pat.Var(arg.paramName)} @ _*)"),
+          arg => _ => Target.pure(p"${Term.Name(s"${operationId.capitalize}${arg.argName.value.capitalize}Matcher")}(${Pat.Var(arg.paramName)})"),
           arg => _ => Target.pure(p"${Term.Name(s"${operationId.capitalize}${arg.argName.value.capitalize}Matcher")}(${Pat.Var(arg.paramName)})"),
           arg => _ => Target.pure(p"${Term.Name(s"${operationId.capitalize}${arg.argName.value.capitalize}Matcher")}(${Pat.Var(arg.paramName)})")
         )(params).map {
@@ -708,14 +708,14 @@ object Http4sServerGenerator {
                 (q"""
                    object ${matcherName} {
                      val delegate = new QueryParamDecoderMatcher[$tpe](${argName.toLit}) {}
-                     def unapplySeq(params: Map[String, Seq[String]]): Option[Seq[String]] = delegate.unapplySeq(params)
+                     def unapply(params: Map[String, Seq[String]]): Option[Seq[String]] = delegate.unapplySeq(params)
                    }
                  """, tpe)
               case param"$_: Iterable[$tpe] = $_" =>
                 (q"""
                    object ${matcherName} {
                      val delegate = new QueryParamDecoderMatcher[$tpe](${argName.toLit}) {}
-                     def unapplySeq(params: Map[String, Seq[String]]): Option[Seq[String]] = delegate.unapplySeq(params)
+                     def unapply(params: Map[String, Seq[String]]): Option[Seq[String]] = delegate.unapplySeq(params)
                    }
                  """, tpe)
               case _ =>

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sServerGenerator.scala
@@ -674,10 +674,11 @@ object Http4sServerGenerator {
       val (decoders, matchers) = qsArgs
         .traverse({
           case LanguageParameter(_, param, _, argName, argType) =>
+            val matcherName = Term.Name(s"${operationId.capitalize}${argName.value.capitalize}Matcher")
             val (queryParamMatcher, elemType) = param match {
               case param"$_: Option[Iterable[$tpe]]" =>
                 (q"""
-                  object ${Term.Name(s"${operationId.capitalize}${argName.value.capitalize}Matcher")} {
+                  object ${matcherName} {
                     val delegate = new OptionalMultiQueryParamDecoderMatcher[$tpe](${argName.toLit}) {}
                     def unapply(params: Map[String, Seq[String]]): Option[Option[List[$tpe]]] = delegate.unapply(params).collectFirst {
                       case cats.data.Validated.Valid(value) => Option(value).filter(_.nonEmpty)
@@ -686,7 +687,7 @@ object Http4sServerGenerator {
                  """, tpe)
               case param"$_: Option[Iterable[$tpe]] = $_" =>
                 (q"""
-                  object ${Term.Name(s"${operationId.capitalize}${argName.value.capitalize}Matcher")} {
+                  object ${matcherName} {
                     val delegate = new OptionalMultiQueryParamDecoderMatcher[$tpe](${argName.toLit}) {}
                     def unapply(params: Map[String, Seq[String]]): Option[Option[List[$tpe]]] = delegate.unapply(params).collectFirst {
                       case cats.data.Validated.Valid(value) => Option(value).filter(_.nonEmpty)
@@ -695,34 +696,31 @@ object Http4sServerGenerator {
                  """, tpe)
               case param"$_: Option[$tpe]" =>
                 (
-                  q"""object ${Term
-                    .Name(s"${operationId.capitalize}${argName.value.capitalize}Matcher")} extends OptionalQueryParamDecoderMatcher[$tpe](${argName.toLit})""",
+                  q"""object ${matcherName} extends OptionalQueryParamDecoderMatcher[$tpe](${argName.toLit})""",
                   tpe
                 )
               case param"$_: Option[$tpe] = $_" =>
                 (
-                  q"""object ${Term
-                    .Name(s"${operationId.capitalize}${argName.value.capitalize}Matcher")} extends OptionalQueryParamDecoderMatcher[$tpe](${argName.toLit})""",
+                  q"""object ${matcherName} extends OptionalQueryParamDecoderMatcher[$tpe](${argName.toLit})""",
                   tpe
                 )
               case param"$_: Iterable[$tpe]" =>
                 (q"""
-                   object ${Term.Name(s"${operationId.capitalize}${argName.value.capitalize}Matcher")} {
+                   object ${matcherName} {
                      val delegate = new QueryParamDecoderMatcher[$tpe](${argName.toLit}) {}
                      def unapplySeq(params: Map[String, Seq[String]]): Option[Seq[String]] = delegate.unapplySeq(params)
                    }
                  """, tpe)
               case param"$_: Iterable[$tpe] = $_" =>
                 (q"""
-                   object ${Term.Name(s"${operationId.capitalize}${argName.value.capitalize}Matcher")} {
+                   object ${matcherName} {
                      val delegate = new QueryParamDecoderMatcher[$tpe](${argName.toLit}) {}
                      def unapplySeq(params: Map[String, Seq[String]]): Option[Seq[String]] = delegate.unapplySeq(params)
                    }
                  """, tpe)
               case _ =>
                 (
-                  q"""object ${Term
-                    .Name(s"${operationId.capitalize}${argName.value.capitalize}Matcher")} extends QueryParamDecoderMatcher[$argType](${argName.toLit})""",
+                  q"""object ${matcherName} extends QueryParamDecoderMatcher[$argType](${argName.toLit})""",
                   argType
                 )
             }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sServerGenerator.scala
@@ -163,30 +163,34 @@ object Http4sServerGenerator {
 
     def directivesFromParams[T](
         required: LanguageParameter[ScalaLanguage] => Type => Target[T],
-        multi: LanguageParameter[ScalaLanguage] => Type => Target[T],
-        multiOpt: LanguageParameter[ScalaLanguage] => Type => Target[T],
+        multi: LanguageParameter[ScalaLanguage] => Type => (Term => Term) => Target[T],
+        multiOpt: LanguageParameter[ScalaLanguage] => Type => (Term => Term) => Target[T],
         optional: LanguageParameter[ScalaLanguage] => Type => Target[T]
     )(params: List[LanguageParameter[ScalaLanguage]]): Target[List[T]] =
       for {
         directives <- params.traverse[Target, T] {
           case scalaParam @ LanguageParameter(_, param, _, _, argType) =>
             val containerTransformations = Map[String, Term => Term](
-              "Iterable" -> identity _
+              "Iterable"   -> identity _,
+              "List"       -> (term => q"$term.toList"),
+              "Vector"     -> (term => q"$term.toVector"),
+              "Seq"        -> (term => q"$term.toSeq"),
+              "IndexedSeq" -> (term => q"$term.toIndexedSeq")
             )
 
             param match {
               case param"$_: Option[$container[$tpe]]" if containerTransformations.contains(container.syntax) =>
-                multiOpt(scalaParam)(tpe)
+                multiOpt(scalaParam)(tpe)(containerTransformations(container.syntax))
               case param"$_: Option[$container[$tpe]] = $_" if containerTransformations.contains(container.syntax) =>
-                multiOpt(scalaParam)(tpe)
+                multiOpt(scalaParam)(tpe)(containerTransformations(container.syntax))
               case param"$_: Option[$tpe]" =>
                 optional(scalaParam)(tpe)
               case param"$_: Option[$tpe] = $_" =>
                 optional(scalaParam)(tpe)
               case param"$_: $container[$tpe]" if containerTransformations.contains(container.syntax) =>
-                multi(scalaParam)(tpe)
+                multi(scalaParam)(tpe)(containerTransformations(container.syntax))
               case param"$_: $container[$tpe] = $_" if containerTransformations.contains(container.syntax) =>
-                multi(scalaParam)(tpe)
+                multi(scalaParam)(tpe)(containerTransformations(container.syntax))
               case _ => required(scalaParam)(argType)
             }
         }
@@ -216,8 +220,8 @@ object Http4sServerGenerator {
               )
             )
         },
-        arg => _ => Target.raiseUserError(s"Unsupported Iterable[${arg}"),
-        arg => _ => Target.raiseUserError(s"Unsupported Option[Iterable[${arg}]]"),
+        arg => _ => _ => Target.raiseUserError(s"Unsupported Iterable[${arg}"),
+        arg => _ => _ => Target.raiseUserError(s"Unsupported Option[Iterable[${arg}]]"),
         arg => {
           case t"String" => Target.pure(Param(None, None, q"req.headers.get(${arg.argName.toLit}.ci).map(_.value)"))
           case tpe =>
@@ -235,8 +239,8 @@ object Http4sServerGenerator {
       params =>
         directivesFromParams(
           arg => _ => Target.pure(p"${Term.Name(s"${operationId.capitalize}${arg.argName.value.capitalize}Matcher")}(${Pat.Var(arg.paramName)})"),
-          arg => _ => Target.pure(p"${Term.Name(s"${operationId.capitalize}${arg.argName.value.capitalize}Matcher")}(${Pat.Var(arg.paramName)})"),
-          arg => _ => Target.pure(p"${Term.Name(s"${operationId.capitalize}${arg.argName.value.capitalize}Matcher")}(${Pat.Var(arg.paramName)})"),
+          arg => _ => _ => Target.pure(p"${Term.Name(s"${operationId.capitalize}${arg.argName.value.capitalize}Matcher")}(${Pat.Var(arg.paramName)})"),
+          arg => _ => _ => Target.pure(p"${Term.Name(s"${operationId.capitalize}${arg.argName.value.capitalize}Matcher")}(${Pat.Var(arg.paramName)})"),
           arg => _ => Target.pure(p"${Term.Name(s"${operationId.capitalize}${arg.argName.value.capitalize}Matcher")}(${Pat.Var(arg.paramName)})")
         )(params).map {
           case Nil => Option.empty
@@ -267,36 +271,38 @@ object Http4sServerGenerator {
         },
         arg => {
           case t"String" =>
-            Target.pure(Param(None, Some((q"urlForm.values.get(${arg.argName.toLit})", p"Some(${Pat.Var(arg.paramName)})")), q"${arg.paramName}.toList"))
+            _ => Target.pure(Param(None, Some((q"urlForm.values.get(${arg.argName.toLit})", p"Some(${Pat.Var(arg.paramName)})")), q"${arg.paramName}.toList"))
           case tpe =>
-            Target.pure(
-              Param(
-                None,
-                Some(
-                  (
-                    q"urlForm.values.get(${arg.argName.toLit}).flatMap(_.toList).traverse(Json.fromString(_).as[$tpe])",
-                    p"Some(Right(${Pat.Var(arg.paramName)}))"
-                  )
-                ),
-                arg.paramName
+            _ =>
+              Target.pure(
+                Param(
+                  None,
+                  Some(
+                    (
+                      q"urlForm.values.get(${arg.argName.toLit}).flatMap(_.toList).traverse(Json.fromString(_).as[$tpe])",
+                      p"Some(Right(${Pat.Var(arg.paramName)}))"
+                    )
+                  ),
+                  arg.paramName
+                )
               )
-            )
         },
         arg => {
-          case t"String" => Target.pure(Param(None, None, q"urlForm.values.get(${arg.argName.toLit}).map(_.toList)"))
+          case t"String" => _ => Target.pure(Param(None, None, q"urlForm.values.get(${arg.argName.toLit}).map(_.toList)"))
           case tpe =>
-            Target.pure(
-              Param(
-                None,
-                Some(
-                  (
-                    q"urlForm.values.get(${arg.argName.toLit}).flatMap(_.toList).map(Json.fromString(_).as[$tpe]).sequence.sequence",
-                    p"Right(${Pat.Var(arg.paramName)})"
-                  )
-                ),
-                arg.paramName
+            _ =>
+              Target.pure(
+                Param(
+                  None,
+                  Some(
+                    (
+                      q"urlForm.values.get(${arg.argName.toLit}).flatMap(_.toList).map(Json.fromString(_).as[$tpe]).sequence.sequence",
+                      p"Right(${Pat.Var(arg.paramName)})"
+                    )
+                  ),
+                  arg.paramName
+                )
               )
-            )
         },
         arg => {
           case t"String" =>
@@ -364,58 +370,60 @@ object Http4sServerGenerator {
               },
         arg =>
           elemType =>
-            if (arg.isFile) {
-              Target.pure(Param(None, None, q"multipart.parts.filter(_.name.contains(${arg.argName.toLit})).map(_.body)"))
-            } else
-              elemType match {
-                case t"String" =>
-                  Target.pure(
-                    Param(
-                      Some(
-                        enumerator"${Pat.Var(arg.paramName)} <- multipart.parts.filter(_.name.contains(${arg.argName.toLit})).map(_.body.through(utf8Decode).compile.foldMonoid).sequence"
-                      ),
-                      None,
-                      arg.paramName
+            _ =>
+              if (arg.isFile) {
+                Target.pure(Param(None, None, q"multipart.parts.filter(_.name.contains(${arg.argName.toLit})).map(_.body)"))
+              } else
+                elemType match {
+                  case t"String" =>
+                    Target.pure(
+                      Param(
+                        Some(
+                          enumerator"${Pat.Var(arg.paramName)} <- multipart.parts.filter(_.name.contains(${arg.argName.toLit})).map(_.body.through(utf8Decode).compile.foldMonoid).sequence"
+                        ),
+                        None,
+                        arg.paramName
+                      )
                     )
-                  )
-                case tpe =>
-                  Target.pure(
-                    Param(
-                      Some(
-                        enumerator"${Pat.Var(arg.paramName)} <- multipart.parts.filter(_.name.contains(${arg.argName.toLit})).map(_.body.through(utf8Decode).compile.foldMonoid.flatMap(str => F.fromEither(Json.fromString(str).as[$tpe]))).sequence"
-                      ),
-                      None,
-                      arg.paramName
+                  case tpe =>
+                    Target.pure(
+                      Param(
+                        Some(
+                          enumerator"${Pat.Var(arg.paramName)} <- multipart.parts.filter(_.name.contains(${arg.argName.toLit})).map(_.body.through(utf8Decode).compile.foldMonoid.flatMap(str => F.fromEither(Json.fromString(str).as[$tpe]))).sequence"
+                        ),
+                        None,
+                        arg.paramName
+                      )
                     )
-                  )
-              },
+                },
         arg =>
           elemType =>
-            if (arg.isFile) {
-              Target.pure(Param(None, None, q"Option(multipart.parts.filter(_.name.contains(${arg.argName.toLit})).map(_.body)).filter(_.nonEmpty)"))
-            } else
-              elemType match {
-                case t"String" =>
-                  Target.pure(
-                    Param(
-                      Some(
-                        enumerator"${Pat.Var(arg.paramName)} <- multipart.parts.filter(_.name.contains(${arg.argName.toLit})).map(_.body.through(utf8Decode).compile.foldMonoid).sequence.map(Option(_).filter(_.nonEmpty))"
-                      ),
-                      None,
-                      arg.paramName
+            _ =>
+              if (arg.isFile) {
+                Target.pure(Param(None, None, q"Option(multipart.parts.filter(_.name.contains(${arg.argName.toLit})).map(_.body)).filter(_.nonEmpty)"))
+              } else
+                elemType match {
+                  case t"String" =>
+                    Target.pure(
+                      Param(
+                        Some(
+                          enumerator"${Pat.Var(arg.paramName)} <- multipart.parts.filter(_.name.contains(${arg.argName.toLit})).map(_.body.through(utf8Decode).compile.foldMonoid).sequence.map(Option(_).filter(_.nonEmpty))"
+                        ),
+                        None,
+                        arg.paramName
+                      )
                     )
-                  )
-                case tpe =>
-                  Target.pure(
-                    Param(
-                      Some(
-                        enumerator"${Pat.Var(arg.paramName)} <- multipart.parts.filter(_.name.contains(${arg.argName.toLit})).map(_.body.through(utf8Decode).compile.foldMonoid.flatMap(str => F.fromEither(Json.fromString(str).as[$tpe]))).sequence.map(Option(_).filter(_.nonEmpty))"
-                      ),
-                      None,
-                      arg.paramName
+                  case tpe =>
+                    Target.pure(
+                      Param(
+                        Some(
+                          enumerator"${Pat.Var(arg.paramName)} <- multipart.parts.filter(_.name.contains(${arg.argName.toLit})).map(_.body.through(utf8Decode).compile.foldMonoid.flatMap(str => F.fromEither(Json.fromString(str).as[$tpe]))).sequence.map(Option(_).filter(_.nonEmpty))"
+                        ),
+                        None,
+                        arg.paramName
+                      )
                     )
-                  )
-              },
+                },
         arg =>
           elemType =>
             if (arg.isFile) {
@@ -679,7 +687,11 @@ object Http4sServerGenerator {
         .traverse({
           case LanguageParameter(_, param, _, argName, argType) =>
             val containerTransformations = Map[String, Term => Term](
-              "Iterable" -> identity _
+              "Iterable"   -> identity _,
+              "List"       -> (term => q"$term.toList"),
+              "Vector"     -> (term => q"$term.toVector"),
+              "Seq"        -> (term => q"$term.toSeq"),
+              "IndexedSeq" -> (term => q"$term.toIndexedSeq")
             )
             val matcherName = Term.Name(s"${operationId.capitalize}${argName.value.capitalize}Matcher")
             val (queryParamMatcher, elemType) = param match {
@@ -687,8 +699,8 @@ object Http4sServerGenerator {
                 (q"""
                   object ${matcherName} {
                     val delegate = new OptionalMultiQueryParamDecoderMatcher[$tpe](${argName.toLit}) {}
-                    def unapply(params: Map[String, Seq[String]]): Option[Option[List[$tpe]]] = delegate.unapply(params).collectFirst {
-                      case cats.data.Validated.Valid(value) => Option(value).filter(_.nonEmpty)
+                    def unapply(params: Map[String, Seq[String]]): Option[Option[$container[$tpe]]] = delegate.unapply(params).collectFirst {
+                      case cats.data.Validated.Valid(value) => Option(value).filter(_.nonEmpty).map(x => ${containerTransformations(container.syntax)(q"x")})
                     }
                   }
                  """, tpe)
@@ -696,8 +708,8 @@ object Http4sServerGenerator {
                 (q"""
                   object ${matcherName} {
                     val delegate = new OptionalMultiQueryParamDecoderMatcher[$tpe](${argName.toLit}) {}
-                    def unapply(params: Map[String, Seq[String]]): Option[Option[List[$tpe]]] = delegate.unapply(params).collectFirst {
-                      case cats.data.Validated.Valid(value) => Option(value).filter(_.nonEmpty)
+                    def unapply(params: Map[String, Seq[String]]): Option[Option[$container[$tpe]]] = delegate.unapply(params).collectFirst {
+                      case cats.data.Validated.Valid(value) => Option(value).filter(_.nonEmpty).map(x => ${containerTransformations(container.syntax)(q"x")})
                     }
                   }
                  """, tpe)
@@ -715,14 +727,18 @@ object Http4sServerGenerator {
                 (q"""
                    object ${matcherName} {
                      val delegate = new QueryParamDecoderMatcher[$tpe](${argName.toLit}) {}
-                     def unapply(params: Map[String, Seq[String]]): Option[Seq[String]] = delegate.unapplySeq(params)
+                     def unapply(params: Map[String, Seq[String]]): Option[$container[$tpe]] = delegate.unapplySeq(params).map(x => ${containerTransformations(
+                  container.syntax
+                )(q"x")})
                    }
                  """, tpe)
               case param"$_: $container[$tpe] = $_" if containerTransformations.contains(container.syntax) =>
                 (q"""
                    object ${matcherName} {
                      val delegate = new QueryParamDecoderMatcher[$tpe](${argName.toLit}) {}
-                     def unapply(params: Map[String, Seq[String]]): Option[Seq[String]] = delegate.unapplySeq(params)
+                     def unapply(params: Map[String, Seq[String]]): Option[$container[$tpe]] = delegate.unapplySeq(params).map(x => ${containerTransformations(
+                  container.syntax
+                )(q"x")})
                    }
                  """, tpe)
               case _ =>

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
@@ -205,8 +205,11 @@ object ScalaGenerator {
                   def addArg(key: String, v: T): String = f(key)(v)
                 }
 
-                implicit def addArgSeq[T](implicit ev: AddArg[T]): AddArg[List[T]] = build[List[T]](key => vs => vs.map(v => ev.addArg(key, v)).mkString("&"))
+                implicit def addArgSeq[T](implicit ev: AddArg[T]): AddArg[Seq[T]] = build[Seq[T]](key => vs => vs.map(v => ev.addArg(key, v)).mkString("&"))
+                implicit def addArgIndexedSeq[T](implicit ev: AddArg[T]): AddArg[IndexedSeq[T]] = build[IndexedSeq[T]](key => vs => vs.map(v => ev.addArg(key, v)).mkString("&"))
                 implicit def addArgIterable[T](implicit ev: AddArg[T]): AddArg[Iterable[T]] = build[Iterable[T]](key => vs => vs.map(v => ev.addArg(key, v)).mkString("&"))
+                implicit def addArgList[T](implicit ev: AddArg[T]): AddArg[List[T]] = build[List[T]](key => vs => vs.map(v => ev.addArg(key, v)).mkString("&"))
+                implicit def addArgVector[T](implicit ev: AddArg[T]): AddArg[Vector[T]] = build[Vector[T]](key => vs => vs.map(v => ev.addArg(key, v)).mkString("&"))
                 implicit def addArgOption[T](implicit ev: AddArg[T]): AddArg[Option[T]] = build[Option[T]](key => v => v.map(ev.addArg(key, _)).getOrElse(""))
               }
 

--- a/modules/sample/src/main/resources/issues/issue622.yaml
+++ b/modules/sample/src/main/resources/issues/issue622.yaml
@@ -1,0 +1,148 @@
+openapi: 3.0.2
+servers:
+  - url: "http://localhost:1234"
+paths:
+  /foo:
+    post:
+      operationId: doFoo
+      responses:
+        '204':
+          description: No response
+      parameters:
+        - name: refvec
+          in: query
+          required: true
+          schema:
+            $ref: "#!/components/schemas/refvec"
+        - name: reflist
+          in: query
+          required: true
+          schema:
+            $ref: "#!/components/schemas/reflist"
+        - name: refseq
+          in: query
+          required: true
+          schema:
+            $ref: "#!/components/schemas/refseq"
+        - name: refidxseq
+          in: query
+          required: true
+          schema:
+            $ref: "#!/components/schemas/refidxseq"
+        - name: vector
+          in: query
+          required: true
+          schema:
+            type: array
+            x-scala-array-type: Vector
+            items:
+              type: integer
+              format: int64
+        - name: list
+          in: query
+          required: true
+          schema:
+            type: array
+            x-scala-array-type: List
+            items:
+              type: integer
+              format: int64
+        - name: seq
+          in: query
+          required: true
+          schema:
+            type: array
+            x-scala-array-type: Seq
+            items:
+              type: integer
+              format: int64
+        - name: idxseq
+          in: query
+          required: true
+          schema:
+            type: array
+            x-scala-array-type: IndexedSeq
+            items:
+              type: integer
+              format: int64
+        - name: optrefvec
+          in: query
+          required: false
+          schema:
+            $ref: "#!/components/schemas/refvec"
+        - name: optreflist
+          in: query
+          required: false
+          schema:
+            $ref: "#!/components/schemas/reflist"
+        - name: optrefseq
+          in: query
+          required: false
+          schema:
+            $ref: "#!/components/schemas/refseq"
+        - name: optrefidxseq
+          in: query
+          required: false
+          schema:
+            $ref: "#!/components/schemas/refidxseq"
+        - name: optvector
+          in: query
+          required: false
+          schema:
+            type: array
+            x-scala-array-type: Vector
+            items:
+              type: integer
+              format: int64
+        - name: optlist
+          in: query
+          required: false
+          schema:
+            type: array
+            x-scala-array-type: List
+            items:
+              type: integer
+              format: int64
+        - name: optseq
+          in: query
+          required: false
+          schema:
+            type: array
+            x-scala-array-type: Seq
+            items:
+              type: integer
+              format: int64
+        - name: optidxseq
+          in: query
+          required: false
+          schema:
+            type: array
+            x-scala-array-type: IndexedSeq
+            items:
+              type: integer
+              format: int64
+components:
+  schemas:
+    refvec:
+      type: array
+      items:
+        type: integer
+        format: int64
+    reflist:
+      type: array
+      x-scala-array-type: List
+      items:
+        type: integer
+        format: int64
+    refseq:
+      type: array
+      x-scala-array-type: Seq
+      items:
+        type: integer
+        format: int64
+    refidxseq:
+      type: array
+      x-scala-array-type: IndexedSeq
+      items:
+        type: integer
+        format: int64


### PR DESCRIPTION
Resolves #622 

Verified in the console:

```
scala> implicitly[AddArg[Option[Vector[Long]]]]
res0: issues.issue622.Implicits.AddArg[Option[Vector[Long]]] = issues.issue622.Implicits$AddArg$$anon$1@269e559f

scala> res0.addArg
   def addArg(key: String,v: Option[Vector[Long]]): String

scala> res0.addArg("foo", Some(Vector(1, 2, 3, 4)))
res1: String = foo=1&foo=2&foo=3&foo=4
```

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
