### PR TITLE
Path matcher before method matcher in Akka HTTP routes.

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpServerGenerator.scala
@@ -782,7 +782,7 @@ object AkkaHttpServerGenerator {
           val tracingMatcher = bindParams(tracingFields.map(t => (t.term, List(t.param.paramName))).toList)
           val bodyMatcher    = bindParams(List((entityProcessor, (bodyArgs.toList ++ formArgs).map(_.paramName))))
 
-          methodMatcher compose pathMatcher compose qsMatcher compose headerMatcher compose tracingMatcher compose bodyMatcher
+          pathMatcher compose methodMatcher compose qsMatcher compose headerMatcher compose tracingMatcher compose bodyMatcher
         }
         handlerCallArgs = List(List(responseCompanionTerm)) ++ orderedParameters.map(_.map(_.paramName))
         fullRoute       = Term.Block(List(fullRouteMatcher(q"complete(handler.${Term.Name(operationId)}(...${handlerCallArgs}))")))

--- a/modules/codegen/src/test/scala/core/issues/Issue126.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue126.scala
@@ -38,7 +38,7 @@ class Issue126 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
       object StoreResource {
         def routes(handler: StoreHandler)(implicit mat: akka.stream.Materializer): Route = {
           {
-            options(pathEndOrSingleSlash(discardEntity(complete(handler.getRoot(getRootResponse)()))))
+            pathEndOrSingleSlash(options(discardEntity(complete(handler.getRoot(getRootResponse)()))))
           }
         }
         sealed abstract class getRootResponse(val statusCode: StatusCode)

--- a/modules/codegen/src/test/scala/core/issues/Issue127.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue127.scala
@@ -71,7 +71,7 @@ class Issue127 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
       object Resource {
         def routes(handler: Handler)(implicit mat: akka.stream.Materializer): Route = {
           {
-            post(path("file")(({
+            path("file")(post(({
               object uploadFileParts {
                 sealed trait Part
                 case class IgnoredPart(unit: Unit) extends Part

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/AkkaHttpServerTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/AkkaHttpServerTest.scala
@@ -144,15 +144,15 @@ class AkkaHttpServerTest extends AnyFunSuite with Matchers with SwaggerSpecRunne
       object StoreResource {
         def routes(handler: StoreHandler)(implicit mat: akka.stream.Materializer): Route = {
           {
-            get(pathEndOrSingleSlash(discardEntity(complete(handler.getRoot(getRootResponse)()))))
+            pathEndOrSingleSlash(get(discardEntity(complete(handler.getRoot(getRootResponse)()))))
           } ~ {
-            put(path("bar")(parameter(Symbol("bar").as[Long]).apply(bar => discardEntity(complete(handler.putBar(putBarResponse)(bar))))))
+            path("bar")(put(parameter(Symbol("bar").as[Long]).apply(bar => discardEntity(complete(handler.putBar(putBarResponse)(bar))))))
           } ~ {
-            get((pathPrefix("foo") & pathEndOrSingleSlash)(discardEntity(complete(handler.getFoo(getFooResponse)()))))
+            (pathPrefix("foo") & pathEndOrSingleSlash)(get(discardEntity(complete(handler.getFoo(getFooResponse)()))))
           } ~ {
-            get(path("foo" / LongNumber).apply(bar => discardEntity(complete(handler.getFooBar(getFooBarResponse)(bar)))))
+            path("foo" / LongNumber).apply(bar => get(discardEntity(complete(handler.getFooBar(getFooBarResponse)(bar)))))
           } ~ {
-            get(path("store" / "order" / LongNumber).apply(orderId => parameter(Symbol("status").as[OrderStatus](stringyJsonUnmarshaller.andThen(unmarshallJson[OrderStatus]))).apply(status => discardEntity(complete(handler.getOrderById(getOrderByIdResponse)(orderId, status))))))
+            path("store" / "order" / LongNumber).apply(orderId => get(parameter(Symbol("status").as[OrderStatus](stringyJsonUnmarshaller.andThen(unmarshallJson[OrderStatus]))).apply(status => discardEntity(complete(handler.getOrderById(getOrderByIdResponse)(orderId, status))))))
           }
         }
         sealed abstract class getRootResponse(val statusCode: StatusCode)
@@ -281,15 +281,15 @@ class AkkaHttpServerTest extends AnyFunSuite with Matchers with SwaggerSpecRunne
       object StoreResource {
         def routes(handler: StoreHandler, trace: String => Directive1[TraceBuilder])(implicit mat: akka.stream.Materializer): Route = {
           {
-            get(pathEndOrSingleSlash(trace("store:getRoot").apply(traceBuilder => discardEntity(complete(handler.getRoot(getRootResponse)()(traceBuilder))))))
+            pathEndOrSingleSlash(get(trace("store:getRoot").apply(traceBuilder => discardEntity(complete(handler.getRoot(getRootResponse)()(traceBuilder))))))
           } ~ {
-            put(path("bar")(parameter(Symbol("bar").as[Long]).apply(bar => trace("store:putBar").apply(traceBuilder => discardEntity(complete(handler.putBar(putBarResponse)(bar)(traceBuilder)))))))
+            path("bar")(put(parameter(Symbol("bar").as[Long]).apply(bar => trace("store:putBar").apply(traceBuilder => discardEntity(complete(handler.putBar(putBarResponse)(bar)(traceBuilder)))))))
           } ~ {
-            get((pathPrefix("foo") & pathEndOrSingleSlash)(trace("store:getFoo").apply(traceBuilder => discardEntity(complete(handler.getFoo(getFooResponse)()(traceBuilder))))))
+            (pathPrefix("foo") & pathEndOrSingleSlash)(get(trace("store:getFoo").apply(traceBuilder => discardEntity(complete(handler.getFoo(getFooResponse)()(traceBuilder))))))
           } ~ {
-            get(path("foo" / LongNumber).apply(bar => trace("completely-custom-label").apply(traceBuilder => discardEntity(complete(handler.getFooBar(getFooBarResponse)(bar)(traceBuilder))))))
+            path("foo" / LongNumber).apply(bar => get(trace("completely-custom-label").apply(traceBuilder => discardEntity(complete(handler.getFooBar(getFooBarResponse)(bar)(traceBuilder))))))
           } ~ {
-            get(path("store" / "order" / LongNumber).apply(orderId => parameter(Symbol("status").as[OrderStatus](stringyJsonUnmarshaller.andThen(unmarshallJson[OrderStatus]))).apply(status => trace("store:getOrderById").apply(traceBuilder => discardEntity(complete(handler.getOrderById(getOrderByIdResponse)(orderId, status)(traceBuilder)))))))
+            path("store" / "order" / LongNumber).apply(orderId => get(parameter(Symbol("status").as[OrderStatus](stringyJsonUnmarshaller.andThen(unmarshallJson[OrderStatus]))).apply(status => trace("store:getOrderById").apply(traceBuilder => discardEntity(complete(handler.getOrderById(getOrderByIdResponse)(orderId, status)(traceBuilder)))))))
           }
         }
         sealed abstract class getRootResponse(val statusCode: StatusCode)

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/CustomHeaderTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/CustomHeaderTest.scala
@@ -50,7 +50,7 @@ class CustomHeaderTest extends AnyFunSuite with Matchers with SwaggerSpecRunner 
       object Resource {
         def routes(handler: Handler)(implicit mat: akka.stream.Materializer): Route = {
           {
-            get(path("foo")(headerValueByName("CustomHeader").flatMap(str => onComplete(Unmarshal(str).to[Bar](stringyJsonUnmarshaller.andThen(unmarshallJson[Bar]), mat.executionContext, mat)).flatMap[Tuple1[Bar]]({
+            path("foo")(get(headerValueByName("CustomHeader").flatMap(str => onComplete(Unmarshal(str).to[Bar](stringyJsonUnmarshaller.andThen(unmarshallJson[Bar]), mat.executionContext, mat)).flatMap[Tuple1[Bar]]({
               case Failure(e) =>
                 reject(MalformedHeaderRejection("CustomHeader", e.getMessage, Some(e)))
               case Success(x) =>

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/StaticParametersTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/StaticParametersTest.scala
@@ -46,9 +46,9 @@ class StaticParametersTest extends AnyFunSuite with Matchers with SwaggerSpecRun
       object Resource {
         def routes(handler: Handler)(implicit mat: akka.stream.Materializer): Route = {
           {
-            get((pathPrefix("foo") & pathEndOrSingleSlash & parameter("bar").require(_ == "2"))(discardEntity(complete(handler.getFoo2(getFoo2Response)()))))
+            (pathPrefix("foo") & pathEndOrSingleSlash & parameter("bar").require(_ == "2"))(get(discardEntity(complete(handler.getFoo2(getFoo2Response)()))))
           } ~ {
-            get((path("foo") & parameter("bar").require(_ == "1"))(discardEntity(complete(handler.getFoo1(getFoo1Response)()))))
+            (path("foo") & parameter("bar").require(_ == "1"))(get(discardEntity(complete(handler.getFoo1(getFoo1Response)()))))
           }
         }
         sealed abstract class getFoo2Response(val statusCode: StatusCode)

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
@@ -82,7 +82,7 @@ class FormFieldsServerTest extends AnyFunSuite with Matchers with SwaggerSpecRun
       object Resource {
         def routes(handler: Handler)(implicit mat: akka.stream.Materializer): Route = {
           {
-            put(path("foo")(({
+            path("foo")(put(({
               object putFooParts {
                 sealed trait Part
                 case class IgnoredPart(unit: Unit) extends Part


### PR DESCRIPTION
This addresses #643 I believe.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
