### PR TITLE
Add afterPathMethodMatch hook to generated Akka HTTP routes.

### DIFF
--- a/modules/codegen/src/test/scala/core/issues/Issue126.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue126.scala
@@ -36,9 +36,9 @@ class Issue126 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
     """
     val resource = q"""
       object StoreResource {
-        def routes(handler: StoreHandler, afterPathMethodMatch: Directive0 = pass)(implicit mat: akka.stream.Materializer): Route = {
+        def routes(handler: StoreHandler, afterPathMethodMatch: String => Directive0 = _ => pass)(implicit mat: akka.stream.Materializer): Route = {
           {
-            pathEndOrSingleSlash(options(afterPathMethodMatch(discardEntity(complete(handler.getRoot(getRootResponse)())))))
+            pathEndOrSingleSlash(options(afterPathMethodMatch("getRoot")(discardEntity(complete(handler.getRoot(getRootResponse)())))))
           }
         }
         sealed abstract class getRootResponse(val statusCode: StatusCode)

--- a/modules/codegen/src/test/scala/core/issues/Issue126.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue126.scala
@@ -36,9 +36,9 @@ class Issue126 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
     """
     val resource = q"""
       object StoreResource {
-        def routes(handler: StoreHandler)(implicit mat: akka.stream.Materializer): Route = {
+        def routes(handler: StoreHandler, beforeComplete: Directive0 = pass)(implicit mat: akka.stream.Materializer): Route = {
           {
-            pathEndOrSingleSlash(options(discardEntity(complete(handler.getRoot(getRootResponse)()))))
+            pathEndOrSingleSlash(options(discardEntity(beforeComplete(complete(handler.getRoot(getRootResponse)())))))
           }
         }
         sealed abstract class getRootResponse(val statusCode: StatusCode)

--- a/modules/codegen/src/test/scala/core/issues/Issue126.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue126.scala
@@ -36,9 +36,9 @@ class Issue126 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
     """
     val resource = q"""
       object StoreResource {
-        def routes(handler: StoreHandler, beforeComplete: Directive0 = pass)(implicit mat: akka.stream.Materializer): Route = {
+        def routes(handler: StoreHandler, afterPathMethodMatch: Directive0 = pass)(implicit mat: akka.stream.Materializer): Route = {
           {
-            pathEndOrSingleSlash(options(discardEntity(beforeComplete(complete(handler.getRoot(getRootResponse)())))))
+            pathEndOrSingleSlash(options(afterPathMethodMatch(discardEntity(complete(handler.getRoot(getRootResponse)())))))
           }
         }
         sealed abstract class getRootResponse(val statusCode: StatusCode)

--- a/modules/codegen/src/test/scala/core/issues/Issue127.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue127.scala
@@ -69,9 +69,9 @@ class Issue127 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
 
     val resource = q"""
       object Resource {
-        def routes(handler: Handler, beforeComplete: Directive0 = pass)(implicit mat: akka.stream.Materializer): Route = {
+        def routes(handler: Handler, afterPathMethodMatch: Directive0 = pass)(implicit mat: akka.stream.Materializer): Route = {
           {
-            path("file")(post(({
+            path("file")(post(afterPathMethodMatch(({
               object uploadFileParts {
                 sealed trait Part
                 case class IgnoredPart(unit: Unit) extends Part
@@ -142,7 +142,7 @@ class Issue127 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
                   }
                   maybe.fold(reject(_), tprovide(_))
               }))
-            }: Directive[Tuple1[(File, Option[String], ContentType)]]).apply(file => beforeComplete(complete(handler.uploadFile(uploadFileResponse)(file))))))
+            }: Directive[Tuple1[(File, Option[String], ContentType)]]).apply(file => complete(handler.uploadFile(uploadFileResponse)(file))))))
           }
         }
         sealed abstract class uploadFileResponse(val statusCode: StatusCode)

--- a/modules/codegen/src/test/scala/core/issues/Issue127.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue127.scala
@@ -69,9 +69,9 @@ class Issue127 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
 
     val resource = q"""
       object Resource {
-        def routes(handler: Handler, afterPathMethodMatch: Directive0 = pass)(implicit mat: akka.stream.Materializer): Route = {
+        def routes(handler: Handler, afterPathMethodMatch: String => Directive0 = _ => pass)(implicit mat: akka.stream.Materializer): Route = {
           {
-            path("file")(post(afterPathMethodMatch(({
+            path("file")(post(afterPathMethodMatch("uploadFile")(({
               object uploadFileParts {
                 sealed trait Part
                 case class IgnoredPart(unit: Unit) extends Part

--- a/modules/codegen/src/test/scala/core/issues/Issue127.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue127.scala
@@ -69,7 +69,7 @@ class Issue127 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
 
     val resource = q"""
       object Resource {
-        def routes(handler: Handler)(implicit mat: akka.stream.Materializer): Route = {
+        def routes(handler: Handler, beforeComplete: Directive0 = pass)(implicit mat: akka.stream.Materializer): Route = {
           {
             path("file")(post(({
               object uploadFileParts {
@@ -142,7 +142,7 @@ class Issue127 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
                   }
                   maybe.fold(reject(_), tprovide(_))
               }))
-            }: Directive[Tuple1[(File, Option[String], ContentType)]]).apply(file => complete(handler.uploadFile(uploadFileResponse)(file)))))
+            }: Directive[Tuple1[(File, Option[String], ContentType)]]).apply(file => beforeComplete(complete(handler.uploadFile(uploadFileResponse)(file))))))
           }
         }
         sealed abstract class uploadFileResponse(val statusCode: StatusCode)

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/AkkaHttpServerTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/AkkaHttpServerTest.scala
@@ -142,17 +142,17 @@ class AkkaHttpServerTest extends AnyFunSuite with Matchers with SwaggerSpecRunne
     """
     val resource = q"""
       object StoreResource {
-        def routes(handler: StoreHandler, beforeComplete: Directive0 = pass)(implicit mat: akka.stream.Materializer): Route = {
+        def routes(handler: StoreHandler, afterPathMethodMatch: Directive0 = pass)(implicit mat: akka.stream.Materializer): Route = {
           {
-            pathEndOrSingleSlash(get(discardEntity(beforeComplete(complete(handler.getRoot(getRootResponse)())))))
+            pathEndOrSingleSlash(get(afterPathMethodMatch(discardEntity(complete(handler.getRoot(getRootResponse)())))))
           } ~ {
-            path("bar")(put(parameter(Symbol("bar").as[Long]).apply(bar => discardEntity(beforeComplete(complete(handler.putBar(putBarResponse)(bar)))))))
+            path("bar")(put(afterPathMethodMatch(parameter(Symbol("bar").as[Long]).apply(bar => discardEntity(complete(handler.putBar(putBarResponse)(bar)))))))
           } ~ {
-            (pathPrefix("foo") & pathEndOrSingleSlash)(get(discardEntity(beforeComplete(complete(handler.getFoo(getFooResponse)())))))
+            (pathPrefix("foo") & pathEndOrSingleSlash)(get(afterPathMethodMatch(discardEntity(complete(handler.getFoo(getFooResponse)())))))
           } ~ {
-            path("foo" / LongNumber).apply(bar => get(discardEntity(beforeComplete(complete(handler.getFooBar(getFooBarResponse)(bar))))))
+            path("foo" / LongNumber).apply(bar => get(afterPathMethodMatch(discardEntity(complete(handler.getFooBar(getFooBarResponse)(bar))))))
           } ~ {
-            path("store" / "order" / LongNumber).apply(orderId => get(parameter(Symbol("status").as[OrderStatus](stringyJsonUnmarshaller.andThen(unmarshallJson[OrderStatus]))).apply(status => discardEntity(beforeComplete(complete(handler.getOrderById(getOrderByIdResponse)(orderId, status)))))))
+            path("store" / "order" / LongNumber).apply(orderId => get(afterPathMethodMatch(parameter(Symbol("status").as[OrderStatus](stringyJsonUnmarshaller.andThen(unmarshallJson[OrderStatus]))).apply(status => discardEntity(complete(handler.getOrderById(getOrderByIdResponse)(orderId, status)))))))
           }
         }
         sealed abstract class getRootResponse(val statusCode: StatusCode)
@@ -279,17 +279,17 @@ class AkkaHttpServerTest extends AnyFunSuite with Matchers with SwaggerSpecRunne
     """
     val resource = q"""
       object StoreResource {
-        def routes(handler: StoreHandler, trace: String => Directive1[TraceBuilder], beforeComplete: Directive0 = pass)(implicit mat: akka.stream.Materializer): Route = {
+        def routes(handler: StoreHandler, trace: String => Directive1[TraceBuilder], afterPathMethodMatch: Directive0 = pass)(implicit mat: akka.stream.Materializer): Route = {
           {
-            pathEndOrSingleSlash(get(trace("store:getRoot").apply(traceBuilder => discardEntity(beforeComplete(complete(handler.getRoot(getRootResponse)()(traceBuilder)))))))
+            pathEndOrSingleSlash(get(afterPathMethodMatch(trace("store:getRoot").apply(traceBuilder => discardEntity(complete(handler.getRoot(getRootResponse)()(traceBuilder)))))))
           } ~ {
-            path("bar")(put(parameter(Symbol("bar").as[Long]).apply(bar => trace("store:putBar").apply(traceBuilder => discardEntity(beforeComplete(complete(handler.putBar(putBarResponse)(bar)(traceBuilder))))))))
+            path("bar")(put(afterPathMethodMatch(parameter(Symbol("bar").as[Long]).apply(bar => trace("store:putBar").apply(traceBuilder => discardEntity(complete(handler.putBar(putBarResponse)(bar)(traceBuilder))))))))
           } ~ {
-            (pathPrefix("foo") & pathEndOrSingleSlash)(get(trace("store:getFoo").apply(traceBuilder => discardEntity(beforeComplete(complete(handler.getFoo(getFooResponse)()(traceBuilder)))))))
+            (pathPrefix("foo") & pathEndOrSingleSlash)(get(afterPathMethodMatch(trace("store:getFoo").apply(traceBuilder => discardEntity(complete(handler.getFoo(getFooResponse)()(traceBuilder)))))))
           } ~ {
-            path("foo" / LongNumber).apply(bar => get(trace("completely-custom-label").apply(traceBuilder => discardEntity(beforeComplete(complete(handler.getFooBar(getFooBarResponse)(bar)(traceBuilder)))))))
+            path("foo" / LongNumber).apply(bar => get(afterPathMethodMatch(trace("completely-custom-label").apply(traceBuilder => discardEntity(complete(handler.getFooBar(getFooBarResponse)(bar)(traceBuilder)))))))
           } ~ {
-            path("store" / "order" / LongNumber).apply(orderId => get(parameter(Symbol("status").as[OrderStatus](stringyJsonUnmarshaller.andThen(unmarshallJson[OrderStatus]))).apply(status => trace("store:getOrderById").apply(traceBuilder => discardEntity(beforeComplete(complete(handler.getOrderById(getOrderByIdResponse)(orderId, status)(traceBuilder))))))))
+            path("store" / "order" / LongNumber).apply(orderId => get(afterPathMethodMatch(parameter(Symbol("status").as[OrderStatus](stringyJsonUnmarshaller.andThen(unmarshallJson[OrderStatus]))).apply(status => trace("store:getOrderById").apply(traceBuilder => discardEntity(complete(handler.getOrderById(getOrderByIdResponse)(orderId, status)(traceBuilder))))))))
           }
         }
         sealed abstract class getRootResponse(val statusCode: StatusCode)

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/AkkaHttpServerTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/AkkaHttpServerTest.scala
@@ -142,17 +142,17 @@ class AkkaHttpServerTest extends AnyFunSuite with Matchers with SwaggerSpecRunne
     """
     val resource = q"""
       object StoreResource {
-        def routes(handler: StoreHandler)(implicit mat: akka.stream.Materializer): Route = {
+        def routes(handler: StoreHandler, beforeComplete: Directive0 = pass)(implicit mat: akka.stream.Materializer): Route = {
           {
-            pathEndOrSingleSlash(get(discardEntity(complete(handler.getRoot(getRootResponse)()))))
+            pathEndOrSingleSlash(get(discardEntity(beforeComplete(complete(handler.getRoot(getRootResponse)())))))
           } ~ {
-            path("bar")(put(parameter(Symbol("bar").as[Long]).apply(bar => discardEntity(complete(handler.putBar(putBarResponse)(bar))))))
+            path("bar")(put(parameter(Symbol("bar").as[Long]).apply(bar => discardEntity(beforeComplete(complete(handler.putBar(putBarResponse)(bar)))))))
           } ~ {
-            (pathPrefix("foo") & pathEndOrSingleSlash)(get(discardEntity(complete(handler.getFoo(getFooResponse)()))))
+            (pathPrefix("foo") & pathEndOrSingleSlash)(get(discardEntity(beforeComplete(complete(handler.getFoo(getFooResponse)())))))
           } ~ {
-            path("foo" / LongNumber).apply(bar => get(discardEntity(complete(handler.getFooBar(getFooBarResponse)(bar)))))
+            path("foo" / LongNumber).apply(bar => get(discardEntity(beforeComplete(complete(handler.getFooBar(getFooBarResponse)(bar))))))
           } ~ {
-            path("store" / "order" / LongNumber).apply(orderId => get(parameter(Symbol("status").as[OrderStatus](stringyJsonUnmarshaller.andThen(unmarshallJson[OrderStatus]))).apply(status => discardEntity(complete(handler.getOrderById(getOrderByIdResponse)(orderId, status))))))
+            path("store" / "order" / LongNumber).apply(orderId => get(parameter(Symbol("status").as[OrderStatus](stringyJsonUnmarshaller.andThen(unmarshallJson[OrderStatus]))).apply(status => discardEntity(beforeComplete(complete(handler.getOrderById(getOrderByIdResponse)(orderId, status)))))))
           }
         }
         sealed abstract class getRootResponse(val statusCode: StatusCode)
@@ -279,17 +279,17 @@ class AkkaHttpServerTest extends AnyFunSuite with Matchers with SwaggerSpecRunne
     """
     val resource = q"""
       object StoreResource {
-        def routes(handler: StoreHandler, trace: String => Directive1[TraceBuilder])(implicit mat: akka.stream.Materializer): Route = {
+        def routes(handler: StoreHandler, trace: String => Directive1[TraceBuilder], beforeComplete: Directive0 = pass)(implicit mat: akka.stream.Materializer): Route = {
           {
-            pathEndOrSingleSlash(get(trace("store:getRoot").apply(traceBuilder => discardEntity(complete(handler.getRoot(getRootResponse)()(traceBuilder))))))
+            pathEndOrSingleSlash(get(trace("store:getRoot").apply(traceBuilder => discardEntity(beforeComplete(complete(handler.getRoot(getRootResponse)()(traceBuilder)))))))
           } ~ {
-            path("bar")(put(parameter(Symbol("bar").as[Long]).apply(bar => trace("store:putBar").apply(traceBuilder => discardEntity(complete(handler.putBar(putBarResponse)(bar)(traceBuilder)))))))
+            path("bar")(put(parameter(Symbol("bar").as[Long]).apply(bar => trace("store:putBar").apply(traceBuilder => discardEntity(beforeComplete(complete(handler.putBar(putBarResponse)(bar)(traceBuilder))))))))
           } ~ {
-            (pathPrefix("foo") & pathEndOrSingleSlash)(get(trace("store:getFoo").apply(traceBuilder => discardEntity(complete(handler.getFoo(getFooResponse)()(traceBuilder))))))
+            (pathPrefix("foo") & pathEndOrSingleSlash)(get(trace("store:getFoo").apply(traceBuilder => discardEntity(beforeComplete(complete(handler.getFoo(getFooResponse)()(traceBuilder)))))))
           } ~ {
-            path("foo" / LongNumber).apply(bar => get(trace("completely-custom-label").apply(traceBuilder => discardEntity(complete(handler.getFooBar(getFooBarResponse)(bar)(traceBuilder))))))
+            path("foo" / LongNumber).apply(bar => get(trace("completely-custom-label").apply(traceBuilder => discardEntity(beforeComplete(complete(handler.getFooBar(getFooBarResponse)(bar)(traceBuilder)))))))
           } ~ {
-            path("store" / "order" / LongNumber).apply(orderId => get(parameter(Symbol("status").as[OrderStatus](stringyJsonUnmarshaller.andThen(unmarshallJson[OrderStatus]))).apply(status => trace("store:getOrderById").apply(traceBuilder => discardEntity(complete(handler.getOrderById(getOrderByIdResponse)(orderId, status)(traceBuilder)))))))
+            path("store" / "order" / LongNumber).apply(orderId => get(parameter(Symbol("status").as[OrderStatus](stringyJsonUnmarshaller.andThen(unmarshallJson[OrderStatus]))).apply(status => trace("store:getOrderById").apply(traceBuilder => discardEntity(beforeComplete(complete(handler.getOrderById(getOrderByIdResponse)(orderId, status)(traceBuilder))))))))
           }
         }
         sealed abstract class getRootResponse(val statusCode: StatusCode)

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/AkkaHttpServerTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/AkkaHttpServerTest.scala
@@ -142,17 +142,17 @@ class AkkaHttpServerTest extends AnyFunSuite with Matchers with SwaggerSpecRunne
     """
     val resource = q"""
       object StoreResource {
-        def routes(handler: StoreHandler, afterPathMethodMatch: Directive0 = pass)(implicit mat: akka.stream.Materializer): Route = {
+        def routes(handler: StoreHandler, afterPathMethodMatch: String => Directive0 = _ => pass)(implicit mat: akka.stream.Materializer): Route = {
           {
-            pathEndOrSingleSlash(get(afterPathMethodMatch(discardEntity(complete(handler.getRoot(getRootResponse)())))))
+            pathEndOrSingleSlash(get(afterPathMethodMatch("getRoot")(discardEntity(complete(handler.getRoot(getRootResponse)())))))
           } ~ {
-            path("bar")(put(afterPathMethodMatch(parameter(Symbol("bar").as[Long]).apply(bar => discardEntity(complete(handler.putBar(putBarResponse)(bar)))))))
+            path("bar")(put(afterPathMethodMatch("putBar")(parameter(Symbol("bar").as[Long]).apply(bar => discardEntity(complete(handler.putBar(putBarResponse)(bar)))))))
           } ~ {
-            (pathPrefix("foo") & pathEndOrSingleSlash)(get(afterPathMethodMatch(discardEntity(complete(handler.getFoo(getFooResponse)())))))
+            (pathPrefix("foo") & pathEndOrSingleSlash)(get(afterPathMethodMatch("getFoo")(discardEntity(complete(handler.getFoo(getFooResponse)())))))
           } ~ {
-            path("foo" / LongNumber).apply(bar => get(afterPathMethodMatch(discardEntity(complete(handler.getFooBar(getFooBarResponse)(bar))))))
+            path("foo" / LongNumber).apply(bar => get(afterPathMethodMatch("getFooBar")(discardEntity(complete(handler.getFooBar(getFooBarResponse)(bar))))))
           } ~ {
-            path("store" / "order" / LongNumber).apply(orderId => get(afterPathMethodMatch(parameter(Symbol("status").as[OrderStatus](stringyJsonUnmarshaller.andThen(unmarshallJson[OrderStatus]))).apply(status => discardEntity(complete(handler.getOrderById(getOrderByIdResponse)(orderId, status)))))))
+            path("store" / "order" / LongNumber).apply(orderId => get(afterPathMethodMatch("getOrderById")(parameter(Symbol("status").as[OrderStatus](stringyJsonUnmarshaller.andThen(unmarshallJson[OrderStatus]))).apply(status => discardEntity(complete(handler.getOrderById(getOrderByIdResponse)(orderId, status)))))))
           }
         }
         sealed abstract class getRootResponse(val statusCode: StatusCode)
@@ -279,17 +279,17 @@ class AkkaHttpServerTest extends AnyFunSuite with Matchers with SwaggerSpecRunne
     """
     val resource = q"""
       object StoreResource {
-        def routes(handler: StoreHandler, trace: String => Directive1[TraceBuilder], afterPathMethodMatch: Directive0 = pass)(implicit mat: akka.stream.Materializer): Route = {
+        def routes(handler: StoreHandler, trace: String => Directive1[TraceBuilder], afterPathMethodMatch: String => Directive0 = _ => pass)(implicit mat: akka.stream.Materializer): Route = {
           {
-            pathEndOrSingleSlash(get(afterPathMethodMatch(trace("store:getRoot").apply(traceBuilder => discardEntity(complete(handler.getRoot(getRootResponse)()(traceBuilder)))))))
+            pathEndOrSingleSlash(get(afterPathMethodMatch("getRoot")(trace("store:getRoot").apply(traceBuilder => discardEntity(complete(handler.getRoot(getRootResponse)()(traceBuilder)))))))
           } ~ {
-            path("bar")(put(afterPathMethodMatch(parameter(Symbol("bar").as[Long]).apply(bar => trace("store:putBar").apply(traceBuilder => discardEntity(complete(handler.putBar(putBarResponse)(bar)(traceBuilder))))))))
+            path("bar")(put(afterPathMethodMatch("putBar")(parameter(Symbol("bar").as[Long]).apply(bar => trace("store:putBar").apply(traceBuilder => discardEntity(complete(handler.putBar(putBarResponse)(bar)(traceBuilder))))))))
           } ~ {
-            (pathPrefix("foo") & pathEndOrSingleSlash)(get(afterPathMethodMatch(trace("store:getFoo").apply(traceBuilder => discardEntity(complete(handler.getFoo(getFooResponse)()(traceBuilder)))))))
+            (pathPrefix("foo") & pathEndOrSingleSlash)(get(afterPathMethodMatch("getFoo")(trace("store:getFoo").apply(traceBuilder => discardEntity(complete(handler.getFoo(getFooResponse)()(traceBuilder)))))))
           } ~ {
-            path("foo" / LongNumber).apply(bar => get(afterPathMethodMatch(trace("completely-custom-label").apply(traceBuilder => discardEntity(complete(handler.getFooBar(getFooBarResponse)(bar)(traceBuilder)))))))
+            path("foo" / LongNumber).apply(bar => get(afterPathMethodMatch("getFooBar")(trace("completely-custom-label").apply(traceBuilder => discardEntity(complete(handler.getFooBar(getFooBarResponse)(bar)(traceBuilder)))))))
           } ~ {
-            path("store" / "order" / LongNumber).apply(orderId => get(afterPathMethodMatch(parameter(Symbol("status").as[OrderStatus](stringyJsonUnmarshaller.andThen(unmarshallJson[OrderStatus]))).apply(status => trace("store:getOrderById").apply(traceBuilder => discardEntity(complete(handler.getOrderById(getOrderByIdResponse)(orderId, status)(traceBuilder))))))))
+            path("store" / "order" / LongNumber).apply(orderId => get(afterPathMethodMatch("getOrderById")(parameter(Symbol("status").as[OrderStatus](stringyJsonUnmarshaller.andThen(unmarshallJson[OrderStatus]))).apply(status => trace("store:getOrderById").apply(traceBuilder => discardEntity(complete(handler.getOrderById(getOrderByIdResponse)(orderId, status)(traceBuilder))))))))
           }
         }
         sealed abstract class getRootResponse(val statusCode: StatusCode)

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/CustomHeaderTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/CustomHeaderTest.scala
@@ -48,14 +48,14 @@ class CustomHeaderTest extends AnyFunSuite with Matchers with SwaggerSpecRunner 
 
     val resource = q"""
       object Resource {
-        def routes(handler: Handler, beforeComplete: Directive0 = pass)(implicit mat: akka.stream.Materializer): Route = {
+        def routes(handler: Handler, afterPathMethodMatch: Directive0 = pass)(implicit mat: akka.stream.Materializer): Route = {
           {
-            path("foo")(get(headerValueByName("CustomHeader").flatMap(str => onComplete(Unmarshal(str).to[Bar](stringyJsonUnmarshaller.andThen(unmarshallJson[Bar]), mat.executionContext, mat)).flatMap[Tuple1[Bar]]({
+            path("foo")(get(afterPathMethodMatch(headerValueByName("CustomHeader").flatMap(str => onComplete(Unmarshal(str).to[Bar](stringyJsonUnmarshaller.andThen(unmarshallJson[Bar]), mat.executionContext, mat)).flatMap[Tuple1[Bar]]({
               case Failure(e) =>
                 reject(MalformedHeaderRejection("CustomHeader", e.getMessage, Some(e)))
               case Success(x) =>
                 provide(x)
-            })).apply(customHeader => discardEntity(beforeComplete(complete(handler.getFoo(getFooResponse)(customHeader)))))))
+            })).apply(customHeader => discardEntity(complete(handler.getFoo(getFooResponse)(customHeader)))))))
           }
         }
         sealed abstract class getFooResponse(val statusCode: StatusCode)

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/CustomHeaderTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/CustomHeaderTest.scala
@@ -48,14 +48,14 @@ class CustomHeaderTest extends AnyFunSuite with Matchers with SwaggerSpecRunner 
 
     val resource = q"""
       object Resource {
-        def routes(handler: Handler)(implicit mat: akka.stream.Materializer): Route = {
+        def routes(handler: Handler, beforeComplete: Directive0 = pass)(implicit mat: akka.stream.Materializer): Route = {
           {
             path("foo")(get(headerValueByName("CustomHeader").flatMap(str => onComplete(Unmarshal(str).to[Bar](stringyJsonUnmarshaller.andThen(unmarshallJson[Bar]), mat.executionContext, mat)).flatMap[Tuple1[Bar]]({
               case Failure(e) =>
                 reject(MalformedHeaderRejection("CustomHeader", e.getMessage, Some(e)))
               case Success(x) =>
                 provide(x)
-            })).apply(customHeader => discardEntity(complete(handler.getFoo(getFooResponse)(customHeader))))))
+            })).apply(customHeader => discardEntity(beforeComplete(complete(handler.getFoo(getFooResponse)(customHeader)))))))
           }
         }
         sealed abstract class getFooResponse(val statusCode: StatusCode)

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/CustomHeaderTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/CustomHeaderTest.scala
@@ -48,9 +48,9 @@ class CustomHeaderTest extends AnyFunSuite with Matchers with SwaggerSpecRunner 
 
     val resource = q"""
       object Resource {
-        def routes(handler: Handler, afterPathMethodMatch: Directive0 = pass)(implicit mat: akka.stream.Materializer): Route = {
+        def routes(handler: Handler, afterPathMethodMatch: String => Directive0 = _ => pass)(implicit mat: akka.stream.Materializer): Route = {
           {
-            path("foo")(get(afterPathMethodMatch(headerValueByName("CustomHeader").flatMap(str => onComplete(Unmarshal(str).to[Bar](stringyJsonUnmarshaller.andThen(unmarshallJson[Bar]), mat.executionContext, mat)).flatMap[Tuple1[Bar]]({
+            path("foo")(get(afterPathMethodMatch("getFoo")(headerValueByName("CustomHeader").flatMap(str => onComplete(Unmarshal(str).to[Bar](stringyJsonUnmarshaller.andThen(unmarshallJson[Bar]), mat.executionContext, mat)).flatMap[Tuple1[Bar]]({
               case Failure(e) =>
                 reject(MalformedHeaderRejection("CustomHeader", e.getMessage, Some(e)))
               case Success(x) =>

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/StaticParametersTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/StaticParametersTest.scala
@@ -44,11 +44,11 @@ class StaticParametersTest extends AnyFunSuite with Matchers with SwaggerSpecRun
 
     val resource = q"""
       object Resource {
-        def routes(handler: Handler)(implicit mat: akka.stream.Materializer): Route = {
+        def routes(handler: Handler, beforeComplete: Directive0 = pass)(implicit mat: akka.stream.Materializer): Route = {
           {
-            (pathPrefix("foo") & pathEndOrSingleSlash & parameter("bar").require(_ == "2"))(get(discardEntity(complete(handler.getFoo2(getFoo2Response)()))))
+            (pathPrefix("foo") & pathEndOrSingleSlash & parameter("bar").require(_ == "2"))(get(discardEntity(beforeComplete(complete(handler.getFoo2(getFoo2Response)())))))
           } ~ {
-            (path("foo") & parameter("bar").require(_ == "1"))(get(discardEntity(complete(handler.getFoo1(getFoo1Response)()))))
+            (path("foo") & parameter("bar").require(_ == "1"))(get(discardEntity(beforeComplete(complete(handler.getFoo1(getFoo1Response)())))))
           }
         }
         sealed abstract class getFoo2Response(val statusCode: StatusCode)

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/StaticParametersTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/StaticParametersTest.scala
@@ -44,11 +44,11 @@ class StaticParametersTest extends AnyFunSuite with Matchers with SwaggerSpecRun
 
     val resource = q"""
       object Resource {
-        def routes(handler: Handler, afterPathMethodMatch: Directive0 = pass)(implicit mat: akka.stream.Materializer): Route = {
+        def routes(handler: Handler, afterPathMethodMatch: String => Directive0 = _ => pass)(implicit mat: akka.stream.Materializer): Route = {
           {
-            (pathPrefix("foo") & pathEndOrSingleSlash & parameter("bar").require(_ == "2"))(get(afterPathMethodMatch(discardEntity(complete(handler.getFoo2(getFoo2Response)())))))
+            (pathPrefix("foo") & pathEndOrSingleSlash & parameter("bar").require(_ == "2"))(get(afterPathMethodMatch("getFoo2")(discardEntity(complete(handler.getFoo2(getFoo2Response)())))))
           } ~ {
-            (path("foo") & parameter("bar").require(_ == "1"))(get(afterPathMethodMatch(discardEntity(complete(handler.getFoo1(getFoo1Response)())))))
+            (path("foo") & parameter("bar").require(_ == "1"))(get(afterPathMethodMatch("getFoo1")(discardEntity(complete(handler.getFoo1(getFoo1Response)())))))
           }
         }
         sealed abstract class getFoo2Response(val statusCode: StatusCode)

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/StaticParametersTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/StaticParametersTest.scala
@@ -44,11 +44,11 @@ class StaticParametersTest extends AnyFunSuite with Matchers with SwaggerSpecRun
 
     val resource = q"""
       object Resource {
-        def routes(handler: Handler, beforeComplete: Directive0 = pass)(implicit mat: akka.stream.Materializer): Route = {
+        def routes(handler: Handler, afterPathMethodMatch: Directive0 = pass)(implicit mat: akka.stream.Materializer): Route = {
           {
-            (pathPrefix("foo") & pathEndOrSingleSlash & parameter("bar").require(_ == "2"))(get(discardEntity(beforeComplete(complete(handler.getFoo2(getFoo2Response)())))))
+            (pathPrefix("foo") & pathEndOrSingleSlash & parameter("bar").require(_ == "2"))(get(afterPathMethodMatch(discardEntity(complete(handler.getFoo2(getFoo2Response)())))))
           } ~ {
-            (path("foo") & parameter("bar").require(_ == "1"))(get(discardEntity(beforeComplete(complete(handler.getFoo1(getFoo1Response)())))))
+            (path("foo") & parameter("bar").require(_ == "1"))(get(afterPathMethodMatch(discardEntity(complete(handler.getFoo1(getFoo1Response)())))))
           }
         }
         sealed abstract class getFoo2Response(val statusCode: StatusCode)

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
@@ -80,9 +80,9 @@ class FormFieldsServerTest extends AnyFunSuite with Matchers with SwaggerSpecRun
     """
     val resource = q"""
       object Resource {
-        def routes(handler: Handler, afterPathMethodMatch: Directive0 = pass)(implicit mat: akka.stream.Materializer): Route = {
+        def routes(handler: Handler, afterPathMethodMatch: String => Directive0 = _ => pass)(implicit mat: akka.stream.Materializer): Route = {
           {
-            path("foo")(put(afterPathMethodMatch(({
+            path("foo")(put(afterPathMethodMatch("putFoo")(({
               object putFooParts {
                 sealed trait Part
                 case class IgnoredPart(unit: Unit) extends Part

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
@@ -80,9 +80,9 @@ class FormFieldsServerTest extends AnyFunSuite with Matchers with SwaggerSpecRun
     """
     val resource = q"""
       object Resource {
-        def routes(handler: Handler, beforeComplete: Directive0 = pass)(implicit mat: akka.stream.Materializer): Route = {
+        def routes(handler: Handler, afterPathMethodMatch: Directive0 = pass)(implicit mat: akka.stream.Materializer): Route = {
           {
-            path("foo")(put(({
+            path("foo")(put(afterPathMethodMatch(({
               object putFooParts {
                 sealed trait Part
                 case class IgnoredPart(unit: Unit) extends Part
@@ -177,7 +177,7 @@ class FormFieldsServerTest extends AnyFunSuite with Matchers with SwaggerSpecRun
                   }
                   maybe.fold(reject(_), tprovide(_))
               }))
-            }: Directive[(String, Long, (File, Option[String], ContentType, String))]).apply((foo, bar, baz) => beforeComplete(complete(handler.putFoo(putFooResponse)(foo, bar, baz))))))
+            }: Directive[(String, Long, (File, Option[String], ContentType, String))]).apply((foo, bar, baz) => complete(handler.putFoo(putFooResponse)(foo, bar, baz))))))
           }
         }
         sealed abstract class putFooResponse(val statusCode: StatusCode)

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
@@ -80,7 +80,7 @@ class FormFieldsServerTest extends AnyFunSuite with Matchers with SwaggerSpecRun
     """
     val resource = q"""
       object Resource {
-        def routes(handler: Handler)(implicit mat: akka.stream.Materializer): Route = {
+        def routes(handler: Handler, beforeComplete: Directive0 = pass)(implicit mat: akka.stream.Materializer): Route = {
           {
             path("foo")(put(({
               object putFooParts {
@@ -177,7 +177,7 @@ class FormFieldsServerTest extends AnyFunSuite with Matchers with SwaggerSpecRun
                   }
                   maybe.fold(reject(_), tprovide(_))
               }))
-            }: Directive[(String, Long, (File, Option[String], ContentType, String))]).apply((foo, bar, baz) => complete(handler.putFoo(putFooResponse)(foo, bar, baz)))))
+            }: Directive[(String, Long, (File, Option[String], ContentType, String))]).apply((foo, bar, baz) => beforeComplete(complete(handler.putFoo(putFooResponse)(foo, bar, baz))))))
           }
         }
         sealed abstract class putFooResponse(val statusCode: StatusCode)


### PR DESCRIPTION
This solves #645, by allowing the Guardrail user to inject behavior that is run immediately before the handler is called, via a `Directive0`. I realize @kelnos wasn't quite sure about this approach, but figured it would be good to have concrete code to discuss.

I followed the approach of #259, which perhaps is a somewhat similar idea on the Http4s side. Like that PR, this has broad applicability for doing auth, monitoring, response transformation, etc., but only after request preconditions specified in the OpenAPI spec are met (e.g. path, method, param matching).

@blast-hardcheese let me know what you think.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
