### PR TITLE
Quoting issue

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/package.scala
@@ -63,7 +63,7 @@ package object syntax {
   private val SPLIT_DELIMITERS = "[-_\\s\\.]+".r
   private val BOUNDARY_SPLITTERS = List(
     "([^A-Z])([A-Z])".r,
-    "([A-Z]+)([A-Z][^A-Z]+)".r
+    "([A-Z]+)([A-Z][a-z]+)".r
   )
 
   implicit class RichString(private val s: String) extends AnyVal {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/package.scala
@@ -2,6 +2,7 @@ package com.twilio.guardrail.generators
 
 import cats.data.NonEmptyList
 import java.util.Locale
+import java.util.regex.Matcher.quoteReplacement
 import io.swagger.v3.oas.models.{ Operation, PathItem }
 import io.swagger.v3.oas.models.media.Schema
 import io.swagger.v3.oas.models.parameters.Parameter
@@ -69,7 +70,7 @@ package object syntax {
     private def splitParts(s: String): List[String] =
       BOUNDARY_SPLITTERS
         .foldLeft(SPLIT_DELIMITERS.split(s))(
-          (last, splitter) => last.flatMap(part => splitter.replaceAllIn(part, m => m.group(1) + "-" + m.group(2)).split("-"))
+          (last, splitter) => last.flatMap(part => splitter.replaceAllIn(part, m => quoteReplacement(m.group(1) + "-" + m.group(2))).split("-"))
         )
         .map(_.toLowerCase(Locale.US))
         .toList

--- a/modules/codegen/src/test/scala/tests/core/CaseConvertersTest.scala
+++ b/modules/codegen/src/test/scala/tests/core/CaseConvertersTest.scala
@@ -31,7 +31,8 @@ object CaseConvertersTest {
     CaseTest("FOO BAR BAZ", "FooBarBaz", "fooBarBaz", "foo_bar_baz", "foo-bar-baz"),
     CaseTest("FOO BAR bazQuux", "FooBarBazQuux", "fooBarBazQuux", "foo_bar_baz_quux", "foo-bar-baz-quux"),
     CaseTest("FOOBarBaz", "FooBarBaz", "fooBarBaz", "foo_bar_baz", "foo-bar-baz"),
-    CaseTest("FooBARBaz", "FooBarBaz", "fooBarBaz", "foo_bar_baz", "foo-bar-baz")
+    CaseTest("FooBARBaz", "FooBarBaz", "fooBarBaz", "foo_bar_baz", "foo-bar-baz"),
+    CaseTest("UNITS_USD$3", "UnitsUsd$3", "unitsUsd$3", "units_usd$3", "units-usd$3")
   )
 }
 


### PR DESCRIPTION
Turns out the casing normalization code attempts to interpolate groups. `$1`/`$2`... etc turn out not to be escaped, causing unexpected oddities.

The generated names are stable, if not odd, so the underlying protocol is not impacted, but the generated interface is unpleasant.

This also addresses an edge case where `[A-Z][^A-Z]`, _intended_ to catch `ABCFoo`, turning it into `abcFoo`, ends up with `ABCFOO$` into `AbcfoO$`, which makes sense, but is odd.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
