### PR TITLE
Make circe enums extend Product & Serializable

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/CirceProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/CirceProtocolGenerator.scala
@@ -76,7 +76,7 @@ object CirceProtocolGenerator {
 
     def renderClass(clsName: String, tpe: scala.meta.Type, elems: List[(String, scala.meta.Term.Name, scala.meta.Term.Select)]) =
       Target.pure(q"""
-        sealed abstract class ${Type.Name(clsName)}(val value: ${tpe}) {
+        sealed abstract class ${Type.Name(clsName)}(val value: ${tpe}) extends Product with Serializable {
           override def toString: String = value.toString
         }
       """)

--- a/modules/codegen/src/test/scala/core/issues/Issue370.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue370.scala
@@ -66,7 +66,7 @@ class Issue370 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
             Encoder.AsObject.instance[Foo](a => JsonObject.fromIterable(Vector(("value", a.value.asJson), ("value2", a.value2.asJson), ("nested", a.nested.asJson)))).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
           }
           implicit val decodeFoo: Decoder[Foo] = new Decoder[Foo] { final def apply(c: HCursor): Decoder.Result[Foo] = for (v0 <- c.downField("value").as[Option[Foo.Value]]; v1 <- c.downField("value2").as[Baz]; v2 <- c.downField("nested").as[Option[Foo.Nested]]) yield Foo(v0, v1, v2) }
-          sealed abstract class Value(val value: String) { override def toString: String = value.toString }
+          sealed abstract class Value(val value: String) extends Product with Serializable { override def toString: String = value.toString }
           object Value {
             object members {
               case object A extends Value("a")
@@ -89,7 +89,7 @@ class Issue370 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
               Encoder.AsObject.instance[Nested](a => JsonObject.fromIterable(Vector(("value", a.value.asJson)))).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
             }
             implicit val decodeNested: Decoder[Nested] = new Decoder[Nested] { final def apply(c: HCursor): Decoder.Result[Nested] = for (v0 <- c.downField("value").as[Option[Foo.Nested.Value]]) yield Nested(v0) }
-            sealed abstract class Value(val value: String) { override def toString: String = value.toString }
+            sealed abstract class Value(val value: String) extends Product with Serializable { override def toString: String = value.toString }
             object Value {
               object members {
                 case object C extends Value("c")

--- a/modules/codegen/src/test/scala/core/issues/Issue43.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue43.scala
@@ -128,7 +128,7 @@ class Issue43 extends AnyFunSpec with Matchers with SwaggerSpecRunner {
             Encoder.AsObject.instance[Cat](a => JsonObject.fromIterable(Vector(("name", a.name.asJson), ("huntingSkill", a.huntingSkill.asJson)))).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
           }
           implicit val decodeCat: Decoder[Cat] = new Decoder[Cat] { final def apply(c: HCursor): Decoder.Result[Cat] = for (v0 <- c.downField("name").as[String]; v1 <- c.downField("huntingSkill").as[Cat.HuntingSkill]) yield Cat(v0, v1) }
-          sealed abstract class HuntingSkill(val value: String) { override def toString: String = value.toString }
+          sealed abstract class HuntingSkill(val value: String) extends Product with Serializable { override def toString: String = value.toString }
           object HuntingSkill {
             object members {
               case object Clueless extends HuntingSkill("clueless")

--- a/modules/codegen/src/test/scala/tests/core/BacktickTest.scala
+++ b/modules/codegen/src/test/scala/tests/core/BacktickTest.scala
@@ -183,7 +183,7 @@ class BacktickTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
     val cmp = companionForStaticDefns(staticDefns)
 
     val definition = q"""
-    sealed abstract class `dashy-enum`(val value: String) {
+    sealed abstract class `dashy-enum`(val value: String) extends Product with Serializable {
       override def toString: String = value.toString
     }
     """

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/DefinitionSpec.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/DefinitionSpec.scala
@@ -102,7 +102,7 @@ class DefinitionSpec extends AnyFunSuite with Matchers with SwaggerSpecRunner {
     val cmp = companionForStaticDefns(staticDefns)
 
     val definition = q"""
-    sealed abstract class Third(val value: String) {
+    sealed abstract class Third(val value: String) extends Product with Serializable {
       override def toString: String = value.toString
     }
     """

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/EnumTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/EnumTest.scala
@@ -63,7 +63,7 @@ class EnumTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
     val cmp = companionForStaticDefns(staticDefns)
 
     val definition = q"""
-    sealed abstract class Bar(val value: String) {
+    sealed abstract class Bar(val value: String) extends Product with Serializable {
       override def toString: String = value.toString
     }
     """


### PR DESCRIPTION
As recommended by https://nrinaudo.github.io/scala-best-practices/adts/product_with_serializable.html

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
