### PR TITLE
Escape invalid characters when used in Java identifiers

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,3 +1,28 @@
+Migrating to 0.59.0
+===================
+
+0.59.0 may contain type and package naming changes that will require changes in consuming code
+----------------------------------------------------------------------------------------------
+
+Fixing Java identifier escaping required some core changes in how various names (type, method, method argument, package) are generated.  This cascaded into all of the framework generators, so both Java and Scala clients may be affected.
+
+The most notable differences are:
+
+* The Scala client and server response class types used to be camelCased but are now PascalCased (which now conforms to Scala norms).  Since these types sometimes occur in type signatures of `Handler` classes, some names might need updating.
+* Operation IDs with mixed casing are now rewritten to generate nicer names.  For example an operation ID of `fooBar_0` would previously map to a method with the same name, but now the method will be named `fooBar0`.  There is a similar change with package names set using `tags` or `x-jvm-package`.
+
+In general, all names should now conform to the following convention for Java and Scala:
+
+* Package names are camelCased.
+* Type (class, interface, trait, enum) names are PascalCased.
+* Method names are camelCased.
+* Method argument names are camelCased.
+* For Java, enum values are UPPER_SNAKE_CASED.  (In Scala, enum values are case objects, which follow the same naming rules as types.)
+
+There is one exception: if generating names in these formats causes a conflict, the original names from the spec will be used if possible.  For example, if an object schema contains two properties, one named `FooBar` and the other named `foo_bar`, guardrail will first try to turn them *both* into `fooBar`.  It will notice the clash and just leave them as `FooBar` and `foo_bar`.
+
+If you find a case where a name is generated in a different way, please file an issue.
+
 Migrating to 0.55.0
 ===================
 

--- a/build.sbt
+++ b/build.sbt
@@ -70,6 +70,7 @@ val exampleCases: List[ExampleCase] = List(
   ExampleCase(sampleResource("custom-header-type.yaml"), "tests.customTypes.customHeader"),
   ExampleCase(sampleResource("date-time.yaml"), "dateTime"),
   ExampleCase(sampleResource("edgecases/defaults.yaml"), "edgecases.defaults"),
+  ExampleCase(sampleResource("invalid-characters.yaml"), "invalidCharacters").frameworks(Set("dropwizard")),
   ExampleCase(sampleResource("formData.yaml"), "form"),
   ExampleCase(sampleResource("issues/issue45.yaml"), "issues.issue45"),
   ExampleCase(sampleResource("issues/issue121.yaml"), "issues.issue121"),

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -120,27 +120,27 @@ object Common {
     import Fw._
     import Sc._
 
-    val pkgPath        = resolveFile(outputPath)(pkgName)
-    val dtoPackagePath = resolveFile(pkgPath.resolve("definitions"))(dtoPackage)
-    val supportPkgPath = resolveFile(pkgPath.resolve("support"))(Nil)
+    for {
+      formattedPkgName <- formatPackageName(pkgName)
+      pkgPath        = resolveFile(outputPath)(formattedPkgName)
+      dtoPackagePath = resolveFile(pkgPath.resolve("definitions"))(dtoPackage)
+      supportPkgPath = resolveFile(pkgPath.resolve("support"))(Nil)
 
-    val definitions: List[String] = pkgName :+ "definitions"
+      definitions: List[String] = formattedPkgName :+ "definitions"
 
-    val ProtocolDefinitions(protocolElems, protocolImports, packageObjectImports, packageObjectContents) = proto
-    val CodegenDefinitions(clients, servers, supportDefinitions, frameworkImplicits)                     = codegen
-    val frameworkImplicitName                                                                            = frameworkImplicits.map(_._1)
+      ProtocolDefinitions(protocolElems, protocolImports, packageObjectImports, packageObjectContents) = proto
+      CodegenDefinitions(clients, servers, supportDefinitions, frameworkImplicits)                     = codegen
+      frameworkImplicitName                                                                            = frameworkImplicits.map(_._1)
 
-    val dtoComponents: List[String] = definitions ++ dtoPackage
+      dtoComponents: List[String] = definitions ++ dtoPackage
 
-    // Only presume ...definitions._ import is available if we have
-    // protocolElems which are not just all type aliases.
-    val filteredDtoComponents: Option[NonEmptyList[String]] =
-      NonEmptyList
+      // Only presume ...definitions._ import is available if we have
+      // protocolElems which are not just all type aliases.
+      filteredDtoComponents: Option[NonEmptyList[String]] = NonEmptyList
         .fromList(dtoComponents)
         .filter(_ => protocolElems.exists({ case _: RandomType[_] => false; case _ => true }))
 
-    for {
-      protoOut <- protocolElems.traverse(writeProtocolDefinition(outputPath, pkgName, definitions, dtoComponents, customImports ++ protocolImports, _))
+      protoOut <- protocolElems.traverse(writeProtocolDefinition(outputPath, formattedPkgName, definitions, dtoComponents, customImports ++ protocolImports, _))
       (protocolDefinitions, extraTypes) = protoOut.foldLeft((List.empty[WriteTree], List.empty[L#Statement]))(_ |+| _)
       packageObject <- writePackageObject(
         dtoPackagePath,
@@ -156,24 +156,24 @@ object Common {
       frameworkDefinitions <- getFrameworkDefinitions(context.tracing)
 
       files <- (
-        clients.flatTraverse(writeClient(pkgPath, pkgName, customImports, frameworkImplicitName, filteredDtoComponents.map(_.toList), _)),
-        servers.flatTraverse(writeServer(pkgPath, pkgName, customImports, frameworkImplicitName, filteredDtoComponents.map(_.toList), _))
+        clients.flatTraverse(writeClient(pkgPath, formattedPkgName, customImports, frameworkImplicitName, filteredDtoComponents.map(_.toList), _)),
+        servers.flatTraverse(writeServer(pkgPath, formattedPkgName, customImports, frameworkImplicitName, filteredDtoComponents.map(_.toList), _))
       ).mapN(_ ++ _)
 
-      implicits <- renderImplicits(pkgPath, pkgName, frameworkImports, protocolImports, customImports)
+      implicits <- renderImplicits(pkgPath, formattedPkgName, frameworkImports, protocolImports, customImports)
       frameworkImplicitsFile <- frameworkImplicits.fold(Option.empty[WriteTree].pure[F])({
-        case (name, defn) => renderFrameworkImplicits(pkgPath, pkgName, frameworkImports, protocolImports, defn, name).map(Option.apply)
+        case (name, defn) => renderFrameworkImplicits(pkgPath, formattedPkgName, frameworkImports, protocolImports, defn, name).map(Option.apply)
       })
 
       frameworkDefinitionsFiles <- frameworkDefinitions.traverse({
-        case (name, defn) => renderFrameworkDefinitions(pkgPath, pkgName, frameworkImports, defn, name)
+        case (name, defn) => renderFrameworkDefinitions(pkgPath, formattedPkgName, frameworkImports, defn, name)
       })
 
-      protocolStaticImports <- Pt.staticProtocolImports(pkgName)
+      protocolStaticImports <- Pt.staticProtocolImports(formattedPkgName)
 
       supportDefinitionsFiles <- (supportDefinitions ++ protocolSupport).traverse({
-        case SupportDefinition(name, imports, defn, true)  => renderFrameworkDefinitions(pkgPath, pkgName, imports ++ protocolStaticImports, defn, name)
-        case SupportDefinition(name, imports, defn, false) => renderFrameworkDefinitions(supportPkgPath, pkgName :+ "support", imports, defn, name)
+        case SupportDefinition(name, imports, defn, true)  => renderFrameworkDefinitions(pkgPath, formattedPkgName, imports ++ protocolStaticImports, defn, name)
+        case SupportDefinition(name, imports, defn, false) => renderFrameworkDefinitions(supportPkgPath, formattedPkgName :+ "support", imports, defn, name)
       })
     } yield (
       protocolDefinitions ++

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
@@ -5,7 +5,7 @@ import cats.syntax.all._
 import com.twilio.guardrail.generators.LanguageParameter
 import com.twilio.guardrail.languages.LA
 import com.twilio.guardrail.protocol.terms.Responses
-import com.twilio.guardrail.protocol.terms.server.ServerTerms
+import com.twilio.guardrail.protocol.terms.server.{ GenerateRouteMeta, ServerTerms }
 import com.twilio.guardrail.terms.framework.FrameworkTerms
 import com.twilio.guardrail.terms.{ LanguageTerms, RouteMeta, SecurityScheme, SwaggerTerms }
 
@@ -21,10 +21,6 @@ case class RenderedRoutes[L <: LA](
 )
 
 object ServerGenerator {
-
-  def formatClassName(str: String): String   = s"${str.capitalize}Resource"
-  def formatHandlerName(str: String): String = s"${str.capitalize}Handler"
-
   def fromSwagger[L <: LA, F[_]](context: Context, basePath: Option[String], frameworkImports: List[L#Import])(
       groupedRoutes: List[(List[String], List[RouteMeta])]
   )(
@@ -33,29 +29,31 @@ object ServerGenerator {
   )(implicit Fw: FrameworkTerms[L, F], Sc: LanguageTerms[L, F], S: ServerTerms[L, F], Sw: SwaggerTerms[L, F]): F[Servers[L]] = {
     import S._
     import Sw._
+    import Sc._
 
     for {
       extraImports       <- getExtraImports(context.tracing)
       supportDefinitions <- generateSupportDefinitions(context.tracing, securitySchemes)
       servers <- groupedRoutes.traverse {
         case (className, unsortedRoutes) =>
-          val routes       = unsortedRoutes.sortBy(r => (r.path.unwrapTracker, r.method))
-          val resourceName = formatClassName(className.lastOption.getOrElse(""))
-          val handlerName =
-            formatHandlerName(className.lastOption.getOrElse(""))
+          val routes = unsortedRoutes.sortBy(r => (r.path.unwrapTracker, r.method))
           for {
+            resourceName <- formatTypeName(className.lastOption.getOrElse(""), Some("Resource"))
+            handlerName  <- formatTypeName(className.lastOption.getOrElse(""), Some("Handler"))
             responseServerPair <- routes.traverse {
               case route @ RouteMeta(path, method, operation, securityRequirements) =>
                 for {
                   operationId         <- getOperationId(operation)
                   responses           <- Responses.getResponses(operationId, operation, protocolElems)
-                  responseDefinitions <- generateResponseDefinitions(operationId, responses, protocolElems)
+                  responseClsName     <- formatTypeName(operationId, Some("Response"))
+                  responseDefinitions <- generateResponseDefinitions(responseClsName, responses, protocolElems)
+                  methodName          <- formatMethodName(operationId)
                   parameters          <- route.getParameters[L, F](protocolElems)
                   tracingField        <- buildTracingFields(operation, className, context.tracing)
-                } yield (responseDefinitions, (operationId, tracingField, route, parameters, responses))
+                } yield (responseDefinitions, GenerateRouteMeta(operationId, methodName, responseClsName, tracingField, route, parameters, responses))
             }
             (responseDefinitions, serverOperations) = responseServerPair.unzip
-            renderedRoutes   <- generateRoutes(context.tracing, resourceName, basePath, serverOperations, protocolElems, securitySchemes)
+            renderedRoutes   <- generateRoutes(context.tracing, resourceName, handlerName, basePath, serverOperations, protocolElems, securitySchemes)
             handlerSrc       <- renderHandler(handlerName, renderedRoutes.methodSigs, renderedRoutes.handlerDefinitions, responseDefinitions.flatten)
             extraRouteParams <- getExtraRouteParams(context.tracing)
             classSrc <- renderClass(

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
@@ -82,41 +82,50 @@ object SwaggerUtil {
       log.debug(s"value: ${value} in ${protocolElems.length} protocol elements") >> (value match {
         case x @ Resolved(_, _, _, _, _) => x.pure[F]
         case Deferred(name) =>
-          resolveType(name, protocolElems)
-            .flatMap {
-              case RandomType(name, tpe) =>
-                Resolved[L](tpe, None, None, None, None).pure[F]
-              case ClassDefinition(name, _, fullType, cls, _, _) =>
-                Resolved[L](fullType, None, None, None, None).pure[F]
-              case EnumDefinition(name, _, fullType, elems, cls, _) =>
-                Resolved[L](fullType, None, None, Some("string"), None).pure[F]
-              case ADT(_, _, fullType, _, _) =>
-                Resolved[L](fullType, None, None, None, None).pure[F]
-            }
+          for {
+            formattedName <- formatTypeName(name)
+            resolved <- resolveType(formattedName, protocolElems)
+              .flatMap {
+                case RandomType(name, tpe) =>
+                  Resolved[L](tpe, None, None, None, None).pure[F]
+                case ClassDefinition(name, _, fullType, cls, _, _) =>
+                  Resolved[L](fullType, None, None, None, None).pure[F]
+                case EnumDefinition(name, _, fullType, elems, cls, _) =>
+                  Resolved[L](fullType, None, None, Some("string"), None).pure[F]
+                case ADT(_, _, fullType, _, _) =>
+                  Resolved[L](fullType, None, None, None, None).pure[F]
+              }
+          } yield resolved
         case DeferredArray(name, containerTpe) =>
-          resolveType(name, protocolElems)
-            .flatMap {
-              case RandomType(name, tpe) =>
-                liftVectorType(tpe, containerTpe).map(Resolved[L](_, None, None, None, None))
-              case ClassDefinition(name, _, fullType, cls, _, _) =>
-                liftVectorType(fullType, containerTpe).map(Resolved[L](_, None, None, None, None))
-              case EnumDefinition(name, _, fullType, elems, cls, _) =>
-                liftVectorType(fullType, containerTpe).map(Resolved[L](_, None, None, None, None))
-              case ADT(_, _, fullType, _, _) =>
-                liftVectorType(fullType, containerTpe).map(Resolved[L](_, None, None, None, None))
-            }
+          for {
+            formattedName <- formatTypeName(name)
+            resolved <- resolveType(formattedName, protocolElems)
+              .flatMap {
+                case RandomType(name, tpe) =>
+                  liftVectorType(tpe, containerTpe).map(Resolved[L](_, None, None, None, None))
+                case ClassDefinition(name, _, fullType, cls, _, _) =>
+                  liftVectorType(fullType, containerTpe).map(Resolved[L](_, None, None, None, None))
+                case EnumDefinition(name, _, fullType, elems, cls, _) =>
+                  liftVectorType(fullType, containerTpe).map(Resolved[L](_, None, None, None, None))
+                case ADT(_, _, fullType, _, _) =>
+                  liftVectorType(fullType, containerTpe).map(Resolved[L](_, None, None, None, None))
+              }
+          } yield resolved
         case DeferredMap(name, containerTpe) =>
-          resolveType(name, protocolElems)
-            .flatMap {
-              case RandomType(name, tpe) =>
-                liftMapType(tpe, containerTpe).map(Resolved[L](_, None, None, None, None))
-              case ClassDefinition(_, _, fullType, _, _, _) =>
-                liftMapType(fullType, containerTpe).map(Resolved[L](_, None, None, None, None))
-              case EnumDefinition(_, _, fullType, _, _, _) =>
-                liftMapType(fullType, containerTpe).map(Resolved[L](_, None, None, None, None))
-              case ADT(_, _, fullType, _, _) =>
-                liftMapType(fullType, containerTpe).map(Resolved[L](_, None, None, None, None))
-            }
+          for {
+            formattedName <- formatTypeName(name)
+            resolved <- resolveType(formattedName, protocolElems)
+              .flatMap {
+                case RandomType(name, tpe) =>
+                  liftMapType(tpe, containerTpe).map(Resolved[L](_, None, None, None, None))
+                case ClassDefinition(_, _, fullType, _, _, _) =>
+                  liftMapType(fullType, containerTpe).map(Resolved[L](_, None, None, None, None))
+                case EnumDefinition(_, _, fullType, _, _, _) =>
+                  liftMapType(fullType, containerTpe).map(Resolved[L](_, None, None, None, None))
+                case ADT(_, _, fullType, _, _) =>
+                  liftMapType(fullType, containerTpe).map(Resolved[L](_, None, None, None, None))
+              }
+          } yield resolved
       })
     }
   }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
@@ -212,7 +212,8 @@ class CoreTermInterp[L <: LA](
               val Ps = implicitly[ProtocolSupportTerms[L, Target]]
               for {
                 _                  <- Sw.log.debug("Running guardrail codegen")
-                definitionsPkgName <- Sc.fullyQualifyPackageName(pkgName)
+                formattedPkgName   <- Sc.formatPackageName(pkgName)
+                definitionsPkgName <- Sc.fullyQualifyPackageName(formattedPkgName)
                 (proto, codegen) <- Common
                   .prepareDefinitions[L, Target](
                     kind,
@@ -223,7 +224,7 @@ class CoreTermInterp[L <: LA](
                   )
                 protocolSupport <- Ps.generateSupportDefinitions()
                 result <- Common
-                  .writePackage[L, Target](proto, codegen, context)(Paths.get(outputPath), pkgName, dtoPackage, customImports, protocolSupport)
+                  .writePackage[L, Target](proto, codegen, context)(Paths.get(outputPath), formattedPkgName, dtoPackage, customImports, protocolSupport)
               } yield result
             } catch {
               case NonFatal(ex) =>

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
@@ -834,7 +834,7 @@ object JacksonGenerator {
           (tpe, classDep) = tpeClassDep
 
           argName <- if (needCamelSnakeConversion) JavaGenerator.JavaInterp.formatMethodArgName(name)
-          else Target.pure(name.escapeIdentifier)
+          else Target.pure(name.escapeInvalidCharacters.escapeIdentifier)
           rawType = RawParameterType(Option(property.getType), Option(property.getFormat))
 
           expressionDefaultValue <- defaultValue match {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
@@ -833,7 +833,8 @@ object JacksonGenerator {
           }
           (tpe, classDep) = tpeClassDep
 
-          argName = if (needCamelSnakeConversion) name.toCamelCase else name
+          argName <- if (needCamelSnakeConversion) JavaGenerator.JavaInterp.formatMethodArgName(name)
+          else Target.pure(name.escapeIdentifier)
           rawType = RawParameterType(Option(property.getType), Option(property.getFormat))
 
           expressionDefaultValue <- defaultValue match {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
@@ -783,10 +783,10 @@ object JacksonGenerator {
         clsName: String,
         dtoPackage: List[String],
         supportPackage: List[String],
-        needCamelSnakeConversion: Boolean,
         concreteTypes: List[PropMeta[JavaLanguage]]
     )(
         name: String,
+        fieldName: String,
         property: Schema[_],
         meta: SwaggerUtil.ResolvedType[JavaLanguage],
         requirement: PropertyRequirement,
@@ -833,8 +833,6 @@ object JacksonGenerator {
           }
           (tpe, classDep) = tpeClassDep
 
-          argName <- if (needCamelSnakeConversion) JavaGenerator.JavaInterp.formatMethodArgName(name)
-          else Target.pure(name.escapeInvalidCharacters.escapeIdentifier)
           rawType = RawParameterType(Option(property.getType), Option(property.getFormat))
 
           expressionDefaultValue <- defaultValue match {
@@ -861,7 +859,7 @@ object JacksonGenerator {
                 )
               ).mapN((_, _))
             )(Function.const(Target.pure((tpe, expressionDefaultValue))) _)
-          term <- safeParseParameter(s"final ${finalDeclType} ${argName.escapeIdentifier}")
+          term <- safeParseParameter(s"final ${finalDeclType} $fieldName")
           dep = classDep.filterNot(_.asString == clsName) // Filter out our own class name
         } yield ProtocolParameter[JavaLanguage](
           term,
@@ -880,7 +878,6 @@ object JacksonGenerator {
     def encodeModel(
         clsName: String,
         dtoPackage: List[String],
-        needCamelSnakeConversion: Boolean,
         selfParams: List[ProtocolParameter[JavaLanguage]],
         parents: List[SuperClass[JavaLanguage]] = Nil
     ) =
@@ -890,7 +887,6 @@ object JacksonGenerator {
         clsName: String,
         dtoPackage: List[String],
         supportPackage: List[String],
-        needCamelSnakeConversion: Boolean,
         selfParams: List[ProtocolParameter[JavaLanguage]],
         parents: List[SuperClass[JavaLanguage]] = Nil
     ) =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvcClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvcClientGenerator.scala
@@ -16,6 +16,7 @@ object SpringMvcClientGenerator {
     def MonadF = Target.targetInstances
     def generateClientOperation(
         className: List[String],
+        responseClsName: String,
         tracing: Boolean,
         securitySchemes: Map[String, SecurityScheme[JavaLanguage]],
         parameters: LanguageParameters[JavaLanguage]
@@ -36,7 +37,7 @@ object SpringMvcClientGenerator {
     ) =
       Target.raiseUserError("spring client generation is not currently supported")
     def generateResponseDefinitions(
-        operationId: String,
+        responseClsName: String,
         responses: Responses[JavaLanguage],
         protocolElems: List[StrictProtocolElems[JavaLanguage]]
     ) =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
@@ -172,13 +172,14 @@ object JavaGenerator {
           Target.raiseUserError(s"Enumeration $tpe somehow has a default value that isn't a string")
       }
 
-    def formatPackageName(packageName: List[String]): Target[List[String]] = Target.pure(packageName.map(_.toCamelCase.escapeIdentifier))
+    def formatPackageName(packageName: List[String]): Target[List[String]] =
+      Target.pure(packageName.map(_.escapeInvalidCharacters.toCamelCase.escapeIdentifier))
     def formatTypeName(typeName: String, suffix: Option[String] = None): Target[String] =
-      Target.pure(typeName.toPascalCase.escapeIdentifier + suffix.fold("")(_.toPascalCase.escapeIdentifier))
-    def formatFieldName(fieldName: String): Target[String]         = Target.pure(fieldName.toCamelCase.escapeIdentifier)
-    def formatMethodName(methodName: String): Target[String]       = Target.pure(methodName.toCamelCase.escapeIdentifier)
-    def formatMethodArgName(methodArgName: String): Target[String] = Target.pure(methodArgName.toCamelCase.escapeIdentifier)
-    def formatEnumName(enumValue: String): Target[String]          = Target.pure(enumValue.toSnakeCase.toUpperCase(Locale.US).escapeIdentifier)
+      Target.pure(typeName.escapeInvalidCharacters.toPascalCase.escapeIdentifier + suffix.fold("")(_.escapeInvalidCharacters.toPascalCase.escapeIdentifier))
+    def formatFieldName(fieldName: String): Target[String]         = Target.pure(fieldName.escapeInvalidCharacters.toCamelCase.escapeIdentifier)
+    def formatMethodName(methodName: String): Target[String]       = Target.pure(methodName.escapeInvalidCharacters.toCamelCase.escapeIdentifier)
+    def formatMethodArgName(methodArgName: String): Target[String] = Target.pure(methodArgName.escapeInvalidCharacters.toCamelCase.escapeIdentifier)
+    def formatEnumName(enumValue: String): Target[String]          = Target.pure(enumValue.escapeInvalidCharacters.toSnakeCase.toUpperCase(Locale.US).escapeIdentifier)
 
     def embedArray(tpe: LazyResolvedType[JavaLanguage], containerTpe: Option[com.github.javaparser.ast.`type`.Type]): Target[LazyResolvedType[JavaLanguage]] =
       tpe match {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
@@ -236,6 +236,7 @@ object JavaGenerator {
       extractTypeName(tpe).map(Option.apply)
     }
     def extractTermName(term: com.github.javaparser.ast.expr.Name): Target[String] = Target.pure(term.asString)
+    def extractTermNameFromParam(param: Parameter): Target[String]                 = Target.pure(param.getNameAsString)
     def selectType(typeNames: NonEmptyList[String]): Target[com.github.javaparser.ast.`type`.Type] =
       safeParseType(typeNames.toList.mkString("."))
     def selectTerm(termNames: NonEmptyList[String]): Target[com.github.javaparser.ast.Node] =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
@@ -31,7 +31,8 @@ import scala.concurrent.Future
 import scala.language.existentials
 
 object JavaGenerator {
-  def buildPkgDecl(parts: List[String]): Target[PackageDeclaration] = safeParseName(parts.mkString(".")).map(new PackageDeclaration(_))
+  def buildPkgDecl(parts: List[String]): Target[PackageDeclaration] =
+    safeParseName(parts.mkString(".")).map(new PackageDeclaration(_))
 
   def buildMethodCall(name: String, arg: Option[Node] = None): Target[Node] = arg match {
     case Some(expr: Expression) => Target.pure(new MethodCallExpr(name, expr))
@@ -170,7 +171,14 @@ object JavaGenerator {
         case _ =>
           Target.raiseUserError(s"Enumeration $tpe somehow has a default value that isn't a string")
       }
-    def formatEnumName(enumValue: String): Target[String] = Target.pure(enumValue.toSnakeCase.toUpperCase(Locale.US))
+
+    def formatPackageName(packageName: List[String]): Target[List[String]] = Target.pure(packageName.map(_.toCamelCase.escapeIdentifier))
+    def formatTypeName(typeName: String, suffix: Option[String] = None): Target[String] =
+      Target.pure(typeName.toPascalCase.escapeIdentifier + suffix.fold("")(_.toPascalCase.escapeIdentifier))
+    def formatFieldName(fieldName: String): Target[String]         = Target.pure(fieldName.toCamelCase.escapeIdentifier)
+    def formatMethodName(methodName: String): Target[String]       = Target.pure(methodName.toCamelCase.escapeIdentifier)
+    def formatMethodArgName(methodArgName: String): Target[String] = Target.pure(methodArgName.toCamelCase.escapeIdentifier)
+    def formatEnumName(enumValue: String): Target[String]          = Target.pure(enumValue.toSnakeCase.toUpperCase(Locale.US).escapeIdentifier)
 
     def embedArray(tpe: LazyResolvedType[JavaLanguage], containerTpe: Option[com.github.javaparser.ast.`type`.Type]): Target[LazyResolvedType[JavaLanguage]] =
       tpe match {
@@ -201,7 +209,7 @@ object JavaGenerator {
         })
     def parseTypeName(tpe: String): Target[Option[JavaTypeName]] = Option(tpe).map(_.trim).filterNot(_.isEmpty).traverse(safeParseTypeName)
     def pureTermName(tpe: String): Target[com.github.javaparser.ast.expr.Name] =
-      Option(tpe).map(_.trim).filterNot(_.isEmpty).map(_.escapeIdentifier).map(safeParseName).getOrElse(Target.raiseUserError("A structure's name is empty"))
+      Option(tpe).map(_.trim).filterNot(_.isEmpty).map(safeParseName).getOrElse(Target.raiseUserError("A structure's name is empty"))
     def pureTypeName(tpe: String): Target[JavaTypeName] =
       Option(tpe).map(_.trim).filterNot(_.isEmpty).map(safeParseTypeName).getOrElse(Target.raiseUserError("A structure's name is empty"))
 
@@ -210,7 +218,7 @@ object JavaGenerator {
         tpe: com.github.javaparser.ast.`type`.Type,
         default: Option[com.github.javaparser.ast.Node]
     ): Target[com.github.javaparser.ast.body.Parameter] =
-      safeParseSimpleName(nameStr.asString.escapeIdentifier).map(name => new Parameter(new NodeList(finalModifier), tpe, name))
+      safeParseSimpleName(nameStr.asString).map(name => new Parameter(new NodeList(finalModifier), tpe, name))
     def typeNamesEqual(a: JavaTypeName, b: JavaTypeName): Target[Boolean]                                               = Target.pure(a.asString == b.asString)
     def typesEqual(a: com.github.javaparser.ast.`type`.Type, b: com.github.javaparser.ast.`type`.Type): Target[Boolean] = Target.pure(a.equals(b))
     def extractTypeName(tpe: com.github.javaparser.ast.`type`.Type): Target[Option[JavaTypeName]] = {
@@ -226,15 +234,16 @@ object JavaGenerator {
       }
       extractTypeName(tpe).map(Option.apply)
     }
-    def extractTermName(term: com.github.javaparser.ast.expr.Name): Target[String]                 = Target.pure(term.asString)
-    def selectType(typeNames: NonEmptyList[String]): Target[com.github.javaparser.ast.`type`.Type] = safeParseType(typeNames.toList.mkString("."))
+    def extractTermName(term: com.github.javaparser.ast.expr.Name): Target[String] = Target.pure(term.asString)
+    def selectType(typeNames: NonEmptyList[String]): Target[com.github.javaparser.ast.`type`.Type] =
+      safeParseType(typeNames.toList.mkString("."))
     def selectTerm(termNames: NonEmptyList[String]): Target[com.github.javaparser.ast.Node] =
       safeParseExpression[Expression](termNames.toList.mkString(".")).map(v => v: Node)
     def alterMethodParameterName(
         param: com.github.javaparser.ast.body.Parameter,
         name: com.github.javaparser.ast.expr.Name
     ): Target[com.github.javaparser.ast.body.Parameter] =
-      safeParseSimpleName(name.asString.escapeIdentifier).map(
+      safeParseSimpleName(name.asString).map(
         new Parameter(
           param.getTokenRange.orElse(null),
           param.getModifiers,

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/LanguageParameter.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/LanguageParameter.scala
@@ -136,8 +136,9 @@ object LanguageParameter {
 
       name <- getParameterName(parameter.get)
 
-      paramName <- pureTermName(name.toCamelCase)
-      param     <- pureMethodParameter(paramName, declType, defaultValue)
+      paramName     <- formatMethodArgName(name)
+      paramTermName <- pureTermName(paramName)
+      param         <- pureMethodParameter(paramTermName, declType, defaultValue)
 
       ftpe       <- fileType(None)
       isFileType <- typesEqual(paramType, ftpe)
@@ -145,7 +146,7 @@ object LanguageParameter {
       new LanguageParameter[L](
         Option(parameter.get.getIn),
         param,
-        paramName,
+        paramTermName,
         RawParameterName(name),
         declType,
         RawParameterType(rawType, rawFormat),

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpClientGenerator.scala
@@ -38,6 +38,7 @@ object AkkaHttpClientGenerator {
 
     def generateClientOperation(
         className: List[String],
+        responseClsName: String,
         tracing: Boolean,
         securitySchemes: Map[String, SecurityScheme[ScalaLanguage]],
         parameters: LanguageParameters[ScalaLanguage]
@@ -172,6 +173,7 @@ object AkkaHttpClientGenerator {
 
       def build(
           methodName: String,
+          responseClsName: String,
           httpMethod: HttpMethod,
           urlWithParams: Term,
           formDataParams: Option[Term],
@@ -256,7 +258,7 @@ object AkkaHttpClientGenerator {
         }
 
         val responseCompanionTerm =
-          Term.Name(s"${methodName.capitalize}Response")
+          Term.Name(responseClsName)
         val cases = responses.value.map { resp =>
             val responseTerm = Term.Name(s"${resp.statusCodeName.value}")
             (resp.value, resp.headers.value) match {
@@ -368,7 +370,18 @@ object AkkaHttpClientGenerator {
           List(LanguageParameter.fromParam(param"methodName: String = ${Lit.String(methodName.toDashedCase)}"))
         else List.empty
         extraImplicits = List.empty
-        renderedClientOperation <- build(methodName, httpMethod, urlWithParams, formDataParams, headerParams, responses, produces, consumes, tracing)(
+        renderedClientOperation <- build(
+          methodName,
+          responseClsName,
+          httpMethod,
+          urlWithParams,
+          formDataParams,
+          headerParams,
+          responses,
+          produces,
+          consumes,
+          tracing
+        )(
           tracingArgsPre,
           tracingArgsPost,
           pathArgs,
@@ -397,11 +410,11 @@ object AkkaHttpClientGenerator {
       )
     }
     def generateResponseDefinitions(
-        operationId: String,
+        responseClsName: String,
         responses: Responses[ScalaLanguage],
         protocolElems: List[StrictProtocolElems[ScalaLanguage]]
     ): Target[List[scala.meta.Defn]] =
-      Target.pure(Http4sHelper.generateResponseDefinitions(operationId, responses, protocolElems))
+      Target.pure(Http4sHelper.generateResponseDefinitions(responseClsName, responses, protocolElems))
     def generateSupportDefinitions(
         tracing: Boolean,
         securitySchemes: Map[String, SecurityScheme[ScalaLanguage]]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpServerGenerator.scala
@@ -29,14 +29,14 @@ object AkkaHttpServerGenerator {
     implicit def MonadF: Monad[Target] = Target.targetInstances
 
     def generateResponseDefinitions(
-        operationId: String,
+        responseClsName: String,
         responses: Responses[ScalaLanguage],
         protocolElems: List[StrictProtocolElems[ScalaLanguage]]
     ) =
       for {
         _ <- Target.pure(())
-        responseSuperType = Type.Name(s"${operationId}Response")
-        responseSuperTerm = Term.Name(s"${operationId}Response")
+        responseSuperType = Type.Name(responseClsName)
+        responseSuperTerm = Term.Name(responseClsName)
         instances = responses.value
           .foldLeft[List[(Defn, Defn, Case)]](List.empty)({
             case (acc, resp) =>
@@ -44,8 +44,8 @@ object AkkaHttpServerGenerator {
                 val statusCodeName = resp.statusCodeName
                 val statusCode     = q"StatusCodes.${statusCodeName}"
                 val valueType      = resp.value.map(_._1)
-                val responseTerm   = Term.Name(s"${operationId}Response${statusCodeName.value}")
-                val responseName   = Type.Name(s"${operationId}Response${statusCodeName.value}")
+                val responseTerm   = Term.Name(s"${responseClsName}${statusCodeName.value}")
+                val responseName   = Type.Name(s"${responseClsName}${statusCodeName.value}")
                 valueType.fold[(Defn, Defn, Case)](
                   (
                     q"case object $responseTerm                      extends $responseSuperType($statusCode)",
@@ -83,10 +83,10 @@ object AkkaHttpServerGenerator {
         companion = q"""
             object ${responseSuperTerm} {
               implicit val ${Pat
-          .Var(Term.Name(s"${operationId}TRM"))}: ToResponseMarshaller[${responseSuperType}] = Marshaller { implicit ec => resp => ${Term
-          .Name(s"${operationId}TR")}(resp) }
+          .Var(Term.Name(s"${responseClsName.uncapitalized}TRM"))}: ToResponseMarshaller[${responseSuperType}] = Marshaller { implicit ec => resp => ${Term
+          .Name(s"${responseClsName.uncapitalized}TR")}(resp) }
               implicit def ${Term
-          .Name(s"${operationId}TR")}(value: ${responseSuperType})(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] =
+          .Name(s"${responseClsName.uncapitalized}TR")}(value: ${responseSuperType})(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] =
                 ${Term.Match(Term.Name("value"), marshallers)}
 
               def apply[T](value: T)(implicit ev: T => ${responseSuperType}): ${responseSuperType} = ev(value)
@@ -122,16 +122,25 @@ object AkkaHttpServerGenerator {
     def generateRoutes(
         tracing: Boolean,
         resourceName: String,
+        handlerName: String,
         basePath: Option[String],
-        routes: List[(String, Option[TracingField[ScalaLanguage]], RouteMeta, LanguageParameters[ScalaLanguage], Responses[ScalaLanguage])],
+        routes: List[GenerateRouteMeta[ScalaLanguage]],
         protocolElems: List[StrictProtocolElems[ScalaLanguage]],
         securitySchemes: Map[String, SecurityScheme[ScalaLanguage]]
     ) =
       for {
         renderedRoutes <- routes.traverse {
-          case (operationId, tracingFields, sr @ RouteMeta(path, method, operation, securityRequirements), parameters, responses) =>
+          case GenerateRouteMeta(
+              operationId,
+              methodName,
+              responseClsName,
+              tracingFields,
+              sr @ RouteMeta(path, method, operation, securityRequirements),
+              parameters,
+              responses
+              ) =>
             for {
-              rendered <- generateRoute(resourceName, basePath, sr, tracingFields, parameters, responses)
+              rendered <- generateRoute(resourceName, basePath, methodName, responseClsName, sr, tracingFields, parameters, responses)
             } yield rendered
         }
         routeTerms = renderedRoutes.map(_.route)
@@ -281,11 +290,11 @@ object AkkaHttpServerGenerator {
           Some((xs.foldLeft[Term](x) { case (a, n) => q"${a} & ${n}" }, params.map(_.paramName)))
       }
 
-    def bodyToAkka(operationId: String, body: Option[LanguageParameter[ScalaLanguage]]): Target[Option[Term]] =
+    def bodyToAkka(methodName: String, body: Option[LanguageParameter[ScalaLanguage]]): Target[Option[Term]] =
       Target.pure(
         body.map {
           case LanguageParameter(_, _, _, _, argType) =>
-            q"entity(as[${argType}](${Term.Name(s"${operationId.uncapitalized}Decoder")}))"
+            q"entity(as[${argType}](${Term.Name(s"${methodName}Decoder")}))"
         }
       )
 
@@ -357,7 +366,7 @@ object AkkaHttpServerGenerator {
       override def toString(): String = s"Binding($value)"
     }
 
-    def formToAkka(consumes: Tracker[NonEmptyList[ContentType]], operationId: String)(
+    def formToAkka(consumes: Tracker[NonEmptyList[ContentType]], methodName: String)(
         params: List[LanguageParameter[ScalaLanguage]]
     ): Target[(Option[Term], List[Stat])] = Target.log.function("formToAkka") {
       for {
@@ -375,7 +384,7 @@ object AkkaHttpServerGenerator {
         result <- NonEmptyList
           .fromList(params)
           .traverse({ params =>
-            val partsTerm = Term.Name(s"${operationId}Parts")
+            val partsTerm = Term.Name(s"${methodName}Parts")
             val (multipartContainers, unmarshallers, matchers, termPatterns, optionalTermPatterns, unpacks, termTypes, grabHeads) = params
               .map({
                 case rawParameter @ LanguageParameter(a, param, paramName, argName, argType) =>
@@ -423,8 +432,8 @@ object AkkaHttpServerGenerator {
                       interpolateUnmarshaller(
                         q"""
                           (
-                            handler.${Term.Name(s"${operationId}UnmarshalToFile")}[${targetFunctor}](${targetHashName}, handler.${Term
-                          .Name(s"${operationId}MapFileField")}(_, _, _))
+                            handler.${Term.Name(s"${methodName}UnmarshalToFile")}[${targetFunctor}](${targetHashName}, handler.${Term
+                          .Name(s"${methodName}MapFileField")}(_, _, _))
                               .map({ case (v1, v2, v3, v4) =>
                                 ${Term.Select(partsTerm, containerName.toTerm)}((..${List(q"v1", q"v2", q"v3") ++ rawParameter.hashAlgorithm
                               .map(Function.const(q"v4"))}))
@@ -508,11 +517,11 @@ object AkkaHttpServerGenerator {
               (
                 List(
                   q"""
-            def ${Term.Name(s"${operationId}MapFileField")}(fieldName: String, fileName: Option[String], contentType: ContentType): File
+            def ${Term.Name(s"${methodName}MapFileField")}(fieldName: String, fileName: Option[String], contentType: ContentType): File
             """,
                   q"""
               def ${Term
-                    .Name(s"${operationId}UnmarshalToFile")}[F[_]: Functor](hashType: F[String], destFn: (String, Option[String], ContentType) => File)(implicit mat: Materializer): Unmarshaller[Multipart.FormData.BodyPart, (File, Option[String], ContentType, F[String])] = Unmarshaller { implicit executionContext => part =>
+                    .Name(s"${methodName}UnmarshalToFile")}[F[_]: Functor](hashType: F[String], destFn: (String, Option[String], ContentType) => File)(implicit mat: Materializer): Unmarshaller[Multipart.FormData.BodyPart, (File, Option[String], ContentType, F[String])] = Unmarshaller { implicit executionContext => part =>
                 val dest = destFn(part.name, part.filename, part.entity.contentType)
                 val messageDigest = hashType.map(MessageDigest.getInstance(_))
                 val fileSink: Sink[ByteString,Future[IOResult]] = FileIO.toPath(dest.toPath).contramap[ByteString] { chunk => val _ = messageDigest.map(_.update(chunk.toArray[Byte])); chunk }
@@ -699,6 +708,8 @@ object AkkaHttpServerGenerator {
     def generateRoute(
         resourceName: String,
         basePath: Option[String],
+        methodName: String,
+        responseClsName: String,
         route: RouteMeta,
         tracingFields: Option[TracingField[ScalaLanguage]],
         parameters: LanguageParameters[ScalaLanguage],
@@ -716,11 +727,6 @@ object AkkaHttpServerGenerator {
                 .fromList(xs.flatMap(ContentType.unapply(_)))
                 .getOrElse(NonEmptyList.one(ApplicationJson))
           )
-        operationId <- operation
-          .downField("operationId", _.getOperationId())
-          .map(_.map(splitOperationParts).map(_._2))
-          .raiseErrorIfEmpty("Missing operationId")
-          .map(_.get)
 
         // special-case file upload stuff
         formArgs = parameters.formParams.map({ x =>
@@ -745,10 +751,11 @@ object AkkaHttpServerGenerator {
         akkaMethod                     <- httpMethodToAkka(method)
         akkaPath                       <- pathStrToAkka(basePath, path, pathArgs)
         akkaQs                         <- qsArgs.grouped(22).toList.flatTraverse(args => qsToAkka(args).map(_.toList))
-        akkaBody                       <- bodyToAkka(operationId, bodyArgs)
-        (akkaForm, handlerDefinitions) <- formToAkka(consumes, operationId)(formArgs)
+        akkaBody                       <- bodyToAkka(methodName, bodyArgs)
+        (akkaForm, handlerDefinitions) <- formToAkka(consumes, methodName)(formArgs)
         akkaHeaders                    <- headerArgs.grouped(22).toList.flatTraverse(args => headersToAkka(args).map(_.toList))
-        (responseCompanionTerm, responseCompanionType) = (Term.Name(s"${operationId}Response"), Type.Name(s"${operationId}Response"))
+        // We aren't capitalizing the response names in order to keep back compat
+        (responseCompanionTerm, responseCompanionType) = (Term.Name(responseClsName), Type.Name(responseClsName))
         responseType = if (ServerRawResponse(operation).getOrElse(false)) {
           t"HttpResponse"
         } else {
@@ -785,7 +792,7 @@ object AkkaHttpServerGenerator {
           pathMatcher compose methodMatcher compose qsMatcher compose headerMatcher compose tracingMatcher compose bodyMatcher
         }
         handlerCallArgs = List(List(responseCompanionTerm)) ++ orderedParameters.map(_.map(_.paramName))
-        fullRoute       = Term.Block(List(fullRouteMatcher(q"complete(handler.${Term.Name(operationId)}(...${handlerCallArgs}))")))
+        fullRoute       = Term.Block(List(fullRouteMatcher(q"complete(handler.${Term.Name(methodName)}(...${handlerCallArgs}))")))
 
         respond = List(List(param"respond: ${Term.Name(resourceName)}.${responseCompanionTerm}.type"))
 
@@ -809,14 +816,11 @@ object AkkaHttpServerGenerator {
                   )
               )
             )
-        codecs <- generateCodecs(operationId, bodyArgs, responses, consumes)
+        codecs <- generateCodecs(methodName, bodyArgs, responses, consumes)
       } yield {
         RenderedRoute(
           fullRoute,
-          q"""
-                def ${Term
-            .Name(operationId)}(...${params}): scala.concurrent.Future[${responseType}]
-              """,
+          q"""def ${Term.Name(methodName)}(...${params}): scala.concurrent.Future[${responseType}]""",
           codecs,
           handlerDefinitions
         )
@@ -829,15 +833,15 @@ object AkkaHttpServerGenerator {
       } yield routes.tail.foldLeft(routes.head) { case (a, n) => q"${a} ~ ${n}" })
 
     def generateCodecs(
-        operationId: String,
+        methodName: String,
         bodyArgs: Option[LanguageParameter[ScalaLanguage]],
         responses: Responses[ScalaLanguage],
         consumes: Tracker[NonEmptyList[ContentType]]
     ): Target[List[Defn.Val]] =
-      generateDecoders(operationId, bodyArgs, consumes)
+      generateDecoders(methodName, bodyArgs, consumes)
 
     def generateDecoders(
-        operationId: String,
+        methodName: String,
         bodyArgs: Option[LanguageParameter[ScalaLanguage]],
         consumes: Tracker[NonEmptyList[ContentType]]
     ): Target[List[Defn.Val]] =
@@ -847,7 +851,7 @@ object AkkaHttpServerGenerator {
             (decoder, baseType) <- AkkaHttpHelper.generateDecoder(argType, consumes)
           } yield {
             q"""
-            val ${Pat.Typed(Pat.Var(Term.Name(s"${operationId.uncapitalized}Decoder")), t"FromRequestUnmarshaller[$baseType]")} = {
+            val ${Pat.Typed(Pat.Var(Term.Name(s"${methodName}Decoder")), t"FromRequestUnmarshaller[$baseType]")} = {
               val extractEntity = implicitly[Unmarshaller[HttpMessage, HttpEntity]]
               val unmarshalEntity = ${decoder}
               extractEntity.andThen(unmarshalEntity)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/CirceProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/CirceProtocolGenerator.scala
@@ -22,7 +22,6 @@ import com.twilio.guardrail.core.Tracker
 import com.twilio.guardrail.core.implicits._
 import com.twilio.guardrail.extract.{ DataRedaction, EmptyValueIsNull }
 import com.twilio.guardrail.generators.{ RawParameterName, RawParameterType, ScalaGenerator }
-import com.twilio.guardrail.generators.syntax.RichString
 import com.twilio.guardrail.languages.ScalaLanguage
 import com.twilio.guardrail.protocol.terms.protocol._
 import com.twilio.guardrail.SwaggerUtil.ResolvedType
@@ -142,10 +141,10 @@ object CirceProtocolGenerator {
         clsName: String,
         dtoPackage: List[String],
         supportPackage: List[String],
-        needCamelSnakeConversion: Boolean,
         concreteTypes: List[PropMeta[ScalaLanguage]]
     )(
         name: String,
+        fieldName: String,
         property: Schema[_],
         meta: ResolvedType[ScalaLanguage],
         requirement: PropertyRequirement,
@@ -156,7 +155,6 @@ object CirceProtocolGenerator {
         for {
           _ <- Target.log.debug(s"Args: (${clsName}, ${name}, ...)")
 
-          argName = if (needCamelSnakeConversion) name.toCamelCase else name
           rawType = RawParameterType(Option(property.getType), Option(property.getFormat))
 
           readOnlyKey = Option(name).filter(_ => Option(property.getReadOnly).contains(true))
@@ -200,7 +198,7 @@ object CirceProtocolGenerator {
             case PropertyRequirement.OptionalNullable =>
               t"$presenceType[Option[$tpe]]" -> defaultValue.map(t => q"$presence.Present($t)")
           }
-          term = param"${Term.Name(argName)}: ${finalDeclType}".copy(default = finalDefaultValue)
+          term = param"${Term.Name(fieldName)}: ${finalDeclType}".copy(default = finalDefaultValue)
           dep  = classDep.filterNot(_.value == clsName) // Filter out our own class name
         } yield ProtocolParameter[ScalaLanguage](
           term,
@@ -264,7 +262,6 @@ object CirceProtocolGenerator {
     def encodeModel(
         clsName: String,
         dtoPackage: List[String],
-        needCamelSnakeConversion: Boolean,
         selfParams: List[ProtocolParameter[ScalaLanguage]],
         parents: List[SuperClass[ScalaLanguage]] = Nil
     ) = {
@@ -365,7 +362,6 @@ object CirceProtocolGenerator {
         clsName: String,
         dtoPackage: List[String],
         supportPackage: List[String],
-        needCamelSnakeConversion: Boolean,
         selfParams: List[ProtocolParameter[ScalaLanguage]],
         parents: List[SuperClass[ScalaLanguage]] = Nil
     ) = {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/EndpointsClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/EndpointsClientGenerator.scala
@@ -31,6 +31,7 @@ object EndpointsClientGenerator {
 
     def generateClientOperation(
         className: List[String],
+        responseClsName: String,
         tracing: Boolean,
         securitySchemes: Map[String, SecurityScheme[ScalaLanguage]],
         parameters: LanguageParameters[ScalaLanguage]
@@ -131,6 +132,7 @@ object EndpointsClientGenerator {
 
       def build(
           methodName: String,
+          responseClsName: String,
           httpMethod: HttpMethod,
           pathPattern: Term,
           formDataParams: Option[Term],
@@ -209,8 +211,8 @@ object EndpointsClientGenerator {
             (None, None)
           }
 
-        val responseCompanionTerm = Term.Name(s"${methodName.capitalize}Response")
-        val responseCompanionType = Type.Name(s"${methodName.capitalize}Response")
+        val responseCompanionTerm = Term.Name(responseClsName)
+        val responseCompanionType = Type.Name(responseClsName)
 
         val cases = responses.value.map { resp =>
             val responseTerm = Term.Name(s"${resp.statusCodeName.value}")
@@ -407,6 +409,7 @@ object EndpointsClientGenerator {
           extraImplicits = List.empty
           renderedClientOperation = build(
             methodName,
+            responseClsName,
             httpMethod,
             pathPattern,
             formDataParams,
@@ -434,11 +437,11 @@ object EndpointsClientGenerator {
     def clientClsArgs(tracingName: Option[String], serverUrls: Option[NonEmptyList[URI]], tracing: Boolean): Target[List[List[scala.meta.Term.Param]]] =
       Target.pure(List(List(formatHost(serverUrls)) ++ (if (tracing) Some(formatClientName(tracingName)) else None)))
     def generateResponseDefinitions(
-        operationId: String,
+        responseClsName: String,
         responses: Responses[ScalaLanguage],
         protocolElems: List[StrictProtocolElems[ScalaLanguage]]
     ): Target[List[scala.meta.Defn]] =
-      Target.pure(Http4sHelper.generateResponseDefinitions(operationId, responses, protocolElems))
+      Target.pure(Http4sHelper.generateResponseDefinitions(responseClsName, responses, protocolElems))
     def generateSupportDefinitions(
         tracing: Boolean,
         securitySchemes: Map[String, SecurityScheme[ScalaLanguage]]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/EndpointsServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/EndpointsServerGenerator.scala
@@ -1,28 +1,27 @@
 package com.twilio.guardrail.generators.Scala
 
-import cats.Monad
-import com.twilio.guardrail.{ Target, TracingField }
-import com.twilio.guardrail.languages.ScalaLanguage
-import com.twilio.guardrail.protocol.terms.server._
-import com.twilio.guardrail.terms.{ RouteMeta, SecurityScheme }
 import _root_.io.swagger.v3.oas.models.Operation
-import com.twilio.guardrail.StrictProtocolElems
+import cats.Monad
+import com.twilio.guardrail.{ StrictProtocolElems, Target }
 import com.twilio.guardrail.core.Tracker
+import com.twilio.guardrail.languages.ScalaLanguage
 import com.twilio.guardrail.protocol.terms.Responses
-import com.twilio.guardrail.generators.LanguageParameters
+import com.twilio.guardrail.protocol.terms.server._
+import com.twilio.guardrail.terms.SecurityScheme
 
 object EndpointsServerGenerator {
   object ServerTermInterp extends ServerTerms[ScalaLanguage, Target] {
     implicit def MonadF: Monad[Target] = Target.targetInstances
-    def generateResponseDefinitions(operationId: String, responses: Responses[ScalaLanguage], protocolElems: List[StrictProtocolElems[ScalaLanguage]]) =
+    def generateResponseDefinitions(responseClsName: String, responses: Responses[ScalaLanguage], protocolElems: List[StrictProtocolElems[ScalaLanguage]]) =
       Target.raiseUserError("endpoints server generation is not currently supported")
     def buildTracingFields(operation: Tracker[Operation], resourceName: List[String], tracing: Boolean) =
       Target.raiseUserError("endpoints server generation is not currently supported")
     def generateRoutes(
         tracing: Boolean,
         resourceName: String,
+        handlerName: String,
         basePath: Option[String],
-        routes: List[(String, Option[TracingField[ScalaLanguage]], RouteMeta, LanguageParameters[ScalaLanguage], Responses[ScalaLanguage])],
+        routes: List[GenerateRouteMeta[ScalaLanguage]],
         protocolElems: List[StrictProtocolElems[ScalaLanguage]],
         securitySchemes: Map[String, SecurityScheme[ScalaLanguage]]
     ) =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sHelper.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sHelper.scala
@@ -7,7 +7,7 @@ import scala.meta._
 
 object Http4sHelper {
   def generateResponseDefinitions(
-      operationId: String,
+      responseClsName: String,
       responses: Responses[ScalaLanguage],
       protocolElems: List[StrictProtocolElems[ScalaLanguage]]
   ): List[Defn] = {
@@ -15,8 +15,8 @@ object Http4sHelper {
     val extraTypes: List[Type]            = if (isGeneric) List(t"F") else Nil
     val extraTypeParams: List[Type.Param] = if (isGeneric) List(tparam"F[_]") else Nil
 
-    val responseSuperType     = Type.Name(s"${operationId.capitalize}Response")
-    val responseSuperTerm     = Term.Name(s"${operationId.capitalize}Response")
+    val responseSuperType     = Type.Name(responseClsName)
+    val responseSuperTerm     = Term.Name(responseClsName)
     val responseSuperTemplate = template"${Init(if (isGeneric) Type.Apply(responseSuperType, extraTypes) else responseSuperType, Name(""), List.empty)}"
 
     val (terms, foldPair) = responses.value
@@ -48,7 +48,7 @@ object Http4sHelper {
     val (foldParams, foldCases) = foldPair.unzip
 
     val companion = q"""
-            object ${Term.Name(s"${operationId.capitalize}Response")} {
+            object ${Term.Name(responseClsName)} {
               ..$terms
             }
           """

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
@@ -123,6 +123,7 @@ object ScalaGenerator {
       val Term.Name(name) = term
       Target.pure(name)
     }
+    def extractTermNameFromParam(param: scala.meta.Term.Param): Target[String] = Target.pure(param.name.value)
     def selectType(typeNames: NonEmptyList[String]): Target[scala.meta.Type] = {
       val tpe   = Type.Name(typeNames.last)
       val names = typeNames.init.map(Term.Name.apply _)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
@@ -68,7 +68,13 @@ object ScalaGenerator {
         case _ =>
           Target.raiseUserError[Term.Select](s"Enumeration $tpe somehow has a default value that isn't a string")
       }
-    def formatEnumName(enumValue: String): Target[String] = Target.pure(enumValue.toPascalCase)
+
+    def formatPackageName(packageName: List[String]): Target[List[String]]              = Target.pure(packageName.map(_.toCamelCase))
+    def formatTypeName(typeName: String, suffix: Option[String] = None): Target[String] = Target.pure(typeName.toPascalCase + suffix.fold("")(_.toPascalCase))
+    def formatFieldName(fieldName: String): Target[String]                              = Target.pure(fieldName.toCamelCase)
+    def formatMethodName(methodName: String): Target[String]                            = Target.pure(methodName.toCamelCase)
+    def formatMethodArgName(methodArgName: String): Target[String]                      = Target.pure(methodArgName.toCamelCase)
+    def formatEnumName(enumValue: String): Target[String]                               = Target.pure(enumValue.toPascalCase)
 
     def embedArray(tpe: LazyResolvedType[ScalaLanguage], containerTpe: Option[scala.meta.Type]): Target[LazyResolvedType[ScalaLanguage]] = tpe match {
       case SwaggerUtil.Deferred(tpe) =>

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/Java.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/Java.scala
@@ -231,6 +231,44 @@ object Java {
   )
 
   implicit class RichJavaString(private val s: String) extends AnyVal {
+    def escapeInvalidCharacters: String =
+      s.map({
+          case '`'  => "_backtick_"
+          case '~'  => "_tilde_"
+          case '!'  => "_bang_"
+          case '@'  => "_at_"
+          case '#'  => "_pound_"
+          case '%'  => "_percent_"
+          case '^'  => "_caret_"
+          case '&'  => "_ampersand_"
+          case '*'  => "_asterisk_"
+          case '('  => "_open_paren_"
+          case ')'  => "_close_paren_"
+          case '-'  => "_"
+          case '+'  => "_plus_"
+          case '='  => "_equals_"
+          case '|'  => "_pipe_"
+          case ':'  => "_colon_"
+          case ';'  => "_semicolon_"
+          case '"'  => "_double_quote_"
+          case '\'' => "_single_quote_"
+          case ','  => "_comma_"
+          case '.'  => "_dot_"
+          case '?'  => "_question_"
+          case '\\' => "_backslash_"
+          case '/'  => "_slash_"
+          case '['  => "_open_square_brace_"
+          case ']'  => "_close_square_brace_"
+          case '{'  => "_open_curly_brace_"
+          case '}'  => "_close_curly_brace_"
+          case '<'  => "_less_than_"
+          case '>'  => "_greater_than_"
+          case c    => c.toString
+        })
+        .mkString
+        .replaceAll("^_+", "")
+        .replaceAll("_+$", "")
+
     def escapeReservedWord: String = if (reservedWords.contains(s)) s + "_" else s
     def unescapeReservedWord: String =
       if (s.endsWith("_")) {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/Responses.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/Responses.scala
@@ -1,12 +1,11 @@
 package com.twilio.guardrail.protocol.terms
 
 import cats.implicits._
-import com.twilio.guardrail.{ StrictProtocolElems, SwaggerUtil, monadForFrameworkTerms }
 import com.twilio.guardrail.core.Tracker
-import com.twilio.guardrail.generators.syntax._
 import com.twilio.guardrail.languages.LA
-import com.twilio.guardrail.terms.{ LanguageTerms, SwaggerTerms }
 import com.twilio.guardrail.terms.framework.FrameworkTerms
+import com.twilio.guardrail.terms.{ LanguageTerms, SwaggerTerms }
+import com.twilio.guardrail.{ StrictProtocolElems, SwaggerUtil, monadForFrameworkTerms }
 import io.swagger.v3.oas.models.Operation
 import scala.collection.JavaConverters._
 
@@ -52,7 +51,8 @@ object Responses {
                   headers <- Option(resp.get.getHeaders).map(_.asScala.toList).getOrElse(List.empty).traverse {
                     case (name, header) =>
                       for {
-                        termName   <- pureTermName(s"${name}Header".toCamelCase)
+                        argName    <- formatMethodArgName(s"${name}Header")
+                        termName   <- pureTermName(argName)
                         typeName   <- pureTypeName("String").flatMap(widenTypeName)
                         resultType <- if (header.getRequired) typeName.pure[F] else liftOptionalType(typeName)
                       } yield new Header(name, header.getRequired, resultType, termName)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientTerms.scala
@@ -11,7 +11,13 @@ import java.net.URI
 
 abstract class ClientTerms[L <: LA, F[_]] {
   def MonadF: Monad[F]
-  def generateClientOperation(className: List[String], tracing: Boolean, securitySchemes: Map[String, SecurityScheme[L]], parameters: LanguageParameters[L])(
+  def generateClientOperation(
+      className: List[String],
+      responseClsName: String,
+      tracing: Boolean,
+      securitySchemes: Map[String, SecurityScheme[L]],
+      parameters: LanguageParameters[L]
+  )(
       route: RouteMeta,
       methodName: String,
       responses: Responses[L]
@@ -19,7 +25,7 @@ abstract class ClientTerms[L <: LA, F[_]] {
   def getImports(tracing: Boolean): F[List[L#Import]]
   def getExtraImports(tracing: Boolean): F[List[L#Import]]
   def clientClsArgs(tracingName: Option[String], serverUrls: Option[NonEmptyList[URI]], tracing: Boolean): F[List[List[L#MethodParameter]]]
-  def generateResponseDefinitions(operationId: String, responses: Responses[L], protocolElems: List[StrictProtocolElems[L]]): F[List[L#Definition]]
+  def generateResponseDefinitions(responseClsName: String, responses: Responses[L], protocolElems: List[StrictProtocolElems[L]]): F[List[L#Definition]]
   def generateSupportDefinitions(tracing: Boolean, securitySchemes: Map[String, SecurityScheme[L]]): F[List[SupportDefinition[L]]]
   def buildStaticDefns(
       clientName: String,
@@ -41,7 +47,7 @@ abstract class ClientTerms[L <: LA, F[_]] {
 
   def copy(
       newMonadF: Monad[F] = this.MonadF,
-      newGenerateClientOperation: (List[String], Boolean, Map[String, SecurityScheme[L]], LanguageParameters[L]) => (
+      newGenerateClientOperation: (List[String], String, Boolean, Map[String, SecurityScheme[L]], LanguageParameters[L]) => (
           RouteMeta,
           String,
           Responses[L]
@@ -65,17 +71,23 @@ abstract class ClientTerms[L <: LA, F[_]] {
       ) => F[NonEmptyList[Either[L#Trait, L#ClassDefinition]]] = buildClient _
   ): ClientTerms[L, F] = new ClientTerms[L, F] {
     def MonadF = newMonadF
-    def generateClientOperation(className: List[String], tracing: Boolean, securitySchemes: Map[String, SecurityScheme[L]], parameters: LanguageParameters[L])(
+    def generateClientOperation(
+        className: List[String],
+        responseClsName: String,
+        tracing: Boolean,
+        securitySchemes: Map[String, SecurityScheme[L]],
+        parameters: LanguageParameters[L]
+    )(
         route: RouteMeta,
         methodName: String,
         responses: Responses[L]
     ) =
-      newGenerateClientOperation(className, tracing, securitySchemes, parameters)(route, methodName, responses)
+      newGenerateClientOperation(className, responseClsName, tracing, securitySchemes, parameters)(route, methodName, responses)
     def getImports(tracing: Boolean)                                                                        = newGetImports(tracing)
     def getExtraImports(tracing: Boolean)                                                                   = newGetExtraImports(tracing)
     def clientClsArgs(tracingName: Option[String], serverUrls: Option[NonEmptyList[URI]], tracing: Boolean) = newClientClsArgs(tracingName, serverUrls, tracing)
-    def generateResponseDefinitions(operationId: String, responses: Responses[L], protocolElems: List[StrictProtocolElems[L]]) =
-      newGenerateResponseDefinitions(operationId, responses, protocolElems)
+    def generateResponseDefinitions(responseClsName: String, responses: Responses[L], protocolElems: List[StrictProtocolElems[L]]) =
+      newGenerateResponseDefinitions(responseClsName, responses, protocolElems)
     def generateSupportDefinitions(tracing: Boolean, securitySchemes: Map[String, SecurityScheme[L]]): F[List[SupportDefinition[L]]] =
       newGenerateSupportDefinitions(tracing, securitySchemes)
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerms.scala
@@ -14,10 +14,10 @@ abstract class ModelProtocolTerms[L <: LA, F[_]] {
       clsName: String,
       dtoPackage: List[String],
       supportPackage: List[String],
-      needCamelSnakeConversion: Boolean,
       concreteTypes: List[PropMeta[L]]
   )(
       name: String,
+      fieldName: String,
       prop: Schema[_],
       meta: ResolvedType[L],
       requirement: PropertyRequirement,
@@ -28,7 +28,6 @@ abstract class ModelProtocolTerms[L <: LA, F[_]] {
   def encodeModel(
       clsName: String,
       dtoPackage: List[String],
-      needCamelSnakeConversion: Boolean,
       params: List[ProtocolParameter[L]],
       parents: List[SuperClass[L]] = Nil
   ): F[Option[L#ValueDefinition]]
@@ -36,7 +35,6 @@ abstract class ModelProtocolTerms[L <: LA, F[_]] {
       clsName: String,
       dtoPackage: List[String],
       supportPackage: List[String],
-      needCamelSnakeConversion: Boolean,
       params: List[ProtocolParameter[L]],
       parents: List[SuperClass[L]] = Nil
   ): F[Option[L#ValueDefinition]]
@@ -49,13 +47,11 @@ abstract class ModelProtocolTerms[L <: LA, F[_]] {
           String,
           List[String],
           List[String],
-          Boolean,
           List[PropMeta[L]]
-      ) => (String, Schema[_], ResolvedType[L], PropertyRequirement, Boolean, Option[L#Term]) => F[ProtocolParameter[L]] = transformProperty _,
+      ) => (String, String, Schema[_], ResolvedType[L], PropertyRequirement, Boolean, Option[L#Term]) => F[ProtocolParameter[L]] = transformProperty _,
       newRenderDTOClass: (String, List[ProtocolParameter[L]], List[SuperClass[L]]) => F[L#ClassDefinition] = renderDTOClass _,
-      newDecodeModel: (String, List[String], List[String], Boolean, List[ProtocolParameter[L]], List[SuperClass[L]]) => F[Option[L#ValueDefinition]] =
-        decodeModel _,
-      newEncodeModel: (String, List[String], Boolean, List[ProtocolParameter[L]], List[SuperClass[L]]) => F[Option[L#ValueDefinition]] = encodeModel _,
+      newDecodeModel: (String, List[String], List[String], List[ProtocolParameter[L]], List[SuperClass[L]]) => F[Option[L#ValueDefinition]] = decodeModel _,
+      newEncodeModel: (String, List[String], List[ProtocolParameter[L]], List[SuperClass[L]]) => F[Option[L#ValueDefinition]] = encodeModel _,
       newRenderDTOStaticDefns: (String, List[L#TermName], Option[L#ValueDefinition], Option[L#ValueDefinition]) => F[StaticDefns[L]] = renderDTOStaticDefns _
   ) = new ModelProtocolTerms[L, F] {
     def MonadF                                         = newMonadF
@@ -64,11 +60,19 @@ abstract class ModelProtocolTerms[L <: LA, F[_]] {
         clsName: String,
         dtoPackage: List[String],
         supportPackage: List[String],
-        needCamelSnakeConversion: Boolean,
         concreteTypes: List[PropMeta[L]]
-    )(name: String, prop: Schema[_], meta: ResolvedType[L], requirement: PropertyRequirement, isCustomType: Boolean, defaultValue: Option[L#Term]) =
-      newTransformProperty(clsName, dtoPackage, supportPackage, needCamelSnakeConversion, concreteTypes)(
+    )(
+        name: String,
+        fieldName: String,
+        prop: Schema[_],
+        meta: ResolvedType[L],
+        requirement: PropertyRequirement,
+        isCustomType: Boolean,
+        defaultValue: Option[L#Term]
+    ) =
+      newTransformProperty(clsName, dtoPackage, supportPackage, concreteTypes)(
         name,
+        fieldName,
         prop,
         meta,
         requirement,
@@ -79,20 +83,18 @@ abstract class ModelProtocolTerms[L <: LA, F[_]] {
     def encodeModel(
         clsName: String,
         dtoPackage: List[String],
-        needCamelSnakeConversion: Boolean,
         params: List[ProtocolParameter[L]],
         parents: List[SuperClass[L]] = Nil
     ) =
-      newEncodeModel(clsName, dtoPackage, needCamelSnakeConversion, params, parents)
+      newEncodeModel(clsName, dtoPackage, params, parents)
     def decodeModel(
         clsName: String,
         dtoPackage: List[String],
         supportPackage: List[String],
-        needCamelSnakeConversion: Boolean,
         params: List[ProtocolParameter[L]],
         parents: List[SuperClass[L]] = Nil
     ) =
-      newDecodeModel(clsName, dtoPackage, supportPackage, needCamelSnakeConversion, params, parents)
+      newDecodeModel(clsName, dtoPackage, supportPackage, params, parents)
     def renderDTOStaticDefns(clsName: String, deps: List[L#TermName], encoder: Option[L#ValueDefinition], decoder: Option[L#ValueDefinition]) =
       newRenderDTOStaticDefns(clsName, deps, encoder, decoder)
   }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/LanguageTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/LanguageTerms.scala
@@ -52,6 +52,7 @@ abstract class LanguageTerms[L <: LA, F[_]] {
   def typesEqual(a: L#Type, b: L#Type): F[Boolean]
   def extractTypeName(tpe: L#Type): F[Option[L#TypeName]]
   def extractTermName(term: L#TermName): F[String]
+  def extractTermNameFromParam(param: L#MethodParameter): F[String]
   def selectType(typeNames: NonEmptyList[String]): F[L#Type]
   def selectTerm(termNames: NonEmptyList[String]): F[L#Term]
   def alterMethodParameterName(param: L#MethodParameter, name: L#TermName): F[L#MethodParameter]
@@ -174,6 +175,7 @@ abstract class LanguageTerms[L <: LA, F[_]] {
       newTypesEqual: (L#Type, L#Type) => F[Boolean] = typesEqual _,
       newExtractTypeName: L#Type => F[Option[L#TypeName]] = extractTypeName _,
       newExtractTermName: L#TermName => F[String] = extractTermName _,
+      newExtractTermNameFromParam: L#MethodParameter => F[String] = extractTermNameFromParam _,
       newSelectType: NonEmptyList[String] => F[L#Type] = selectType _,
       newSelectTerm: NonEmptyList[String] => F[L#Term] = selectTerm _,
       newAlterMethodParameterName: (L#MethodParameter, L#TermName) => F[L#MethodParameter] = alterMethodParameterName _,
@@ -258,6 +260,7 @@ abstract class LanguageTerms[L <: LA, F[_]] {
     def typesEqual(a: L#Type, b: L#Type)                                              = newTypesEqual(a, b)
     def extractTypeName(tpe: L#Type)                                                  = newExtractTypeName(tpe)
     def extractTermName(term: L#TermName)                                             = newExtractTermName(term)
+    def extractTermNameFromParam(param: L#MethodParameter)                            = newExtractTermNameFromParam(param)
     def selectType(typeNames: NonEmptyList[String])                                   = newSelectType(typeNames)
     def selectTerm(termNames: NonEmptyList[String])                                   = newSelectTerm(termNames)
     def alterMethodParameterName(param: L#MethodParameter, name: L#TermName)          = newAlterMethodParameterName(param, name)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/LanguageTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/LanguageTerms.scala
@@ -31,6 +31,12 @@ abstract class LanguageTerms[L <: LA, F[_]] {
   def fullyQualifyPackageName(rawPkgName: List[String]): F[List[String]]
 
   def lookupEnumDefaultValue(tpe: L#TypeName, defaultValue: L#Term, values: List[(String, L#TermName, L#TermSelect)]): F[L#TermSelect]
+
+  def formatPackageName(packageName: List[String]): F[List[String]]
+  def formatTypeName(typeName: String, suffix: Option[String] = None): F[String]
+  def formatFieldName(fieldName: String): F[String]
+  def formatMethodName(methodName: String): F[String]
+  def formatMethodArgName(methodArgName: String): F[String]
   def formatEnumName(enumValue: String): F[String]
 
   def embedArray(tpe: LazyResolvedType[L], customTpe: Option[L#Type]): F[LazyResolvedType[L]]
@@ -151,6 +157,11 @@ abstract class LanguageTerms[L <: LA, F[_]] {
       newLiftMapType: (L#Type, Option[L#Type]) => F[L#Type] = liftMapType _,
       newFullyQualifyPackageName: List[String] => F[List[String]] = fullyQualifyPackageName _,
       newLookupEnumDefaultValue: (L#TypeName, L#Term, List[(String, L#TermName, L#TermSelect)]) => F[L#TermSelect] = lookupEnumDefaultValue _,
+      newFormatPackageName: List[String] => F[List[String]] = formatPackageName _,
+      newFormatTypeName: (String, Option[String]) => F[String] = formatTypeName _,
+      newFormatFieldName: String => F[String] = formatFieldName _,
+      newFormatMethodName: String => F[String] = formatMethodName _,
+      newFormatMethodArgName: String => F[String] = formatMethodArgName _,
       newFormatEnumName: String => F[String] = formatEnumName _,
       newEmbedArray: (LazyResolvedType[L], Option[L#Type]) => F[LazyResolvedType[L]] = embedArray _,
       newEmbedMap: (LazyResolvedType[L], Option[L#Type]) => F[LazyResolvedType[L]] = embedMap _,
@@ -230,6 +241,11 @@ abstract class LanguageTerms[L <: LA, F[_]] {
     def fullyQualifyPackageName(rawPkgName: List[String])        = newFullyQualifyPackageName(rawPkgName)
     def lookupEnumDefaultValue(tpe: L#TypeName, defaultValue: L#Term, values: List[(String, L#TermName, L#TermSelect)]) =
       newLookupEnumDefaultValue(tpe, defaultValue, values)
+    def formatPackageName(packageName: List[String]): F[List[String]]                 = newFormatPackageName(packageName)
+    def formatTypeName(typeName: String, suffix: Option[String] = None): F[String]    = newFormatTypeName(typeName, suffix)
+    def formatFieldName(fieldName: String): F[String]                                 = newFormatFieldName(fieldName)
+    def formatMethodName(methodName: String): F[String]                               = newFormatMethodName(methodName)
+    def formatMethodArgName(methodArgName: String): F[String]                         = newFormatMethodArgName(methodArgName)
     def formatEnumName(enumValue: String)                                             = newFormatEnumName(enumValue)
     def embedArray(tpe: LazyResolvedType[L], customTpe: Option[L#Type])               = newEmbedArray(tpe, customTpe)
     def embedMap(tpe: LazyResolvedType[L], customTpe: Option[L#Type])                 = newEmbedMap(tpe, customTpe)

--- a/modules/codegen/src/test/scala/core/issues/Issue126.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue126.scala
@@ -31,30 +31,30 @@ class Issue126 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
 
     val handler  = q"""
       trait StoreHandler {
-        def getRoot(respond: StoreResource.getRootResponse.type)(): scala.concurrent.Future[StoreResource.getRootResponse]
+        def getRoot(respond: StoreResource.GetRootResponse.type)(): scala.concurrent.Future[StoreResource.GetRootResponse]
       }
     """
     val resource = q"""
       object StoreResource {
         def routes(handler: StoreHandler)(implicit mat: akka.stream.Materializer): Route = {
           {
-            pathEndOrSingleSlash(options(discardEntity(complete(handler.getRoot(getRootResponse)()))))
+            pathEndOrSingleSlash(options(discardEntity(complete(handler.getRoot(GetRootResponse)()))))
           }
         }
-        sealed abstract class getRootResponse(val statusCode: StatusCode)
-        case object getRootResponseOK extends getRootResponse(StatusCodes.OK)
-        object getRootResponse {
-          implicit val getRootTRM: ToResponseMarshaller[getRootResponse] = Marshaller { implicit ec =>
-            resp => getRootTR(resp)
+        sealed abstract class GetRootResponse(val statusCode: StatusCode)
+        case object GetRootResponseOK extends GetRootResponse(StatusCodes.OK)
+        object GetRootResponse {
+          implicit val getRootResponseTRM: ToResponseMarshaller[GetRootResponse] = Marshaller { implicit ec =>
+            resp => getRootResponseTR(resp)
           }
-          implicit def getRootTR(value: getRootResponse)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
-            case r: getRootResponseOK.type =>
+          implicit def getRootResponseTR(value: GetRootResponse)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
+            case r: GetRootResponseOK.type =>
               scala.concurrent.Future.successful(Marshalling.Opaque {
                 () => HttpResponse(r.statusCode)
               } :: Nil)
           }
-          def apply[T](value: T)(implicit ev: T => getRootResponse): getRootResponse = ev(value)
-          def OK: getRootResponse = getRootResponseOK
+          def apply[T](value: T)(implicit ev: T => GetRootResponse): GetRootResponse = ev(value)
+          def OK: GetRootResponse = GetRootResponseOK
         }
       }
     """

--- a/modules/codegen/src/test/scala/core/issues/Issue127.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue127.scala
@@ -40,7 +40,7 @@ class Issue127 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
 
     val handler = q"""
       trait Handler {
-        def uploadFile(respond: Resource.uploadFileResponse.type)(file: (File, Option[String], ContentType)): scala.concurrent.Future[Resource.uploadFileResponse]
+        def uploadFile(respond: Resource.UploadFileResponse.type)(file: (File, Option[String], ContentType)): scala.concurrent.Future[Resource.UploadFileResponse]
         def uploadFileMapFileField(fieldName: String, fileName: Option[String], contentType: ContentType): File
         def uploadFileUnmarshalToFile[F[_]: Functor](hashType: F[String], destFn: (String, Option[String], ContentType) => File)(implicit mat: Materializer): Unmarshaller[Multipart.FormData.BodyPart, (File, Option[String], ContentType, F[String])] = Unmarshaller { implicit executionContext =>
           part => {
@@ -142,23 +142,23 @@ class Issue127 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
                   }
                   maybe.fold(reject(_), tprovide(_))
               }))
-            }: Directive[Tuple1[(File, Option[String], ContentType)]]).apply(file => complete(handler.uploadFile(uploadFileResponse)(file)))))
+            }: Directive[Tuple1[(File, Option[String], ContentType)]]).apply(file => complete(handler.uploadFile(UploadFileResponse)(file)))))
           }
         }
-        sealed abstract class uploadFileResponse(val statusCode: StatusCode)
-        case object uploadFileResponseCreated extends uploadFileResponse(StatusCodes.Created)
-        object uploadFileResponse {
-          implicit val uploadFileTRM: ToResponseMarshaller[uploadFileResponse] = Marshaller { implicit ec =>
-            resp => uploadFileTR(resp)
+        sealed abstract class UploadFileResponse(val statusCode: StatusCode)
+        case object UploadFileResponseCreated extends UploadFileResponse(StatusCodes.Created)
+        object UploadFileResponse {
+          implicit val uploadFileResponseTRM: ToResponseMarshaller[UploadFileResponse] = Marshaller { implicit ec =>
+            resp => uploadFileResponseTR(resp)
           }
-          implicit def uploadFileTR(value: uploadFileResponse)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
-            case r: uploadFileResponseCreated.type =>
+          implicit def uploadFileResponseTR(value: UploadFileResponse)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
+            case r: UploadFileResponseCreated.type =>
               scala.concurrent.Future.successful(Marshalling.Opaque {
                 () => HttpResponse(r.statusCode)
               } :: Nil)
           }
-          def apply[T](value: T)(implicit ev: T => uploadFileResponse): uploadFileResponse = ev(value)
-          def Created: uploadFileResponse = uploadFileResponseCreated
+          def apply[T](value: T)(implicit ev: T => UploadFileResponse): UploadFileResponse = ev(value)
+          def Created: UploadFileResponse = UploadFileResponseCreated
         }
       }
     """

--- a/modules/codegen/src/test/scala/core/issues/Issue416.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue416.scala
@@ -46,9 +46,9 @@ class Issue416 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
         def routes(handler: Handler[F]): HttpRoutes[F] = HttpRoutes.of {
           {
             case req @ GET -> Root =>
-              mapRoute("GetRoot", req, {
+              mapRoute("getRoot", req, {
                 req.decodeWith(getRootDecoder, strict = false) { body =>
-                  handler.GetRoot(GetRootResponse)(body) flatMap ({
+                  handler.getRoot(GetRootResponse)(body) flatMap ({
                     case GetRootResponse.Ok =>
                       F.pure(Response[F](status = org.http4s.Status.Ok))
                   })

--- a/modules/codegen/src/test/scala/tests/core/BacktickTest.scala
+++ b/modules/codegen/src/test/scala/tests/core/BacktickTest.scala
@@ -77,7 +77,7 @@ class BacktickTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
     tags should equal(Seq("dashy-package"))
 
     val client = q"""
-      class `Dashy-packageClient`(host: String = "http://localhost:1234")(implicit httpClient: HttpRequest => Future[HttpResponse], ec: ExecutionContext, mat: Materializer) {
+      class DashyPackageClient(host: String = "http://localhost:1234")(implicit httpClient: HttpRequest => Future[HttpResponse], ec: ExecutionContext, mat: Materializer) {
         val basePath: String = ""
         private[this] def makeRequest[T: ToEntityMarshaller](method: HttpMethod, uri: Uri, headers: scala.collection.immutable.Seq[HttpHeader], entity: T, protocol: HttpProtocol): EitherT[Future, Either[Throwable, HttpResponse], HttpRequest] = {
           EitherT(Marshal(entity).to[RequestEntity].map[Either[Either[Throwable, HttpResponse], HttpRequest]] {
@@ -87,17 +87,17 @@ class BacktickTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
               Left(Left(t))
           }))
         }
-        val `postDashy-op-idOKDecoder` = {
+        val postDashyOpIdOKDecoder = {
           structuredJsonEntityUnmarshaller.flatMap(_ => _ => json => io.circe.Decoder[`dashy-class`].decodeJson(json).fold(FastFuture.failed, FastFuture.successful))
         }
-        val `dashy-op-idOKDecoder` = {
+        val dashyOpIdOKDecoder = {
           structuredJsonEntityUnmarshaller.flatMap(_ => _ => json => io.circe.Decoder[`dashy-class`].decodeJson(json).fold(FastFuture.failed, FastFuture.successful))
         }
-        def `postDashy-op-id`(dashyParameter: String, headers: List[HttpHeader] = Nil): EitherT[Future, Either[Throwable, HttpResponse], `PostDashy-op-idResponse`] = {
+        def postDashyOpId(dashyParameter: String, headers: List[HttpHeader] = Nil): EitherT[Future, Either[Throwable, HttpResponse], PostDashyOpIdResponse] = {
           val allHeaders = headers ++ scala.collection.immutable.Seq[Option[HttpHeader]]().flatten
           makeRequest(HttpMethods.POST, host + basePath + "/dashy-route" + "?" + Formatter.addArg("dashy-parameter", dashyParameter), allHeaders, HttpEntity.Empty, HttpProtocols.`HTTP/1.1`).flatMap(req => EitherT(httpClient(req).flatMap(resp => resp.status match {
             case StatusCodes.OK =>
-              Unmarshal(resp.entity).to[`dashy-class`](`postDashy-op-idOKDecoder`, implicitly, implicitly).map(x => Right(`PostDashy-op-idResponse`.OK(x)))
+              Unmarshal(resp.entity).to[`dashy-class`](postDashyOpIdOKDecoder, implicitly, implicitly).map(x => Right(PostDashyOpIdResponse.OK(x)))
             case _ =>
               FastFuture.successful(Left(Right(resp)))
           }).recover({
@@ -105,11 +105,11 @@ class BacktickTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
               Left(Left(e))
           })))
         }
-        def `dashy-op-id`(dashyParameter: String, headers: List[HttpHeader] = Nil): EitherT[Future, Either[Throwable, HttpResponse], `Dashy-op-idResponse`] = {
+        def dashyOpId(dashyParameter: String, headers: List[HttpHeader] = Nil): EitherT[Future, Either[Throwable, HttpResponse], DashyOpIdResponse] = {
           val allHeaders = headers ++ scala.collection.immutable.Seq[Option[HttpHeader]]().flatten
           makeRequest(HttpMethods.GET, host + basePath + "/dashy-route" + "?" + Formatter.addArg("dashy-parameter", dashyParameter), allHeaders, HttpEntity.Empty, HttpProtocols.`HTTP/1.1`).flatMap(req => EitherT(httpClient(req).flatMap(resp => resp.status match {
             case StatusCodes.OK =>
-              Unmarshal(resp.entity).to[`dashy-class`](`dashy-op-idOKDecoder`, implicitly, implicitly).map(x => Right(`Dashy-op-idResponse`.OK(x)))
+              Unmarshal(resp.entity).to[`dashy-class`](dashyOpIdOKDecoder, implicitly, implicitly).map(x => Right(DashyOpIdResponse.OK(x)))
             case _ =>
               FastFuture.successful(Left(Right(resp)))
           }).recover({
@@ -121,8 +121,8 @@ class BacktickTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
     """
 
     cls.head.right.get.structure should equal(client.structure)
-    cls.head.right.get.toString should include("class `Dashy-packageClient`")
-    cls.head.right.get.toString should include("def `dashy-op-id`")
+    cls.head.right.get.toString should include("class DashyPackageClient")
+    cls.head.right.get.toString should include("def dashyOpId")
     cls.head.right.get.toString should include("dashyParameter: String")
     cls.head.right.get.toString should include("\"dashy-parameter\", dashyParameter")
     cls.head.right.get.toString shouldNot include("``")
@@ -133,7 +133,7 @@ class BacktickTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
     //   automatically stripping the backticks. The following test ensures that even though
     //   the test doesn't follow the pattern, the generated code is still escaped.
     //   This behavior may change in scalameta 2.0.0+
-    cls.head.right.get.toString should include("def `postDashy-op-id`(dashyParameter")
+    cls.head.right.get.toString should include("def postDashyOpId(dashyParameter")
 
     cmp.toString shouldNot include("``")
   }

--- a/modules/codegen/src/test/scala/tests/core/BacktickTest.scala
+++ b/modules/codegen/src/test/scala/tests/core/BacktickTest.scala
@@ -88,16 +88,16 @@ class BacktickTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
           }))
         }
         val postDashyOpIdOKDecoder = {
-          structuredJsonEntityUnmarshaller.flatMap(_ => _ => json => io.circe.Decoder[`dashy-class`].decodeJson(json).fold(FastFuture.failed, FastFuture.successful))
+          structuredJsonEntityUnmarshaller.flatMap(_ => _ => json => io.circe.Decoder[DashyClass].decodeJson(json).fold(FastFuture.failed, FastFuture.successful))
         }
         val dashyOpIdOKDecoder = {
-          structuredJsonEntityUnmarshaller.flatMap(_ => _ => json => io.circe.Decoder[`dashy-class`].decodeJson(json).fold(FastFuture.failed, FastFuture.successful))
+          structuredJsonEntityUnmarshaller.flatMap(_ => _ => json => io.circe.Decoder[DashyClass].decodeJson(json).fold(FastFuture.failed, FastFuture.successful))
         }
         def postDashyOpId(dashyParameter: String, headers: List[HttpHeader] = Nil): EitherT[Future, Either[Throwable, HttpResponse], PostDashyOpIdResponse] = {
           val allHeaders = headers ++ scala.collection.immutable.Seq[Option[HttpHeader]]().flatten
           makeRequest(HttpMethods.POST, host + basePath + "/dashy-route" + "?" + Formatter.addArg("dashy-parameter", dashyParameter), allHeaders, HttpEntity.Empty, HttpProtocols.`HTTP/1.1`).flatMap(req => EitherT(httpClient(req).flatMap(resp => resp.status match {
             case StatusCodes.OK =>
-              Unmarshal(resp.entity).to[`dashy-class`](postDashyOpIdOKDecoder, implicitly, implicitly).map(x => Right(PostDashyOpIdResponse.OK(x)))
+              Unmarshal(resp.entity).to[DashyClass](postDashyOpIdOKDecoder, implicitly, implicitly).map(x => Right(PostDashyOpIdResponse.OK(x)))
             case _ =>
               FastFuture.successful(Left(Right(resp)))
           }).recover({
@@ -109,7 +109,7 @@ class BacktickTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
           val allHeaders = headers ++ scala.collection.immutable.Seq[Option[HttpHeader]]().flatten
           makeRequest(HttpMethods.GET, host + basePath + "/dashy-route" + "?" + Formatter.addArg("dashy-parameter", dashyParameter), allHeaders, HttpEntity.Empty, HttpProtocols.`HTTP/1.1`).flatMap(req => EitherT(httpClient(req).flatMap(resp => resp.status match {
             case StatusCodes.OK =>
-              Unmarshal(resp.entity).to[`dashy-class`](dashyOpIdOKDecoder, implicitly, implicitly).map(x => Right(DashyOpIdResponse.OK(x)))
+              Unmarshal(resp.entity).to[DashyClass](dashyOpIdOKDecoder, implicitly, implicitly).map(x => Right(DashyOpIdResponse.OK(x)))
             case _ =>
               FastFuture.successful(Left(Right(resp)))
           }).recover({
@@ -147,27 +147,27 @@ class BacktickTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
     val cmp = companionForStaticDefns(staticDefns)
 
     val definition = q"""
-    case class `dashy-class`(dashyParam: Option[Long] = None)
+    case class DashyClass(dashyParam: Option[Long] = None)
     """
     val companion  = q"""
-      object `dashy-class` {
-        implicit val `encodedashy-class`: Encoder.AsObject[`dashy-class`] = {
+      object DashyClass {
+        implicit val encodeDashyClass: Encoder.AsObject[DashyClass] = {
           val readOnlyKeys = Set[String]()
-          Encoder.AsObject.instance[`dashy-class`](a => JsonObject.fromIterable(Vector(("dashy-param", a.dashyParam.asJson)))).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
+          Encoder.AsObject.instance[DashyClass](a => JsonObject.fromIterable(Vector(("dashy-param", a.dashyParam.asJson)))).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
         }
-        implicit val `decodedashy-class`: Decoder[`dashy-class`] = new Decoder[`dashy-class`] { final def apply(c: HCursor): Decoder.Result[`dashy-class`] = for (v0 <- c.downField("dashy-param").as[Option[Long]]) yield `dashy-class`(v0) }
+        implicit val decodeDashyClass: Decoder[DashyClass] = new Decoder[DashyClass] { final def apply(c: HCursor): Decoder.Result[DashyClass] = for (v0 <- c.downField("dashy-param").as[Option[Long]]) yield DashyClass(v0) }
       }
     """
 
     cls.structure should equal(definition.structure)
-    cls.toString should include("case class `dashy-class`")
+    cls.toString should include("case class DashyClass")
     cls.toString should include("dashyParam")
     cls.toString shouldNot include("``")
 
     cmp.structure should equal(companion.structure)
-    cmp.toString should include("`encodedashy-class`")
-    cmp.toString should include("`decodedashy-class`")
-    cmp.toString should include("`dashy-class`(v0)")
+    cmp.toString should include("encodeDashyClass")
+    cmp.toString should include("decodeDashyClass")
+    cmp.toString should include("DashyClass(v0)")
     cmp.toString shouldNot include(".dashy-")
     cmp.toString shouldNot include("[dashy-")
     cmp.toString shouldNot include("= dashy-")
@@ -183,40 +183,40 @@ class BacktickTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
     val cmp = companionForStaticDefns(staticDefns)
 
     val definition = q"""
-    sealed abstract class `dashy-enum`(val value: String) extends Product with Serializable {
+    sealed abstract class DashyEnum(val value: String) extends Product with Serializable {
       override def toString: String = value.toString
     }
     """
     val companion  = q"""
-    object `dashy-enum` {
+    object DashyEnum {
       object members {
-        case object DashyValueA extends `dashy-enum`("dashy-value-a")
-        case object DashyValueB extends `dashy-enum`("dashy-value-b")
-        case object DashyValueC extends `dashy-enum`("dashy-value.c")
+        case object DashyValueA extends DashyEnum("dashy-value-a")
+        case object DashyValueB extends DashyEnum("dashy-value-b")
+        case object DashyValueC extends DashyEnum("dashy-value.c")
       }
-      val DashyValueA: `dashy-enum` = members.DashyValueA
-      val DashyValueB: `dashy-enum` = members.DashyValueB
-      val DashyValueC: `dashy-enum` = members.DashyValueC
+      val DashyValueA: DashyEnum = members.DashyValueA
+      val DashyValueB: DashyEnum = members.DashyValueB
+      val DashyValueC: DashyEnum = members.DashyValueC
       val values = Vector(DashyValueA, DashyValueB, DashyValueC)
-      implicit val `encodedashy-enum`: Encoder[`dashy-enum`] = Encoder[String].contramap(_.value)
-      implicit val `decodedashy-enum`: Decoder[`dashy-enum`] = Decoder[String].emap(value => parse(value).toRight(s"$$value not a member of dashy-enum"))
-      implicit val `addPathdashy-enum`: AddPath[`dashy-enum`] = AddPath.build(_.value)
-      implicit val `showdashy-enum`: Show[`dashy-enum`] = Show.build(_.value)
-      def parse(value: String): Option[`dashy-enum`] = values.find(_.value == value)
-      implicit val order: cats.Order[`dashy-enum`] = cats.Order.by[`dashy-enum`, Int](values.indexOf)
+      implicit val encodeDashyEnum: Encoder[DashyEnum] = Encoder[String].contramap(_.value)
+      implicit val decodeDashyEnum: Decoder[DashyEnum] = Decoder[String].emap(value => parse(value).toRight(s"$$value not a member of DashyEnum"))
+      implicit val addPathDashyEnum: AddPath[DashyEnum] = AddPath.build(_.value)
+      implicit val showDashyEnum: Show[DashyEnum] = Show.build(_.value)
+      def parse(value: String): Option[DashyEnum] = values.find(_.value == value)
+      implicit val order: cats.Order[DashyEnum] = cats.Order.by[DashyEnum, Int](values.indexOf)
     }
     """
 
     cls.structure should equal(definition.structure)
-    cls.toString should include("sealed abstract class `dashy-enum`")
+    cls.toString should include("sealed abstract class DashyEnum")
     cls.toString shouldNot include("``")
 
     cmp.structure should equal(companion.structure)
     cmp.toString should include("val DashyValueA")
     cmp.toString should include("case object DashyValueB")
-    cmp.toString should include("`encodedashy-enum`")
-    cmp.toString should include("`decodedashy-enum`")
-    cmp.toString should include("def parse(value: String): Option[`dashy-enum`]")
+    cmp.toString should include("encodeDashyEnum")
+    cmp.toString should include("decodeDashyEnum")
+    cmp.toString should include("def parse(value: String): Option[DashyEnum]")
     cmp.toString should include("DashyValueC")
     cmp.toString shouldNot include(".dashy-")
     cmp.toString shouldNot include("[dashy-")

--- a/modules/codegen/src/test/scala/tests/core/DereferencingAliasesSpec.scala
+++ b/modules/codegen/src/test/scala/tests/core/DereferencingAliasesSpec.scala
@@ -75,16 +75,16 @@ class DereferencingAliasesSpec extends AnyFunSuite with Matchers with SwaggerSpe
     val clientCmp = companionForStaticDefns(clientStaticDefns)
 
     val definition = q"""
-      case class propRef(param: Option[Long] = None, array: Option[Vector[Long]] = None, arrayArray: Option[Vector[Vector[Long]]] = None)
+      case class PropRef(param: Option[Long] = None, array: Option[Vector[Long]] = None, arrayArray: Option[Vector[Vector[Long]]] = None)
     """
 
     val companion = q"""
-      object propRef {
-        implicit val encodepropRef: Encoder.AsObject[propRef] = {
+      object PropRef {
+        implicit val encodePropRef: Encoder.AsObject[PropRef] = {
           val readOnlyKeys = Set[String]()
-          Encoder.AsObject.instance[propRef](a => JsonObject.fromIterable(Vector(("param", a.param.asJson), ("array", a.array.asJson), ("arrayArray", a.arrayArray.asJson)))).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
+          Encoder.AsObject.instance[PropRef](a => JsonObject.fromIterable(Vector(("param", a.param.asJson), ("array", a.array.asJson), ("arrayArray", a.arrayArray.asJson)))).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
         }
-        implicit val decodepropRef: Decoder[propRef] = new Decoder[propRef] { final def apply(c: HCursor): Decoder.Result[propRef] = for (v0 <- c.downField("param").as[Option[Long]]; v1 <- c.downField("array").as[Option[Vector[Long]]]; v2 <- c.downField("arrayArray").as[Option[Vector[Vector[Long]]]]) yield propRef(v0, v1, v2) }
+        implicit val decodePropRef: Decoder[PropRef] = new Decoder[PropRef] { final def apply(c: HCursor): Decoder.Result[PropRef] = for (v0 <- c.downField("param").as[Option[Long]]; v1 <- c.downField("array").as[Option[Vector[Long]]]; v2 <- c.downField("arrayArray").as[Option[Vector[Vector[Long]]]]) yield PropRef(v0, v1, v2) }
       }
     """
 
@@ -111,7 +111,7 @@ class DereferencingAliasesSpec extends AnyFunSuite with Matchers with SwaggerSpe
         val doFooOKDecoder = {
           structuredJsonEntityUnmarshaller.flatMap(_ => _ => json => io.circe.Decoder[Vector[Vector[Long]]].decodeJson(json).fold(FastFuture.failed, FastFuture.successful))
         }
-        def doFoo(long: Option[Long] = None, body: Option[propRef] = None, headers: List[HttpHeader] = Nil): EitherT[Future, Either[Throwable, HttpResponse], DoFooResponse] = {
+        def doFoo(long: Option[Long] = None, body: Option[PropRef] = None, headers: List[HttpHeader] = Nil): EitherT[Future, Either[Throwable, HttpResponse], DoFooResponse] = {
           val allHeaders = headers ++ scala.collection.immutable.Seq[Option[HttpHeader]]().flatten
           makeRequest(HttpMethods.POST, host + basePath + "/foo" + "?" + Formatter.addArg("long", long), allHeaders, body, HttpProtocols.`HTTP/1.1`).flatMap(req => EitherT(httpClient(req).flatMap(resp => resp.status match {
             case StatusCodes.OK =>

--- a/modules/codegen/src/test/scala/tests/core/TypesTest.scala
+++ b/modules/codegen/src/test/scala/tests/core/TypesTest.scala
@@ -103,7 +103,7 @@ class TypesTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
         bool: Option[Boolean] = None,
         string: Option[String] = None,
         date: Option[java.time.LocalDate] = None,
-        date_time: Option[java.time.OffsetDateTime] = None,
+        dateTime: Option[java.time.OffsetDateTime] = None,
         byte: Option[Base64String] = None,
         long: Option[Long] = None,
         int: Option[Int] = None,
@@ -124,7 +124,7 @@ class TypesTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
       object Types {
         implicit val encodeTypes: Encoder.AsObject[Types] = {
           val readOnlyKeys = Set[String]()
-          Encoder.AsObject.instance[Types](a => JsonObject.fromIterable(Vector(("array", a.array.asJson), ("map", a.map.asJson), ("obj", a.obj.asJson), ("bool", a.bool.asJson), ("string", a.string.asJson), ("date", a.date.asJson), ("date_time", a.date_time.asJson), ("byte", a.byte.asJson), ("long", a.long.asJson), ("int", a.int.asJson), ("float", a.float.asJson), ("double", a.double.asJson), ("number", a.number.asJson), ("integer", a.integer.asJson), ("untyped", a.untyped.asJson), ("custom", a.custom.asJson), ("customComplex", a.customComplex.asJson), ("nested", a.nested.asJson), ("nestedArray", a.nestedArray.asJson), ("requiredArray", a.requiredArray.asJson)))).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
+          Encoder.AsObject.instance[Types](a => JsonObject.fromIterable(Vector(("array", a.array.asJson), ("map", a.map.asJson), ("obj", a.obj.asJson), ("bool", a.bool.asJson), ("string", a.string.asJson), ("date", a.date.asJson), ("date_time", a.dateTime.asJson), ("byte", a.byte.asJson), ("long", a.long.asJson), ("int", a.int.asJson), ("float", a.float.asJson), ("double", a.double.asJson), ("number", a.number.asJson), ("integer", a.integer.asJson), ("untyped", a.untyped.asJson), ("custom", a.custom.asJson), ("customComplex", a.customComplex.asJson), ("nested", a.nested.asJson), ("nestedArray", a.nestedArray.asJson), ("requiredArray", a.requiredArray.asJson)))).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
         }
         implicit val decodeTypes: Decoder[Types] = new Decoder[Types] { final def apply(c: HCursor): Decoder.Result[Types] = for (v0 <- c.downField("array").as[Option[Vector[Boolean]]]; v1 <- c.downField("map").as[Option[Map[String, Boolean]]]; v2 <- c.downField("obj").as[Option[io.circe.Json]]; v3 <- c.downField("bool").as[Option[Boolean]]; v4 <- c.downField("string").as[Option[String]]; v5 <- c.downField("date").as[Option[java.time.LocalDate]]; v6 <- c.downField("date_time").as[Option[java.time.OffsetDateTime]]; v7 <- c.downField("byte").as[Option[Base64String]]; v8 <- c.downField("long").as[Option[Long]]; v9 <- c.downField("int").as[Option[Int]]; v10 <- c.downField("float").as[Option[Float]]; v11 <- c.downField("double").as[Option[Double]]; v12 <- c.downField("number").as[Option[BigDecimal]]; v13 <- c.downField("integer").as[Option[BigInt]]; v14 <- c.downField("untyped").as[Option[io.circe.Json]]; v15 <- c.downField("custom").as[Option[Foo]]; v16 <- c.downField("customComplex").as[Option[Foo[Bar]]]; v17 <- c.downField("nested").as[Option[Types.Nested]]; v18 <- c.downField("nestedArray").as[Option[Vector[Types.NestedArray]]]; v19 <- c.downField("requiredArray").as[Vector[String]]) yield Types(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19) }
         case class Nested(prop1: Option[String] = None)
@@ -235,27 +235,27 @@ class TypesTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
     )       = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
     val cmp = companionForStaticDefns(staticDefns)
 
-    val definition = q"""case class First(Second: Option[First.Second] = None)"""
+    val definition = q"""case class First(second: Option[First.Second] = None)"""
 
     val companion = q"""
       object First {
         implicit val encodeFirst: Encoder.AsObject[First] = {
           val readOnlyKeys = Set[String]()
-          Encoder.AsObject.instance[First](a => JsonObject.fromIterable(Vector(("Second", a.Second.asJson)))).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
+          Encoder.AsObject.instance[First](a => JsonObject.fromIterable(Vector(("Second", a.second.asJson)))).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
         }
         implicit val decodeFirst: Decoder[First] = new Decoder[First] { final def apply(c: HCursor): Decoder.Result[First] = for (v0 <- c.downField("Second").as[Option[First.Second]]) yield First(v0) }
-        case class Second(Third: Option[First.Second.Third] = None)
+        case class Second(third: Option[First.Second.Third] = None)
         object Second {
           implicit val encodeSecond: Encoder.AsObject[Second] = {
             val readOnlyKeys = Set[String]()
-            Encoder.AsObject.instance[Second](a => JsonObject.fromIterable(Vector(("Third", a.Third.asJson)))).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
+            Encoder.AsObject.instance[Second](a => JsonObject.fromIterable(Vector(("Third", a.third.asJson)))).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
           }
           implicit val decodeSecond: Decoder[Second] = new Decoder[Second] { final def apply(c: HCursor): Decoder.Result[Second] = for (v0 <- c.downField("Third").as[Option[First.Second.Third]]) yield Second(v0) }
-          case class Third(Fourth: Option[String] = None)
+          case class Third(fourth: Option[String] = None)
           object Third {
             implicit val encodeThird: Encoder.AsObject[Third] = {
               val readOnlyKeys = Set[String]()
-              Encoder.AsObject.instance[Third](a => JsonObject.fromIterable(Vector(("Fourth", a.Fourth.asJson)))).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
+              Encoder.AsObject.instance[Third](a => JsonObject.fromIterable(Vector(("Fourth", a.fourth.asJson)))).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
             }
             implicit val decodeThird: Decoder[Third] = new Decoder[Third] { final def apply(c: HCursor): Decoder.Result[Third] = for (v0 <- c.downField("Fourth").as[Option[String]]) yield Third(v0) }
           }

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/AkkaHttpServerTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/AkkaHttpServerTest.scala
@@ -133,126 +133,126 @@ class AkkaHttpServerTest extends AnyFunSuite with Matchers with SwaggerSpecRunne
 
     val handler  = q"""
       trait StoreHandler {
-        def getRoot(respond: StoreResource.getRootResponse.type)(): scala.concurrent.Future[StoreResource.getRootResponse]
-        def putBar(respond: StoreResource.putBarResponse.type)(bar: Long): scala.concurrent.Future[HttpResponse]
-        def getFoo(respond: StoreResource.getFooResponse.type)(): scala.concurrent.Future[StoreResource.getFooResponse]
-        def getFooBar(respond: StoreResource.getFooBarResponse.type)(bar: Long): scala.concurrent.Future[StoreResource.getFooBarResponse]
-        def getOrderById(respond: StoreResource.getOrderByIdResponse.type)(orderId: Long, status: OrderStatus = OrderStatus.Placed): scala.concurrent.Future[StoreResource.getOrderByIdResponse]
+        def getRoot(respond: StoreResource.GetRootResponse.type)(): scala.concurrent.Future[StoreResource.GetRootResponse]
+        def putBar(respond: StoreResource.PutBarResponse.type)(bar: Long): scala.concurrent.Future[HttpResponse]
+        def getFoo(respond: StoreResource.GetFooResponse.type)(): scala.concurrent.Future[StoreResource.GetFooResponse]
+        def getFooBar(respond: StoreResource.GetFooBarResponse.type)(bar: Long): scala.concurrent.Future[StoreResource.GetFooBarResponse]
+        def getOrderById(respond: StoreResource.GetOrderByIdResponse.type)(orderId: Long, status: OrderStatus = OrderStatus.Placed): scala.concurrent.Future[StoreResource.GetOrderByIdResponse]
       }
     """
     val resource = q"""
       object StoreResource {
         def routes(handler: StoreHandler)(implicit mat: akka.stream.Materializer): Route = {
           {
-            pathEndOrSingleSlash(get(discardEntity(complete(handler.getRoot(getRootResponse)()))))
+            pathEndOrSingleSlash(get(discardEntity(complete(handler.getRoot(GetRootResponse)()))))
           } ~ {
-            path("bar")(put(parameter(Symbol("bar").as[Long]).apply(bar => discardEntity(complete(handler.putBar(putBarResponse)(bar))))))
+            path("bar")(put(parameter(Symbol("bar").as[Long]).apply(bar => discardEntity(complete(handler.putBar(PutBarResponse)(bar))))))
           } ~ {
-            (pathPrefix("foo") & pathEndOrSingleSlash)(get(discardEntity(complete(handler.getFoo(getFooResponse)()))))
+            (pathPrefix("foo") & pathEndOrSingleSlash)(get(discardEntity(complete(handler.getFoo(GetFooResponse)()))))
           } ~ {
-            path("foo" / LongNumber).apply(bar => get(discardEntity(complete(handler.getFooBar(getFooBarResponse)(bar)))))
+            path("foo" / LongNumber).apply(bar => get(discardEntity(complete(handler.getFooBar(GetFooBarResponse)(bar)))))
           } ~ {
-            path("store" / "order" / LongNumber).apply(orderId => get(parameter(Symbol("status").as[OrderStatus](stringyJsonUnmarshaller.andThen(unmarshallJson[OrderStatus]))).apply(status => discardEntity(complete(handler.getOrderById(getOrderByIdResponse)(orderId, status))))))
+            path("store" / "order" / LongNumber).apply(orderId => get(parameter(Symbol("status").as[OrderStatus](stringyJsonUnmarshaller.andThen(unmarshallJson[OrderStatus]))).apply(status => discardEntity(complete(handler.getOrderById(GetOrderByIdResponse)(orderId, status))))))
           }
         }
-        sealed abstract class getRootResponse(val statusCode: StatusCode)
-        case object getRootResponseOK extends getRootResponse(StatusCodes.OK)
-        object getRootResponse {
-          implicit val getRootTRM: ToResponseMarshaller[getRootResponse] = Marshaller { implicit ec =>
-            resp => getRootTR(resp)
+        sealed abstract class GetRootResponse(val statusCode: StatusCode)
+        case object GetRootResponseOK extends GetRootResponse(StatusCodes.OK)
+        object GetRootResponse {
+          implicit val getRootResponseTRM: ToResponseMarshaller[GetRootResponse] = Marshaller { implicit ec =>
+            resp => getRootResponseTR(resp)
           }
-          implicit def getRootTR(value: getRootResponse)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
-            case r: getRootResponseOK.type =>
+          implicit def getRootResponseTR(value: GetRootResponse)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
+            case r: GetRootResponseOK.type =>
               scala.concurrent.Future.successful(Marshalling.Opaque {
                 () => HttpResponse(r.statusCode)
               } :: Nil)
           }
-          def apply[T](value: T)(implicit ev: T => getRootResponse): getRootResponse = ev(value)
-          def OK: getRootResponse = getRootResponseOK
+          def apply[T](value: T)(implicit ev: T => GetRootResponse): GetRootResponse = ev(value)
+          def OK: GetRootResponse = GetRootResponseOK
         }
-        sealed abstract class putBarResponse(val statusCode: StatusCode)
-        case class putBarResponseOK(value: Boolean) extends putBarResponse(StatusCodes.OK)
-        object putBarResponse {
-          implicit val putBarTRM: ToResponseMarshaller[putBarResponse] = Marshaller { implicit ec =>
-            resp => putBarTR(resp)
+        sealed abstract class PutBarResponse(val statusCode: StatusCode)
+        case class PutBarResponseOK(value: Boolean) extends PutBarResponse(StatusCodes.OK)
+        object PutBarResponse {
+          implicit val putBarResponseTRM: ToResponseMarshaller[PutBarResponse] = Marshaller { implicit ec =>
+            resp => putBarResponseTR(resp)
           }
-          implicit def putBarTR(value: putBarResponse)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
-            case r @ putBarResponseOK(value) =>
+          implicit def putBarResponseTR(value: PutBarResponse)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
+            case r @ PutBarResponseOK(value) =>
               Marshal(value).to[ResponseEntity].map {
                 entity => Marshalling.Opaque {
                   () => HttpResponse(r.statusCode, entity = entity)
                 } :: Nil
               }
           }
-          def apply[T](value: T)(implicit ev: T => putBarResponse): putBarResponse = ev(value)
-          implicit def OKEv(value: Boolean): putBarResponse = OK(value)
-          def OK(value: Boolean): putBarResponse = putBarResponseOK(value)
+          def apply[T](value: T)(implicit ev: T => PutBarResponse): PutBarResponse = ev(value)
+          implicit def OKEv(value: Boolean): PutBarResponse = OK(value)
+          def OK(value: Boolean): PutBarResponse = PutBarResponseOK(value)
         }
-        sealed abstract class getFooResponse(val statusCode: StatusCode)
-        case class getFooResponseOK(value: Boolean) extends getFooResponse(StatusCodes.OK)
-        object getFooResponse {
-          implicit val getFooTRM: ToResponseMarshaller[getFooResponse] = Marshaller { implicit ec =>
-            resp => getFooTR(resp)
+        sealed abstract class GetFooResponse(val statusCode: StatusCode)
+        case class GetFooResponseOK(value: Boolean) extends GetFooResponse(StatusCodes.OK)
+        object GetFooResponse {
+          implicit val getFooResponseTRM: ToResponseMarshaller[GetFooResponse] = Marshaller { implicit ec =>
+            resp => getFooResponseTR(resp)
           }
-          implicit def getFooTR(value: getFooResponse)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
-            case r @ getFooResponseOK(value) =>
+          implicit def getFooResponseTR(value: GetFooResponse)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
+            case r @ GetFooResponseOK(value) =>
               Marshal(value).to[ResponseEntity].map {
                 entity => Marshalling.Opaque {
                   () => HttpResponse(r.statusCode, entity = entity)
                 } :: Nil
               }
           }
-          def apply[T](value: T)(implicit ev: T => getFooResponse): getFooResponse = ev(value)
-          implicit def OKEv(value: Boolean): getFooResponse = OK(value)
-          def OK(value: Boolean): getFooResponse = getFooResponseOK(value)
+          def apply[T](value: T)(implicit ev: T => GetFooResponse): GetFooResponse = ev(value)
+          implicit def OKEv(value: Boolean): GetFooResponse = OK(value)
+          def OK(value: Boolean): GetFooResponse = GetFooResponseOK(value)
         }
-        sealed abstract class getFooBarResponse(val statusCode: StatusCode)
-        case class getFooBarResponseOK(value: Boolean) extends getFooBarResponse(StatusCodes.OK)
-        object getFooBarResponse {
-          implicit val getFooBarTRM: ToResponseMarshaller[getFooBarResponse] = Marshaller { implicit ec =>
-            resp => getFooBarTR(resp)
+        sealed abstract class GetFooBarResponse(val statusCode: StatusCode)
+        case class GetFooBarResponseOK(value: Boolean) extends GetFooBarResponse(StatusCodes.OK)
+        object GetFooBarResponse {
+          implicit val getFooBarResponseTRM: ToResponseMarshaller[GetFooBarResponse] = Marshaller { implicit ec =>
+            resp => getFooBarResponseTR(resp)
           }
-          implicit def getFooBarTR(value: getFooBarResponse)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
-            case r @ getFooBarResponseOK(value) =>
+          implicit def getFooBarResponseTR(value: GetFooBarResponse)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
+            case r @ GetFooBarResponseOK(value) =>
               Marshal(value).to[ResponseEntity].map {
                 entity => Marshalling.Opaque {
                   () => HttpResponse(r.statusCode, entity = entity)
                 } :: Nil
               }
           }
-          def apply[T](value: T)(implicit ev: T => getFooBarResponse): getFooBarResponse = ev(value)
-          implicit def OKEv(value: Boolean): getFooBarResponse = OK(value)
-          def OK(value: Boolean): getFooBarResponse = getFooBarResponseOK(value)
+          def apply[T](value: T)(implicit ev: T => GetFooBarResponse): GetFooBarResponse = ev(value)
+          implicit def OKEv(value: Boolean): GetFooBarResponse = OK(value)
+          def OK(value: Boolean): GetFooBarResponse = GetFooBarResponseOK(value)
         }
-        sealed abstract class getOrderByIdResponse(val statusCode: StatusCode)
-        case class getOrderByIdResponseOK(value: Order) extends getOrderByIdResponse(StatusCodes.OK)
-        case object getOrderByIdResponseBadRequest extends getOrderByIdResponse(StatusCodes.BadRequest)
-        case object getOrderByIdResponseNotFound extends getOrderByIdResponse(StatusCodes.NotFound)
-        object getOrderByIdResponse {
-          implicit val getOrderByIdTRM: ToResponseMarshaller[getOrderByIdResponse] = Marshaller { implicit ec =>
-            resp => getOrderByIdTR(resp)
+        sealed abstract class GetOrderByIdResponse(val statusCode: StatusCode)
+        case class GetOrderByIdResponseOK(value: Order) extends GetOrderByIdResponse(StatusCodes.OK)
+        case object GetOrderByIdResponseBadRequest extends GetOrderByIdResponse(StatusCodes.BadRequest)
+        case object GetOrderByIdResponseNotFound extends GetOrderByIdResponse(StatusCodes.NotFound)
+        object GetOrderByIdResponse {
+          implicit val getOrderByIdResponseTRM: ToResponseMarshaller[GetOrderByIdResponse] = Marshaller { implicit ec =>
+            resp => getOrderByIdResponseTR(resp)
           }
-          implicit def getOrderByIdTR(value: getOrderByIdResponse)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
-            case r @ getOrderByIdResponseOK(value) =>
+          implicit def getOrderByIdResponseTR(value: GetOrderByIdResponse)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
+            case r @ GetOrderByIdResponseOK(value) =>
               Marshal(value).to[ResponseEntity].map {
                 entity => Marshalling.Opaque {
                   () => HttpResponse(r.statusCode, entity = entity)
                 } :: Nil
               }
-            case r: getOrderByIdResponseBadRequest.type =>
+            case r: GetOrderByIdResponseBadRequest.type =>
               scala.concurrent.Future.successful(Marshalling.Opaque {
                 () => HttpResponse(r.statusCode)
               } :: Nil)
-            case r: getOrderByIdResponseNotFound.type =>
+            case r: GetOrderByIdResponseNotFound.type =>
               scala.concurrent.Future.successful(Marshalling.Opaque {
                 () => HttpResponse(r.statusCode)
               } :: Nil)
           }
-          def apply[T](value: T)(implicit ev: T => getOrderByIdResponse): getOrderByIdResponse = ev(value)
-          implicit def OKEv(value: Order): getOrderByIdResponse = OK(value)
-          def OK(value: Order): getOrderByIdResponse = getOrderByIdResponseOK(value)
-          def BadRequest: getOrderByIdResponse = getOrderByIdResponseBadRequest
-          def NotFound: getOrderByIdResponse = getOrderByIdResponseNotFound
+          def apply[T](value: T)(implicit ev: T => GetOrderByIdResponse): GetOrderByIdResponse = ev(value)
+          implicit def OKEv(value: Order): GetOrderByIdResponse = OK(value)
+          def OK(value: Order): GetOrderByIdResponse = GetOrderByIdResponseOK(value)
+          def BadRequest: GetOrderByIdResponse = GetOrderByIdResponseBadRequest
+          def NotFound: GetOrderByIdResponse = GetOrderByIdResponseNotFound
         }
       }
     """
@@ -270,126 +270,126 @@ class AkkaHttpServerTest extends AnyFunSuite with Matchers with SwaggerSpecRunne
 
     val handler  = q"""
       trait StoreHandler {
-        def getRoot(respond: StoreResource.getRootResponse.type)()(traceBuilder: TraceBuilder): scala.concurrent.Future[StoreResource.getRootResponse]
-        def putBar(respond: StoreResource.putBarResponse.type)(bar: Long)(traceBuilder: TraceBuilder): scala.concurrent.Future[HttpResponse]
-        def getFoo(respond: StoreResource.getFooResponse.type)()(traceBuilder: TraceBuilder): scala.concurrent.Future[StoreResource.getFooResponse]
-        def getFooBar(respond: StoreResource.getFooBarResponse.type)(bar: Long)(traceBuilder: TraceBuilder): scala.concurrent.Future[StoreResource.getFooBarResponse]
-        def getOrderById(respond: StoreResource.getOrderByIdResponse.type)(orderId: Long, status: OrderStatus = OrderStatus.Placed)(traceBuilder: TraceBuilder): scala.concurrent.Future[StoreResource.getOrderByIdResponse]
+        def getRoot(respond: StoreResource.GetRootResponse.type)()(traceBuilder: TraceBuilder): scala.concurrent.Future[StoreResource.GetRootResponse]
+        def putBar(respond: StoreResource.PutBarResponse.type)(bar: Long)(traceBuilder: TraceBuilder): scala.concurrent.Future[HttpResponse]
+        def getFoo(respond: StoreResource.GetFooResponse.type)()(traceBuilder: TraceBuilder): scala.concurrent.Future[StoreResource.GetFooResponse]
+        def getFooBar(respond: StoreResource.GetFooBarResponse.type)(bar: Long)(traceBuilder: TraceBuilder): scala.concurrent.Future[StoreResource.GetFooBarResponse]
+        def getOrderById(respond: StoreResource.GetOrderByIdResponse.type)(orderId: Long, status: OrderStatus = OrderStatus.Placed)(traceBuilder: TraceBuilder): scala.concurrent.Future[StoreResource.GetOrderByIdResponse]
       }
     """
     val resource = q"""
       object StoreResource {
         def routes(handler: StoreHandler, trace: String => Directive1[TraceBuilder])(implicit mat: akka.stream.Materializer): Route = {
           {
-            pathEndOrSingleSlash(get(trace("store:getRoot").apply(traceBuilder => discardEntity(complete(handler.getRoot(getRootResponse)()(traceBuilder))))))
+            pathEndOrSingleSlash(get(trace("store:getRoot").apply(traceBuilder => discardEntity(complete(handler.getRoot(GetRootResponse)()(traceBuilder))))))
           } ~ {
-            path("bar")(put(parameter(Symbol("bar").as[Long]).apply(bar => trace("store:putBar").apply(traceBuilder => discardEntity(complete(handler.putBar(putBarResponse)(bar)(traceBuilder)))))))
+            path("bar")(put(parameter(Symbol("bar").as[Long]).apply(bar => trace("store:putBar").apply(traceBuilder => discardEntity(complete(handler.putBar(PutBarResponse)(bar)(traceBuilder)))))))
           } ~ {
-            (pathPrefix("foo") & pathEndOrSingleSlash)(get(trace("store:getFoo").apply(traceBuilder => discardEntity(complete(handler.getFoo(getFooResponse)()(traceBuilder))))))
+            (pathPrefix("foo") & pathEndOrSingleSlash)(get(trace("store:getFoo").apply(traceBuilder => discardEntity(complete(handler.getFoo(GetFooResponse)()(traceBuilder))))))
           } ~ {
-            path("foo" / LongNumber).apply(bar => get(trace("completely-custom-label").apply(traceBuilder => discardEntity(complete(handler.getFooBar(getFooBarResponse)(bar)(traceBuilder))))))
+            path("foo" / LongNumber).apply(bar => get(trace("completely-custom-label").apply(traceBuilder => discardEntity(complete(handler.getFooBar(GetFooBarResponse)(bar)(traceBuilder))))))
           } ~ {
-            path("store" / "order" / LongNumber).apply(orderId => get(parameter(Symbol("status").as[OrderStatus](stringyJsonUnmarshaller.andThen(unmarshallJson[OrderStatus]))).apply(status => trace("store:getOrderById").apply(traceBuilder => discardEntity(complete(handler.getOrderById(getOrderByIdResponse)(orderId, status)(traceBuilder)))))))
+            path("store" / "order" / LongNumber).apply(orderId => get(parameter(Symbol("status").as[OrderStatus](stringyJsonUnmarshaller.andThen(unmarshallJson[OrderStatus]))).apply(status => trace("store:getOrderById").apply(traceBuilder => discardEntity(complete(handler.getOrderById(GetOrderByIdResponse)(orderId, status)(traceBuilder)))))))
           }
         }
-        sealed abstract class getRootResponse(val statusCode: StatusCode)
-        case object getRootResponseOK extends getRootResponse(StatusCodes.OK)
-        object getRootResponse {
-          implicit val getRootTRM: ToResponseMarshaller[getRootResponse] = Marshaller { implicit ec =>
-            resp => getRootTR(resp)
+        sealed abstract class GetRootResponse(val statusCode: StatusCode)
+        case object GetRootResponseOK extends GetRootResponse(StatusCodes.OK)
+        object GetRootResponse {
+          implicit val getRootResponseTRM: ToResponseMarshaller[GetRootResponse] = Marshaller { implicit ec =>
+            resp => getRootResponseTR(resp)
           }
-          implicit def getRootTR(value: getRootResponse)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
-            case r: getRootResponseOK.type =>
+          implicit def getRootResponseTR(value: GetRootResponse)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
+            case r: GetRootResponseOK.type =>
               scala.concurrent.Future.successful(Marshalling.Opaque {
                 () => HttpResponse(r.statusCode)
               } :: Nil)
           }
-          def apply[T](value: T)(implicit ev: T => getRootResponse): getRootResponse = ev(value)
-          def OK: getRootResponse = getRootResponseOK
+          def apply[T](value: T)(implicit ev: T => GetRootResponse): GetRootResponse = ev(value)
+          def OK: GetRootResponse = GetRootResponseOK
         }
-        sealed abstract class putBarResponse(val statusCode: StatusCode)
-        case class putBarResponseOK(value: Boolean) extends putBarResponse(StatusCodes.OK)
-        object putBarResponse {
-          implicit val putBarTRM: ToResponseMarshaller[putBarResponse] = Marshaller { implicit ec =>
-            resp => putBarTR(resp)
+        sealed abstract class PutBarResponse(val statusCode: StatusCode)
+        case class PutBarResponseOK(value: Boolean) extends PutBarResponse(StatusCodes.OK)
+        object PutBarResponse {
+          implicit val putBarResponseTRM: ToResponseMarshaller[PutBarResponse] = Marshaller { implicit ec =>
+            resp => putBarResponseTR(resp)
           }
-          implicit def putBarTR(value: putBarResponse)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
-            case r @ putBarResponseOK(value) =>
+          implicit def putBarResponseTR(value: PutBarResponse)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
+            case r @ PutBarResponseOK(value) =>
               Marshal(value).to[ResponseEntity].map {
                 entity => Marshalling.Opaque {
                   () => HttpResponse(r.statusCode, entity = entity)
                 } :: Nil
               }
           }
-          def apply[T](value: T)(implicit ev: T => putBarResponse): putBarResponse = ev(value)
-          implicit def OKEv(value: Boolean): putBarResponse = OK(value)
-          def OK(value: Boolean): putBarResponse = putBarResponseOK(value)
+          def apply[T](value: T)(implicit ev: T => PutBarResponse): PutBarResponse = ev(value)
+          implicit def OKEv(value: Boolean): PutBarResponse = OK(value)
+          def OK(value: Boolean): PutBarResponse = PutBarResponseOK(value)
         }
-        sealed abstract class getFooResponse(val statusCode: StatusCode)
-        case class getFooResponseOK(value: Boolean) extends getFooResponse(StatusCodes.OK)
-        object getFooResponse {
-          implicit val getFooTRM: ToResponseMarshaller[getFooResponse] = Marshaller { implicit ec =>
-            resp => getFooTR(resp)
+        sealed abstract class GetFooResponse(val statusCode: StatusCode)
+        case class GetFooResponseOK(value: Boolean) extends GetFooResponse(StatusCodes.OK)
+        object GetFooResponse {
+          implicit val getFooResponseTRM: ToResponseMarshaller[GetFooResponse] = Marshaller { implicit ec =>
+            resp => getFooResponseTR(resp)
           }
-          implicit def getFooTR(value: getFooResponse)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
-            case r @ getFooResponseOK(value) =>
+          implicit def getFooResponseTR(value: GetFooResponse)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
+            case r @ GetFooResponseOK(value) =>
               Marshal(value).to[ResponseEntity].map {
                 entity => Marshalling.Opaque {
                   () => HttpResponse(r.statusCode, entity = entity)
                 } :: Nil
               }
           }
-          def apply[T](value: T)(implicit ev: T => getFooResponse): getFooResponse = ev(value)
-          implicit def OKEv(value: Boolean): getFooResponse = OK(value)
-          def OK(value: Boolean): getFooResponse = getFooResponseOK(value)
+          def apply[T](value: T)(implicit ev: T => GetFooResponse): GetFooResponse = ev(value)
+          implicit def OKEv(value: Boolean): GetFooResponse = OK(value)
+          def OK(value: Boolean): GetFooResponse = GetFooResponseOK(value)
         }
-        sealed abstract class getFooBarResponse(val statusCode: StatusCode)
-        case class getFooBarResponseOK(value: Boolean) extends getFooBarResponse(StatusCodes.OK)
-        object getFooBarResponse {
-          implicit val getFooBarTRM: ToResponseMarshaller[getFooBarResponse] = Marshaller { implicit ec =>
-            resp => getFooBarTR(resp)
+        sealed abstract class GetFooBarResponse(val statusCode: StatusCode)
+        case class GetFooBarResponseOK(value: Boolean) extends GetFooBarResponse(StatusCodes.OK)
+        object GetFooBarResponse {
+          implicit val getFooBarResponseTRM: ToResponseMarshaller[GetFooBarResponse] = Marshaller { implicit ec =>
+            resp => getFooBarResponseTR(resp)
           }
-          implicit def getFooBarTR(value: getFooBarResponse)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
-            case r @ getFooBarResponseOK(value) =>
+          implicit def getFooBarResponseTR(value: GetFooBarResponse)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
+            case r @ GetFooBarResponseOK(value) =>
               Marshal(value).to[ResponseEntity].map {
                 entity => Marshalling.Opaque {
                   () => HttpResponse(r.statusCode, entity = entity)
                 } :: Nil
               }
           }
-          def apply[T](value: T)(implicit ev: T => getFooBarResponse): getFooBarResponse = ev(value)
-          implicit def OKEv(value: Boolean): getFooBarResponse = OK(value)
-          def OK(value: Boolean): getFooBarResponse = getFooBarResponseOK(value)
+          def apply[T](value: T)(implicit ev: T => GetFooBarResponse): GetFooBarResponse = ev(value)
+          implicit def OKEv(value: Boolean): GetFooBarResponse = OK(value)
+          def OK(value: Boolean): GetFooBarResponse = GetFooBarResponseOK(value)
         }
-        sealed abstract class getOrderByIdResponse(val statusCode: StatusCode)
-        case class getOrderByIdResponseOK(value: Order) extends getOrderByIdResponse(StatusCodes.OK)
-        case object getOrderByIdResponseBadRequest extends getOrderByIdResponse(StatusCodes.BadRequest)
-        case object getOrderByIdResponseNotFound extends getOrderByIdResponse(StatusCodes.NotFound)
-        object getOrderByIdResponse {
-          implicit val getOrderByIdTRM: ToResponseMarshaller[getOrderByIdResponse] = Marshaller { implicit ec =>
-            resp => getOrderByIdTR(resp)
+        sealed abstract class GetOrderByIdResponse(val statusCode: StatusCode)
+        case class GetOrderByIdResponseOK(value: Order) extends GetOrderByIdResponse(StatusCodes.OK)
+        case object GetOrderByIdResponseBadRequest extends GetOrderByIdResponse(StatusCodes.BadRequest)
+        case object GetOrderByIdResponseNotFound extends GetOrderByIdResponse(StatusCodes.NotFound)
+        object GetOrderByIdResponse {
+          implicit val getOrderByIdResponseTRM: ToResponseMarshaller[GetOrderByIdResponse] = Marshaller { implicit ec =>
+            resp => getOrderByIdResponseTR(resp)
           }
-          implicit def getOrderByIdTR(value: getOrderByIdResponse)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
-            case r @ getOrderByIdResponseOK(value) =>
+          implicit def getOrderByIdResponseTR(value: GetOrderByIdResponse)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
+            case r @ GetOrderByIdResponseOK(value) =>
               Marshal(value).to[ResponseEntity].map {
                 entity => Marshalling.Opaque {
                   () => HttpResponse(r.statusCode, entity = entity)
                 } :: Nil
               }
-            case r: getOrderByIdResponseBadRequest.type =>
+            case r: GetOrderByIdResponseBadRequest.type =>
               scala.concurrent.Future.successful(Marshalling.Opaque {
                 () => HttpResponse(r.statusCode)
               } :: Nil)
-            case r: getOrderByIdResponseNotFound.type =>
+            case r: GetOrderByIdResponseNotFound.type =>
               scala.concurrent.Future.successful(Marshalling.Opaque {
                 () => HttpResponse(r.statusCode)
               } :: Nil)
           }
-          def apply[T](value: T)(implicit ev: T => getOrderByIdResponse): getOrderByIdResponse = ev(value)
-          implicit def OKEv(value: Order): getOrderByIdResponse = OK(value)
-          def OK(value: Order): getOrderByIdResponse = getOrderByIdResponseOK(value)
-          def BadRequest: getOrderByIdResponse = getOrderByIdResponseBadRequest
-          def NotFound: getOrderByIdResponse = getOrderByIdResponseNotFound
+          def apply[T](value: T)(implicit ev: T => GetOrderByIdResponse): GetOrderByIdResponse = ev(value)
+          implicit def OKEv(value: Order): GetOrderByIdResponse = OK(value)
+          def OK(value: Order): GetOrderByIdResponse = GetOrderByIdResponseOK(value)
+          def BadRequest: GetOrderByIdResponse = GetOrderByIdResponseBadRequest
+          def NotFound: GetOrderByIdResponse = GetOrderByIdResponseNotFound
         }
       }
     """

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/CustomHeaderTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/CustomHeaderTest.scala
@@ -44,7 +44,7 @@ class CustomHeaderTest extends AnyFunSuite with Matchers with SwaggerSpecRunner 
       runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
 
     val handler =
-      q"""trait Handler { def getFoo(respond: Resource.getFooResponse.type)(customHeader: Bar): scala.concurrent.Future[Resource.getFooResponse] }"""
+      q"""trait Handler { def getFoo(respond: Resource.GetFooResponse.type)(customHeader: Bar): scala.concurrent.Future[Resource.GetFooResponse] }"""
 
     val resource = q"""
       object Resource {
@@ -55,23 +55,23 @@ class CustomHeaderTest extends AnyFunSuite with Matchers with SwaggerSpecRunner 
                 reject(MalformedHeaderRejection("CustomHeader", e.getMessage, Some(e)))
               case Success(x) =>
                 provide(x)
-            })).apply(customHeader => discardEntity(complete(handler.getFoo(getFooResponse)(customHeader))))))
+            })).apply(customHeader => discardEntity(complete(handler.getFoo(GetFooResponse)(customHeader))))))
           }
         }
-        sealed abstract class getFooResponse(val statusCode: StatusCode)
-        case object getFooResponseOK extends getFooResponse(StatusCodes.OK)
-        object getFooResponse {
-          implicit val getFooTRM: ToResponseMarshaller[getFooResponse] = Marshaller { implicit ec =>
-            resp => getFooTR(resp)
+        sealed abstract class GetFooResponse(val statusCode: StatusCode)
+        case object GetFooResponseOK extends GetFooResponse(StatusCodes.OK)
+        object GetFooResponse {
+          implicit val getFooResponseTRM: ToResponseMarshaller[GetFooResponse] = Marshaller { implicit ec =>
+            resp => getFooResponseTR(resp)
           }
-          implicit def getFooTR(value: getFooResponse)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
-            case r: getFooResponseOK.type =>
+          implicit def getFooResponseTR(value: GetFooResponse)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
+            case r: GetFooResponseOK.type =>
               scala.concurrent.Future.successful(Marshalling.Opaque {
                 () => HttpResponse(r.statusCode)
               } :: Nil)
           }
-          def apply[T](value: T)(implicit ev: T => getFooResponse): getFooResponse = ev(value)
-          def OK: getFooResponse = getFooResponseOK
+          def apply[T](value: T)(implicit ev: T => GetFooResponse): GetFooResponse = ev(value)
+          def OK: GetFooResponse = GetFooResponseOK
         }
       }
     """

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/StaticParametersTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/StaticParametersTest.scala
@@ -37,8 +37,8 @@ class StaticParametersTest extends AnyFunSuite with Matchers with SwaggerSpecRun
 
     val handler = q"""
       trait Handler {
-        def getFoo2(respond: Resource.getFoo2Response.type)(): scala.concurrent.Future[Resource.getFoo2Response]
-        def getFoo1(respond: Resource.getFoo1Response.type)(): scala.concurrent.Future[Resource.getFoo1Response]
+        def getFoo2(respond: Resource.GetFoo2Response.type)(): scala.concurrent.Future[Resource.GetFoo2Response]
+        def getFoo1(respond: Resource.GetFoo1Response.type)(): scala.concurrent.Future[Resource.GetFoo1Response]
       }
     """
 
@@ -46,40 +46,40 @@ class StaticParametersTest extends AnyFunSuite with Matchers with SwaggerSpecRun
       object Resource {
         def routes(handler: Handler)(implicit mat: akka.stream.Materializer): Route = {
           {
-            (pathPrefix("foo") & pathEndOrSingleSlash & parameter("bar").require(_ == "2"))(get(discardEntity(complete(handler.getFoo2(getFoo2Response)()))))
+            (pathPrefix("foo") & pathEndOrSingleSlash & parameter("bar").require(_ == "2"))(get(discardEntity(complete(handler.getFoo2(GetFoo2Response)()))))
           } ~ {
-            (path("foo") & parameter("bar").require(_ == "1"))(get(discardEntity(complete(handler.getFoo1(getFoo1Response)()))))
+            (path("foo") & parameter("bar").require(_ == "1"))(get(discardEntity(complete(handler.getFoo1(GetFoo1Response)()))))
           }
         }
-        sealed abstract class getFoo2Response(val statusCode: StatusCode)
-        case object getFoo2ResponseOK extends getFoo2Response(StatusCodes.OK)
-        object getFoo2Response {
-          implicit val getFoo2TRM: ToResponseMarshaller[getFoo2Response] = Marshaller { implicit ec =>
-            resp => getFoo2TR(resp)
+        sealed abstract class GetFoo2Response(val statusCode: StatusCode)
+        case object GetFoo2ResponseOK extends GetFoo2Response(StatusCodes.OK)
+        object GetFoo2Response {
+          implicit val getFoo2ResponseTRM: ToResponseMarshaller[GetFoo2Response] = Marshaller { implicit ec =>
+            resp => getFoo2ResponseTR(resp)
           }
-          implicit def getFoo2TR(value: getFoo2Response)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
-            case r: getFoo2ResponseOK.type =>
+          implicit def getFoo2ResponseTR(value: GetFoo2Response)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
+            case r: GetFoo2ResponseOK.type =>
               scala.concurrent.Future.successful(Marshalling.Opaque {
                 () => HttpResponse(r.statusCode)
               } :: Nil)
           }
-          def apply[T](value: T)(implicit ev: T => getFoo2Response): getFoo2Response = ev(value)
-          def OK: getFoo2Response = getFoo2ResponseOK
+          def apply[T](value: T)(implicit ev: T => GetFoo2Response): GetFoo2Response = ev(value)
+          def OK: GetFoo2Response = GetFoo2ResponseOK
         }
-        sealed abstract class getFoo1Response(val statusCode: StatusCode)
-        case object getFoo1ResponseOK extends getFoo1Response(StatusCodes.OK)
-        object getFoo1Response {
-          implicit val getFoo1TRM: ToResponseMarshaller[getFoo1Response] = Marshaller { implicit ec =>
-            resp => getFoo1TR(resp)
+        sealed abstract class GetFoo1Response(val statusCode: StatusCode)
+        case object GetFoo1ResponseOK extends GetFoo1Response(StatusCodes.OK)
+        object GetFoo1Response {
+          implicit val getFoo1ResponseTRM: ToResponseMarshaller[GetFoo1Response] = Marshaller { implicit ec =>
+            resp => getFoo1ResponseTR(resp)
           }
-          implicit def getFoo1TR(value: getFoo1Response)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
-            case r: getFoo1ResponseOK.type =>
+          implicit def getFoo1ResponseTR(value: GetFoo1Response)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
+            case r: GetFoo1ResponseOK.type =>
               scala.concurrent.Future.successful(Marshalling.Opaque {
                 () => HttpResponse(r.statusCode)
               } :: Nil)
           }
-          def apply[T](value: T)(implicit ev: T => getFoo1Response): getFoo1Response = ev(value)
-          def OK: getFoo1Response = getFoo1ResponseOK
+          def apply[T](value: T)(implicit ev: T => GetFoo1Response): GetFoo1Response = ev(value)
+          def OK: GetFoo1Response = GetFoo1ResponseOK
         }
       }
     """

--- a/modules/codegen/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
@@ -52,7 +52,7 @@ class FormFieldsServerTest extends AnyFunSuite with Matchers with SwaggerSpecRun
 
     val handler  = q"""
       trait Handler {
-        def putFoo(respond: Resource.putFooResponse.type)(foo: String, bar: Long, baz: (File, Option[String], ContentType, String)): scala.concurrent.Future[Resource.putFooResponse]
+        def putFoo(respond: Resource.PutFooResponse.type)(foo: String, bar: Long, baz: (File, Option[String], ContentType, String)): scala.concurrent.Future[Resource.PutFooResponse]
         def putFooMapFileField(fieldName: String, fileName: Option[String], contentType: ContentType): File
         def putFooUnmarshalToFile[F[_]: Functor](hashType: F[String], destFn: (String, Option[String], ContentType) => File)(implicit mat: Materializer): Unmarshaller[Multipart.FormData.BodyPart, (File, Option[String], ContentType, F[String])] = Unmarshaller { implicit executionContext =>
           part => {
@@ -177,23 +177,23 @@ class FormFieldsServerTest extends AnyFunSuite with Matchers with SwaggerSpecRun
                   }
                   maybe.fold(reject(_), tprovide(_))
               }))
-            }: Directive[(String, Long, (File, Option[String], ContentType, String))]).apply((foo, bar, baz) => complete(handler.putFoo(putFooResponse)(foo, bar, baz)))))
+            }: Directive[(String, Long, (File, Option[String], ContentType, String))]).apply((foo, bar, baz) => complete(handler.putFoo(PutFooResponse)(foo, bar, baz)))))
           }
         }
-        sealed abstract class putFooResponse(val statusCode: StatusCode)
-        case object putFooResponseOK extends putFooResponse(StatusCodes.OK)
-        object putFooResponse {
-          implicit val putFooTRM: ToResponseMarshaller[putFooResponse] = Marshaller { implicit ec =>
-            resp => putFooTR(resp)
+        sealed abstract class PutFooResponse(val statusCode: StatusCode)
+        case object PutFooResponseOK extends PutFooResponse(StatusCodes.OK)
+        object PutFooResponse {
+          implicit val putFooResponseTRM: ToResponseMarshaller[PutFooResponse] = Marshaller { implicit ec =>
+            resp => putFooResponseTR(resp)
           }
-          implicit def putFooTR(value: putFooResponse)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
-            case r: putFooResponseOK.type =>
+          implicit def putFooResponseTR(value: PutFooResponse)(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[List[Marshalling[HttpResponse]]] = value match {
+            case r: PutFooResponseOK.type =>
               scala.concurrent.Future.successful(Marshalling.Opaque {
                 () => HttpResponse(r.statusCode)
               } :: Nil)
           }
-          def apply[T](value: T)(implicit ev: T => putFooResponse): putFooResponse = ev(value)
-          def OK: putFooResponse = putFooResponseOK
+          def apply[T](value: T)(implicit ev: T => PutFooResponse): PutFooResponse = ev(value)
+          def OK: PutFooResponse = PutFooResponseOK
         }
       }
     """

--- a/modules/sample-akkaHttp/src/test/scala/core/AkkaHttp/AkkaHttpFullTracerTest.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/AkkaHttp/AkkaHttpFullTracerTest.scala
@@ -53,11 +53,11 @@ class AkkaHttpFullTracerTest extends FunSuite with Matchers with EitherValues wi
     val server2: HttpRequest => Future[HttpResponse] = Route.asyncHandler(
       AddressesResource.routes(
         new AddressesHandler {
-          def getAddress(respond: AddressesResource.getAddressResponse.type)(id: String)(traceBuilder: TraceBuilder) =
+          def getAddress(respond: AddressesResource.GetAddressResponse.type)(id: String)(traceBuilder: TraceBuilder) =
             Future.successful(if (id == "addressId") {
               respond.OK(sdefs.Address(Some("line1"), Some("line2"), Some("line3")))
             } else respond.NotFound)
-          def getAddresses(respond: AddressesResource.getAddressesResponse.type)()(traceBuilder: TraceBuilder) =
+          def getAddresses(respond: AddressesResource.GetAddressesResponse.type)()(traceBuilder: TraceBuilder) =
             Future.successful(respond.NotFound)
         },
         trace
@@ -70,7 +70,7 @@ class AkkaHttpFullTracerTest extends FunSuite with Matchers with EitherValues wi
         new UsersHandler {
           // ... using the "Address" server explicitly in the addressesClient
           val addressesClient = AddressesClient.httpClient(server2)
-          def getUser(respond: UsersResource.getUserResponse.type)(id: String)(traceBuilder: TraceBuilder) =
+          def getUser(respond: UsersResource.GetUserResponse.type)(id: String)(traceBuilder: TraceBuilder) =
             addressesClient
               .getAddress(traceBuilder, "addressId")
               .fold(

--- a/modules/sample-akkaHttp/src/test/scala/core/AkkaHttp/AkkaHttpRawServerTest.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/AkkaHttp/AkkaHttpRawServerTest.scala
@@ -13,7 +13,7 @@ import akka.http.scaladsl.marshalling.Marshal
 class AkkaHttpRawServerTest extends FunSuite with Matchers with EitherValues with ScalaFutures with ScalatestRouteTest {
   test("raw server response") {
     FooResource.routes(new FooHandler {
-      def doFoo(respond: FooResource.doFooResponse.type)(): scala.concurrent.Future[HttpResponse] =
+      def doFoo(respond: FooResource.DoFooResponse.type)(): scala.concurrent.Future[HttpResponse] =
         Marshal(respond.Created(sdefs.Foo(1234L))).to[HttpResponse]
     })
   }

--- a/modules/sample-akkaHttp/src/test/scala/core/AkkaHttp/AkkaHttpRoundTripTest.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/AkkaHttp/AkkaHttpRoundTripTest.scala
@@ -42,7 +42,7 @@ class AkkaHttpRoundTripTest extends FunSuite with Matchers with EitherValues wit
 
   test("round-trip: definition query, unit response") {
     val httpClient = Route.asyncHandler(PetResource.routes(new PetHandler {
-      def addPet(respond: PetResource.addPetResponse.type)(body: sdefs.Pet): Future[PetResource.addPetResponse] =
+      def addPet(respond: PetResource.AddPetResponse.type)(body: sdefs.Pet): Future[PetResource.AddPetResponse] =
         body match {
           case sdefs.Pet(
               `id`,
@@ -56,17 +56,17 @@ class AkkaHttpRoundTripTest extends FunSuite with Matchers with EitherValues wit
           case _ => failTest("Parameters didn't match")
         }
       def deletePet(
-          respond: PetResource.deletePetResponse.type
+          respond: PetResource.DeletePetResponse.type
       )(_petId: Long, includeChildren: Option[Boolean], status: Option[sdefs.PetStatus], _apiKey: Option[String] = None)                                  = ???
-      def findPetsByStatus(respond: PetResource.findPetsByStatusResponse.type)(status: Iterable[String])                                                  = ???
-      def findPetsByStatusEnum(respond: PetResource.findPetsByStatusEnumResponse.type)(status: sdefs.PetStatus)                                           = ???
-      def findPetsByTags(respond: PetResource.findPetsByTagsResponse.type)(tags: Iterable[String])                                                        = ???
-      def getPetById(respond: PetResource.getPetByIdResponse.type)(petId: Long)                                                                           = ???
-      def updatePet(respond: PetResource.updatePetResponse.type)(body: sdefs.Pet)                                                                         = ???
-      def updatePetWithForm(respond: PetResource.updatePetWithFormResponse.type)(petId: Long, name: Option[String] = None, status: Option[String] = None) = ???
+      def findPetsByStatus(respond: PetResource.FindPetsByStatusResponse.type)(status: Iterable[String])                                                  = ???
+      def findPetsByStatusEnum(respond: PetResource.FindPetsByStatusEnumResponse.type)(status: sdefs.PetStatus)                                           = ???
+      def findPetsByTags(respond: PetResource.FindPetsByTagsResponse.type)(tags: Iterable[String])                                                        = ???
+      def getPetById(respond: PetResource.GetPetByIdResponse.type)(petId: Long)                                                                           = ???
+      def updatePet(respond: PetResource.UpdatePetResponse.type)(body: sdefs.Pet)                                                                         = ???
+      def updatePetWithForm(respond: PetResource.UpdatePetWithFormResponse.type)(petId: Long, name: Option[String] = None, status: Option[String] = None) = ???
       def uploadFileMapFileField(fieldName: String, fileName: Option[String], contentType: ContentType) =
         java.io.File.createTempFile("download_", ".dat", new java.io.File("/tmp"))
-      def uploadFile(respond: PetResource.uploadFileResponse.type)(
+      def uploadFile(respond: PetResource.UploadFileResponse.type)(
           petId: examples.support.PositiveLong,
           additionalMetadata: Option[String],
           file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType)],
@@ -98,8 +98,8 @@ class AkkaHttpRoundTripTest extends FunSuite with Matchers with EitherValues wit
   test("round-trip: enum query, Vector of definition response") {
     val httpClient = Route.asyncHandler(PetResource.routes(new PetHandler {
       def findPetsByStatusEnum(
-          respond: PetResource.findPetsByStatusEnumResponse.type
-      )(_status: sdefs.PetStatus): Future[PetResource.findPetsByStatusEnumResponse] =
+          respond: PetResource.FindPetsByStatusEnumResponse.type
+      )(_status: sdefs.PetStatus): Future[PetResource.FindPetsByStatusEnumResponse] =
         Future.successful(petStatus.fold(Vector.empty[sdefs.Pet])({ value =>
           if (_status.value == value) {
             Vector(
@@ -117,18 +117,18 @@ class AkkaHttpRoundTripTest extends FunSuite with Matchers with EitherValues wit
           }
         }))
 
-      def addPet(respond: PetResource.addPetResponse.type)(body: sdefs.Pet) = ???
+      def addPet(respond: PetResource.AddPetResponse.type)(body: sdefs.Pet) = ???
       def deletePet(
-          respond: PetResource.deletePetResponse.type
+          respond: PetResource.DeletePetResponse.type
       )(_petId: Long, includeChildren: Option[Boolean], status: Option[sdefs.PetStatus], _apiKey: Option[String] = None)                                  = ???
-      def findPetsByStatus(respond: PetResource.findPetsByStatusResponse.type)(status: Iterable[String])                                                  = ???
-      def findPetsByTags(respond: PetResource.findPetsByTagsResponse.type)(tags: Iterable[String])                                                        = ???
-      def getPetById(respond: PetResource.getPetByIdResponse.type)(petId: Long)                                                                           = ???
-      def updatePet(respond: PetResource.updatePetResponse.type)(body: sdefs.Pet)                                                                         = ???
-      def updatePetWithForm(respond: PetResource.updatePetWithFormResponse.type)(petId: Long, name: Option[String] = None, status: Option[String] = None) = ???
+      def findPetsByStatus(respond: PetResource.FindPetsByStatusResponse.type)(status: Iterable[String])                                                  = ???
+      def findPetsByTags(respond: PetResource.FindPetsByTagsResponse.type)(tags: Iterable[String])                                                        = ???
+      def getPetById(respond: PetResource.GetPetByIdResponse.type)(petId: Long)                                                                           = ???
+      def updatePet(respond: PetResource.UpdatePetResponse.type)(body: sdefs.Pet)                                                                         = ???
+      def updatePetWithForm(respond: PetResource.UpdatePetWithFormResponse.type)(petId: Long, name: Option[String] = None, status: Option[String] = None) = ???
       def uploadFileMapFileField(fieldName: String, fileName: Option[String], contentType: ContentType) =
         java.io.File.createTempFile("download_", ".dat", new java.io.File("/tmp"))
-      def uploadFile(respond: PetResource.uploadFileResponse.type)(
+      def uploadFile(respond: PetResource.UploadFileResponse.type)(
           petId: examples.support.PositiveLong,
           additionalMetadata: Option[String],
           file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType)],
@@ -162,21 +162,21 @@ class AkkaHttpRoundTripTest extends FunSuite with Matchers with EitherValues wit
 
   test("round-trip: 404 response") {
     val httpClient = Route.asyncHandler(PetResource.routes(new PetHandler {
-      def findPetsByStatus(respond: PetResource.findPetsByStatusResponse.type)(status: Iterable[String]): Future[PetResource.findPetsByStatusResponse] =
+      def findPetsByStatus(respond: PetResource.FindPetsByStatusResponse.type)(status: Iterable[String]): Future[PetResource.FindPetsByStatusResponse] =
         Future.successful(respond.NotFound)
 
-      def addPet(respond: PetResource.addPetResponse.type)(body: sdefs.Pet) = ???
+      def addPet(respond: PetResource.AddPetResponse.type)(body: sdefs.Pet) = ???
       def deletePet(
-          respond: PetResource.deletePetResponse.type
+          respond: PetResource.DeletePetResponse.type
       )(_petId: Long, includeChildren: Option[Boolean], status: Option[sdefs.PetStatus], _apiKey: Option[String] = None)                                  = ???
-      def findPetsByStatusEnum(respond: PetResource.findPetsByStatusEnumResponse.type)(status: sdefs.PetStatus)                                           = ???
-      def findPetsByTags(respond: PetResource.findPetsByTagsResponse.type)(tags: Iterable[String])                                                        = ???
-      def getPetById(respond: PetResource.getPetByIdResponse.type)(petId: Long)                                                                           = ???
-      def updatePet(respond: PetResource.updatePetResponse.type)(body: sdefs.Pet)                                                                         = ???
-      def updatePetWithForm(respond: PetResource.updatePetWithFormResponse.type)(petId: Long, name: Option[String] = None, status: Option[String] = None) = ???
+      def findPetsByStatusEnum(respond: PetResource.FindPetsByStatusEnumResponse.type)(status: sdefs.PetStatus)                                           = ???
+      def findPetsByTags(respond: PetResource.FindPetsByTagsResponse.type)(tags: Iterable[String])                                                        = ???
+      def getPetById(respond: PetResource.GetPetByIdResponse.type)(petId: Long)                                                                           = ???
+      def updatePet(respond: PetResource.UpdatePetResponse.type)(body: sdefs.Pet)                                                                         = ???
+      def updatePetWithForm(respond: PetResource.UpdatePetWithFormResponse.type)(petId: Long, name: Option[String] = None, status: Option[String] = None) = ???
       def uploadFileMapFileField(fieldName: String, fileName: Option[String], contentType: ContentType) =
         java.io.File.createTempFile("download_", ".dat", new java.io.File("/tmp"))
-      def uploadFile(respond: PetResource.uploadFileResponse.type)(
+      def uploadFile(respond: PetResource.UploadFileResponse.type)(
           petId: examples.support.PositiveLong,
           additionalMetadata: Option[String],
           file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType)],
@@ -201,26 +201,26 @@ class AkkaHttpRoundTripTest extends FunSuite with Matchers with EitherValues wit
     val petId: Long    = 123L
     val apiKey: String = "foobar"
     val httpClient = Route.asyncHandler(PetResource.routes(new PetHandler {
-      def deletePet(respond: PetResource.deletePetResponse.type)(
+      def deletePet(respond: PetResource.DeletePetResponse.type)(
           _petId: Long,
           includeChildren: Option[Boolean],
           status: Option[sdefs.PetStatus],
           _apiKey: Option[String] = None
-      ): Future[PetResource.deletePetResponse] =
+      ): Future[PetResource.DeletePetResponse] =
         if (_petId == petId && _apiKey.contains(apiKey) && status.contains(sdefs.PetStatus.Pending))
           Future.successful(respond.OK)
         else Future.successful(respond.NotFound)
 
-      def addPet(respond: PetResource.addPetResponse.type)(body: sdefs.Pet)                                                                               = ???
-      def findPetsByStatus(respond: PetResource.findPetsByStatusResponse.type)(status: Iterable[String])                                                  = ???
-      def findPetsByStatusEnum(respond: PetResource.findPetsByStatusEnumResponse.type)(status: sdefs.PetStatus)                                           = ???
-      def findPetsByTags(respond: PetResource.findPetsByTagsResponse.type)(tags: Iterable[String])                                                        = ???
-      def getPetById(respond: PetResource.getPetByIdResponse.type)(petId: Long)                                                                           = ???
-      def updatePet(respond: PetResource.updatePetResponse.type)(body: sdefs.Pet)                                                                         = ???
-      def updatePetWithForm(respond: PetResource.updatePetWithFormResponse.type)(petId: Long, name: Option[String] = None, status: Option[String] = None) = ???
+      def addPet(respond: PetResource.AddPetResponse.type)(body: sdefs.Pet)                                                                               = ???
+      def findPetsByStatus(respond: PetResource.FindPetsByStatusResponse.type)(status: Iterable[String])                                                  = ???
+      def findPetsByStatusEnum(respond: PetResource.FindPetsByStatusEnumResponse.type)(status: sdefs.PetStatus)                                           = ???
+      def findPetsByTags(respond: PetResource.FindPetsByTagsResponse.type)(tags: Iterable[String])                                                        = ???
+      def getPetById(respond: PetResource.GetPetByIdResponse.type)(petId: Long)                                                                           = ???
+      def updatePet(respond: PetResource.UpdatePetResponse.type)(body: sdefs.Pet)                                                                         = ???
+      def updatePetWithForm(respond: PetResource.UpdatePetWithFormResponse.type)(petId: Long, name: Option[String] = None, status: Option[String] = None) = ???
       def uploadFileMapFileField(fieldName: String, fileName: Option[String], contentType: ContentType) =
         java.io.File.createTempFile("download_", ".dat", new java.io.File("/tmp"))
-      def uploadFile(respond: PetResource.uploadFileResponse.type)(
+      def uploadFile(respond: PetResource.UploadFileResponse.type)(
           petId: examples.support.PositiveLong,
           additionalMetadata: Option[String],
           file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType)],
@@ -249,19 +249,19 @@ class AkkaHttpRoundTripTest extends FunSuite with Matchers with EitherValues wit
     val petId: Long    = 123L
     val apiKey: String = "foobar"
     val httpClient = Route.asyncHandler(PetResource.routes(new PetHandler {
-      def addPet(respond: PetResource.addPetResponse.type)(body: sdefs.Pet) = ???
+      def addPet(respond: PetResource.AddPetResponse.type)(body: sdefs.Pet) = ???
       def deletePet(
-          respond: PetResource.deletePetResponse.type
+          respond: PetResource.DeletePetResponse.type
       )(_petId: Long, includeChildren: Option[Boolean], status: Option[sdefs.PetStatus], _apiKey: Option[String] = None)                                  = ???
-      def findPetsByStatus(respond: PetResource.findPetsByStatusResponse.type)(status: Iterable[String])                                                  = ???
-      def findPetsByStatusEnum(respond: PetResource.findPetsByStatusEnumResponse.type)(status: sdefs.PetStatus)                                           = ???
-      def findPetsByTags(respond: PetResource.findPetsByTagsResponse.type)(tags: Iterable[String])                                                        = ???
-      def getPetById(respond: PetResource.getPetByIdResponse.type)(petId: Long)                                                                           = ???
-      def updatePet(respond: PetResource.updatePetResponse.type)(body: sdefs.Pet)                                                                         = ???
-      def updatePetWithForm(respond: PetResource.updatePetWithFormResponse.type)(petId: Long, name: Option[String] = None, status: Option[String] = None) = ???
+      def findPetsByStatus(respond: PetResource.FindPetsByStatusResponse.type)(status: Iterable[String])                                                  = ???
+      def findPetsByStatusEnum(respond: PetResource.FindPetsByStatusEnumResponse.type)(status: sdefs.PetStatus)                                           = ???
+      def findPetsByTags(respond: PetResource.FindPetsByTagsResponse.type)(tags: Iterable[String])                                                        = ???
+      def getPetById(respond: PetResource.GetPetByIdResponse.type)(petId: Long)                                                                           = ???
+      def updatePet(respond: PetResource.UpdatePetResponse.type)(body: sdefs.Pet)                                                                         = ???
+      def updatePetWithForm(respond: PetResource.UpdatePetWithFormResponse.type)(petId: Long, name: Option[String] = None, status: Option[String] = None) = ???
       def uploadFileMapFileField(fieldName: String, fileName: Option[String], contentType: ContentType) =
         java.io.File.createTempFile("download_", ".dat", new java.io.File("/tmp"))
-      def uploadFile(respond: PetResource.uploadFileResponse.type)(
+      def uploadFile(respond: PetResource.UploadFileResponse.type)(
           petId: examples.support.PositiveLong,
           additionalMetadata: Option[String],
           file: Option[(java.io.File, Option[String], akka.http.scaladsl.model.ContentType)],

--- a/modules/sample-akkaHttp/src/test/scala/core/issues/Issue121.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/issues/Issue121.scala
@@ -18,7 +18,7 @@ class Issue121Suite extends FunSuite with Matchers with EitherValues with ScalaF
   test("akka-http server can respond with 204") {
     import issues.issue121.server.akkaHttp.{ Handler, Resource }
     val route = Resource.routes(new Handler {
-      override def deleteFoo(respond: Resource.deleteFooResponse.type)(id: Long): Future[Resource.deleteFooResponse] =
+      override def deleteFoo(respond: Resource.DeleteFooResponse.type)(id: Long): Future[Resource.DeleteFooResponse] =
         Future.successful(respond.NoContent)
     })
 

--- a/modules/sample-akkaHttp/src/test/scala/core/issues/Issue143.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/issues/Issue143.scala
@@ -24,8 +24,8 @@ class Issue143 extends FunSuite with Matchers with EitherValues with ScalaFuture
     val tempDest = File.createTempFile("guardrail.", ".dat")
     val route = Resource.routes(new Handler {
       def uploadFile(
-          respond: Resource.uploadFileResponse.type
-      )(file: (File, Option[String], akka.http.scaladsl.model.ContentType)): Future[Resource.uploadFileResponse] =
+          respond: Resource.UploadFileResponse.type
+      )(file: (File, Option[String], akka.http.scaladsl.model.ContentType)): Future[Resource.UploadFileResponse] =
         Future.successful(respond.Created)
       def uploadFileMapFileField(fieldName: String, fileName: Option[String], contentType: akka.http.scaladsl.model.ContentType): java.io.File =
         tempDest

--- a/modules/sample-akkaHttp/src/test/scala/core/issues/Issue148.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/issues/Issue148.scala
@@ -28,12 +28,12 @@ class Issue148Suite extends FunSuite with Matchers with EitherValues with ScalaF
     import issues.issue148.server.akkaHttp.definitions._
     val route = Resource.routes(new Handler {
       override def createFoo(
-          respond: Resource.createFooResponse.type
-      )(body: Foo, xHeader: Boolean, xOptionalHeader: Option[Boolean]): Future[Resource.createFooResponse] =
+          respond: Resource.CreateFooResponse.type
+      )(body: Foo, xHeader: Boolean, xOptionalHeader: Option[Boolean]): Future[Resource.CreateFooResponse] =
         Future.successful(respond.OK(body))
-      override def getFoo(respond: Resource.getFooResponse.type)(): Future[Resource.getFooResponse] =
+      override def getFoo(respond: Resource.GetFooResponse.type)(): Future[Resource.GetFooResponse] =
         Future.successful(respond.OK(Bar("bar")))
-      override def updateFoo(respond: Resource.updateFooResponse.type)(name: Boolean, bar: Option[Boolean]): Future[Resource.updateFooResponse] =
+      override def updateFoo(respond: Resource.UpdateFooResponse.type)(name: Boolean, bar: Option[Boolean]): Future[Resource.UpdateFooResponse] =
         Future.successful(respond.Accepted(Bar("bar")))
     })
 

--- a/modules/sample-akkaHttp/src/test/scala/core/issues/Issue184.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/issues/Issue184.scala
@@ -25,7 +25,7 @@ class Issue184Suite extends FunSuite with Matchers with EitherValues with ScalaF
   test("akka-http server request body validation") {
     import issues.issue184.server.akkaHttp.{ Handler, Resource }
     val route = Resource.routes(new Handler {
-      override def deleteFoo(respond: Resource.deleteFooResponse.type)(path: String, query: String, form: String): Future[Resource.deleteFooResponse] =
+      override def deleteFoo(respond: Resource.DeleteFooResponse.type)(path: String, query: String, form: String): Future[Resource.DeleteFooResponse] =
         Future.successful(respond.NoContent)
     })
 

--- a/modules/sample-akkaHttp/src/test/scala/core/issues/Issue315.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/issues/Issue315.scala
@@ -1,21 +1,16 @@
 package core.issues
 
 import akka.http.scaladsl.model._
-import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
+import cats.implicits._
+import org.scalactic.source
+import org.scalatest.EitherValues
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{ Assertion, EitherValues }
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import org.scalactic.source
-
-import _root_.tests.scalatest.EitherTValues
-
-import io.circe.syntax._
-import cats.implicits._
 
 class Issue315Suite extends AnyFunSuite with Matchers with EitherValues with ScalaFutures with ScalatestRouteTest {
   override implicit val patienceConfig = PatienceConfig(1000.millis, 1000.millis)
@@ -67,10 +62,10 @@ class Issue315Suite extends AnyFunSuite with Matchers with EitherValues with Sca
         .futureValue
     }
 
-    def legacyrequired_nullable(httpClient: HttpRequest => Future[HttpResponse]) = {
-      import _root_.issues.issue315.legacyrequired_nullable.client.akkaHttp.Client
-      import _root_.issues.issue315.legacyrequired_nullable.client.akkaHttp.definitions._
-      import _root_.issues.issue315.legacyrequired_nullable.client.akkaHttp.support.Presence
+    def legacyrequiredNullable(httpClient: HttpRequest => Future[HttpResponse]) = {
+      import _root_.issues.issue315.legacyrequiredNullable.client.akkaHttp.Client
+      import _root_.issues.issue315.legacyrequiredNullable.client.akkaHttp.definitions._
+      import _root_.issues.issue315.legacyrequiredNullable.client.akkaHttp.support.Presence
       val clientBody = TestObject(
         required = "foo",
         requiredNullable = None,
@@ -124,10 +119,10 @@ class Issue315Suite extends AnyFunSuite with Matchers with EitherValues with Sca
         .futureValue
     }
 
-    def optionalrequired_nullable(httpClient: HttpRequest => Future[HttpResponse]) = {
-      import _root_.issues.issue315.optionalrequired_nullable.client.akkaHttp.Client
-      import _root_.issues.issue315.optionalrequired_nullable.client.akkaHttp.definitions._
-      import _root_.issues.issue315.optionalrequired_nullable.client.akkaHttp.support.Presence
+    def optionalrequiredNullable(httpClient: HttpRequest => Future[HttpResponse]) = {
+      import _root_.issues.issue315.optionalrequiredNullable.client.akkaHttp.Client
+      import _root_.issues.issue315.optionalrequiredNullable.client.akkaHttp.definitions._
+      import _root_.issues.issue315.optionalrequiredNullable.client.akkaHttp.support.Presence
       val clientBody = TestObject(
         required = "foo",
         requiredNullable = None,
@@ -143,10 +138,10 @@ class Issue315Suite extends AnyFunSuite with Matchers with EitherValues with Sca
         .futureValue
     }
 
-    def required_nullablelegacy(httpClient: HttpRequest => Future[HttpResponse]) = {
-      import _root_.issues.issue315.required_nullablelegacy.client.akkaHttp.Client
-      import _root_.issues.issue315.required_nullablelegacy.client.akkaHttp.definitions._
-      import _root_.issues.issue315.required_nullablelegacy.client.akkaHttp.support.Presence
+    def requiredNullablelegacy(httpClient: HttpRequest => Future[HttpResponse]) = {
+      import _root_.issues.issue315.requiredNullablelegacy.client.akkaHttp.Client
+      import _root_.issues.issue315.requiredNullablelegacy.client.akkaHttp.definitions._
+      import _root_.issues.issue315.requiredNullablelegacy.client.akkaHttp.support.Presence
       val clientBody = TestObject(
         required = "foo",
         requiredNullable = None,
@@ -162,10 +157,10 @@ class Issue315Suite extends AnyFunSuite with Matchers with EitherValues with Sca
         .futureValue
     }
 
-    def required_nullableoptional(httpClient: HttpRequest => Future[HttpResponse]) = {
-      import _root_.issues.issue315.required_nullableoptional.client.akkaHttp.Client
-      import _root_.issues.issue315.required_nullableoptional.client.akkaHttp.definitions._
-      import _root_.issues.issue315.required_nullableoptional.client.akkaHttp.support.Presence
+    def requiredNullableoptional(httpClient: HttpRequest => Future[HttpResponse]) = {
+      import _root_.issues.issue315.requiredNullableoptional.client.akkaHttp.Client
+      import _root_.issues.issue315.requiredNullableoptional.client.akkaHttp.definitions._
+      import _root_.issues.issue315.requiredNullableoptional.client.akkaHttp.support.Presence
       val clientBody = TestObject(
         required = "foo",
         requiredNullable = None,
@@ -181,10 +176,10 @@ class Issue315Suite extends AnyFunSuite with Matchers with EitherValues with Sca
         .futureValue
     }
 
-    def required_nullablerequired_nullable(httpClient: HttpRequest => Future[HttpResponse]) = {
-      import _root_.issues.issue315.required_nullablerequired_nullable.client.akkaHttp.Client
-      import _root_.issues.issue315.required_nullablerequired_nullable.client.akkaHttp.definitions._
-      import _root_.issues.issue315.required_nullablerequired_nullable.client.akkaHttp.support.Presence
+    def requiredNullablerequiredNullable(httpClient: HttpRequest => Future[HttpResponse]) = {
+      import _root_.issues.issue315.requiredNullablerequiredNullable.client.akkaHttp.Client
+      import _root_.issues.issue315.requiredNullablerequiredNullable.client.akkaHttp.definitions._
+      import _root_.issues.issue315.requiredNullablerequiredNullable.client.akkaHttp.support.Presence
       val clientBody = TestObject(
         required = "foo",
         requiredNullable = None,
@@ -203,11 +198,11 @@ class Issue315Suite extends AnyFunSuite with Matchers with EitherValues with Sca
 
   object server {
     val legacylegacy: HttpRequest => Future[HttpResponse] = {
-      import _root_.issues.issue315.legacylegacy.server.akkaHttp.{ Handler, Resource }
       import _root_.issues.issue315.legacylegacy.server.akkaHttp.definitions._
       import _root_.issues.issue315.legacylegacy.server.akkaHttp.support.Presence
+      import _root_.issues.issue315.legacylegacy.server.akkaHttp.{ Handler, Resource }
       Route.asyncHandler(Resource.routes(new Handler {
-        def postTest(respond: Resource.postTestResponse.type)(body: TestObject) =
+        def postTest(respond: Resource.PostTestResponse.type)(body: TestObject) =
           body match {
             case TestObject("foo", None, Presence.Absent, Presence.Absent, None) => respond.OK.pure[Future]
             case _                                                               => respond.NotAcceptable.pure[Future]
@@ -216,11 +211,11 @@ class Issue315Suite extends AnyFunSuite with Matchers with EitherValues with Sca
     }
 
     val legacyoptional: HttpRequest => Future[HttpResponse] = {
-      import _root_.issues.issue315.legacyoptional.server.akkaHttp.{ Handler, Resource }
       import _root_.issues.issue315.legacyoptional.server.akkaHttp.definitions._
       import _root_.issues.issue315.legacyoptional.server.akkaHttp.support.Presence
+      import _root_.issues.issue315.legacyoptional.server.akkaHttp.{ Handler, Resource }
       Route.asyncHandler(Resource.routes(new Handler {
-        def postTest(respond: Resource.postTestResponse.type)(body: TestObject) =
+        def postTest(respond: Resource.PostTestResponse.type)(body: TestObject) =
           body match {
             case TestObject("foo", None, Presence.Absent, Presence.Absent, None) => respond.OK.pure[Future]
             case _                                                               => respond.NotAcceptable.pure[Future]
@@ -228,12 +223,12 @@ class Issue315Suite extends AnyFunSuite with Matchers with EitherValues with Sca
       }))
     }
 
-    val legacyrequired_nullable: HttpRequest => Future[HttpResponse] = {
-      import _root_.issues.issue315.legacyrequired_nullable.server.akkaHttp.{ Handler, Resource }
-      import _root_.issues.issue315.legacyrequired_nullable.server.akkaHttp.definitions._
-      import _root_.issues.issue315.legacyrequired_nullable.server.akkaHttp.support.Presence
+    val legacyrequiredNullable: HttpRequest => Future[HttpResponse] = {
+      import _root_.issues.issue315.legacyrequiredNullable.server.akkaHttp.definitions._
+      import _root_.issues.issue315.legacyrequiredNullable.server.akkaHttp.support.Presence
+      import _root_.issues.issue315.legacyrequiredNullable.server.akkaHttp.{ Handler, Resource }
       Route.asyncHandler(Resource.routes(new Handler {
-        def postTest(respond: Resource.postTestResponse.type)(body: TestObject) =
+        def postTest(respond: Resource.PostTestResponse.type)(body: TestObject) =
           body match {
             case TestObject("foo", None, Presence.Absent, Presence.Absent, None) => respond.OK.pure[Future]
             case _                                                               => respond.NotAcceptable.pure[Future]
@@ -242,11 +237,11 @@ class Issue315Suite extends AnyFunSuite with Matchers with EitherValues with Sca
     }
 
     val optionallegacy: HttpRequest => Future[HttpResponse] = {
-      import _root_.issues.issue315.optionallegacy.server.akkaHttp.{ Handler, Resource }
       import _root_.issues.issue315.optionallegacy.server.akkaHttp.definitions._
       import _root_.issues.issue315.optionallegacy.server.akkaHttp.support.Presence
+      import _root_.issues.issue315.optionallegacy.server.akkaHttp.{ Handler, Resource }
       Route.asyncHandler(Resource.routes(new Handler {
-        def postTest(respond: Resource.postTestResponse.type)(body: TestObject) =
+        def postTest(respond: Resource.PostTestResponse.type)(body: TestObject) =
           body match {
             case TestObject("foo", None, Presence.Absent, Presence.Absent, None) => respond.OK.pure[Future]
             case _                                                               => respond.NotAcceptable.pure[Future]
@@ -255,11 +250,11 @@ class Issue315Suite extends AnyFunSuite with Matchers with EitherValues with Sca
     }
 
     val optionaloptional: HttpRequest => Future[HttpResponse] = {
-      import _root_.issues.issue315.optionaloptional.server.akkaHttp.{ Handler, Resource }
       import _root_.issues.issue315.optionaloptional.server.akkaHttp.definitions._
       import _root_.issues.issue315.optionaloptional.server.akkaHttp.support.Presence
+      import _root_.issues.issue315.optionaloptional.server.akkaHttp.{ Handler, Resource }
       Route.asyncHandler(Resource.routes(new Handler {
-        def postTest(respond: Resource.postTestResponse.type)(body: TestObject) =
+        def postTest(respond: Resource.PostTestResponse.type)(body: TestObject) =
           body match {
             case TestObject("foo", None, Presence.Absent, Presence.Absent, Presence.Absent) => respond.OK.pure[Future]
             case _                                                                          => respond.NotAcceptable.pure[Future]
@@ -267,12 +262,12 @@ class Issue315Suite extends AnyFunSuite with Matchers with EitherValues with Sca
       }))
     }
 
-    val optionalrequired_nullable: HttpRequest => Future[HttpResponse] = {
-      import _root_.issues.issue315.optionalrequired_nullable.server.akkaHttp.{ Handler, Resource }
-      import _root_.issues.issue315.optionalrequired_nullable.server.akkaHttp.definitions._
-      import _root_.issues.issue315.optionalrequired_nullable.server.akkaHttp.support.Presence
+    val optionalrequiredNullable: HttpRequest => Future[HttpResponse] = {
+      import _root_.issues.issue315.optionalrequiredNullable.server.akkaHttp.definitions._
+      import _root_.issues.issue315.optionalrequiredNullable.server.akkaHttp.support.Presence
+      import _root_.issues.issue315.optionalrequiredNullable.server.akkaHttp.{ Handler, Resource }
       Route.asyncHandler(Resource.routes(new Handler {
-        def postTest(respond: Resource.postTestResponse.type)(body: TestObject) =
+        def postTest(respond: Resource.PostTestResponse.type)(body: TestObject) =
           body match {
             case TestObject("foo", None, Presence.Absent, Presence.Absent, None) => respond.OK.pure[Future]
             case _                                                               => respond.NotAcceptable.pure[Future]
@@ -280,12 +275,12 @@ class Issue315Suite extends AnyFunSuite with Matchers with EitherValues with Sca
       }))
     }
 
-    val required_nullablelegacy: HttpRequest => Future[HttpResponse] = {
-      import _root_.issues.issue315.required_nullablelegacy.server.akkaHttp.{ Handler, Resource }
-      import _root_.issues.issue315.required_nullablelegacy.server.akkaHttp.definitions._
-      import _root_.issues.issue315.required_nullablelegacy.server.akkaHttp.support.Presence
+    val requiredNullablelegacy: HttpRequest => Future[HttpResponse] = {
+      import _root_.issues.issue315.requiredNullablelegacy.server.akkaHttp.definitions._
+      import _root_.issues.issue315.requiredNullablelegacy.server.akkaHttp.support.Presence
+      import _root_.issues.issue315.requiredNullablelegacy.server.akkaHttp.{ Handler, Resource }
       Route.asyncHandler(Resource.routes(new Handler {
-        def postTest(respond: Resource.postTestResponse.type)(body: TestObject) =
+        def postTest(respond: Resource.PostTestResponse.type)(body: TestObject) =
           body match {
             case TestObject("foo", None, Presence.Absent, Presence.Absent, None) => respond.OK.pure[Future]
             case _                                                               => respond.NotAcceptable.pure[Future]
@@ -293,12 +288,12 @@ class Issue315Suite extends AnyFunSuite with Matchers with EitherValues with Sca
       }))
     }
 
-    val required_nullableoptional: HttpRequest => Future[HttpResponse] = {
-      import _root_.issues.issue315.required_nullableoptional.server.akkaHttp.{ Handler, Resource }
-      import _root_.issues.issue315.required_nullableoptional.server.akkaHttp.definitions._
-      import _root_.issues.issue315.required_nullableoptional.server.akkaHttp.support.Presence
+    val requiredNullableoptional: HttpRequest => Future[HttpResponse] = {
+      import _root_.issues.issue315.requiredNullableoptional.server.akkaHttp.definitions._
+      import _root_.issues.issue315.requiredNullableoptional.server.akkaHttp.support.Presence
+      import _root_.issues.issue315.requiredNullableoptional.server.akkaHttp.{ Handler, Resource }
       Route.asyncHandler(Resource.routes(new Handler {
-        def postTest(respond: Resource.postTestResponse.type)(body: TestObject) =
+        def postTest(respond: Resource.PostTestResponse.type)(body: TestObject) =
           body match {
             case TestObject("foo", None, Presence.Absent, Presence.Absent, None) => respond.OK.pure[Future]
             case _                                                               => respond.NotAcceptable.pure[Future]
@@ -306,12 +301,12 @@ class Issue315Suite extends AnyFunSuite with Matchers with EitherValues with Sca
       }))
     }
 
-    val required_nullablerequired_nullable: HttpRequest => Future[HttpResponse] = {
-      import _root_.issues.issue315.required_nullablerequired_nullable.server.akkaHttp.{ Handler, Resource }
-      import _root_.issues.issue315.required_nullablerequired_nullable.server.akkaHttp.definitions._
-      import _root_.issues.issue315.required_nullablerequired_nullable.server.akkaHttp.support.Presence
+    val requiredNullablerequiredNullable: HttpRequest => Future[HttpResponse] = {
+      import _root_.issues.issue315.requiredNullablerequiredNullable.server.akkaHttp.definitions._
+      import _root_.issues.issue315.requiredNullablerequiredNullable.server.akkaHttp.support.Presence
+      import _root_.issues.issue315.requiredNullablerequiredNullable.server.akkaHttp.{ Handler, Resource }
       Route.asyncHandler(Resource.routes(new Handler {
-        def postTest(respond: Resource.postTestResponse.type)(body: TestObject) =
+        def postTest(respond: Resource.PostTestResponse.type)(body: TestObject) =
           body match {
             case TestObject("foo", None, Presence.Absent, Presence.Absent, None) => respond.OK.pure[Future]
             case _                                                               => respond.NotAcceptable.pure[Future]
@@ -322,95 +317,95 @@ class Issue315Suite extends AnyFunSuite with Matchers with EitherValues with Sca
 
   test("expected protocol rejections") {
     // `"legacy": null` (from required/nullable) incompatible with `optional` decoder
-    expectProtocolError(client.required_nullableoptional(server.legacyoptional))
-    expectProtocolError(client.required_nullableoptional(server.optionaloptional))
-    expectProtocolError(client.required_nullableoptional(server.required_nullableoptional))
+    expectProtocolError(client.requiredNullableoptional(server.legacyoptional))
+    expectProtocolError(client.requiredNullableoptional(server.optionaloptional))
+    expectProtocolError(client.requiredNullableoptional(server.requiredNullableoptional))
 
     // `"legacy": null` (from legacy encoder) incompatible with `optional` decoder
     expectProtocolError(client.legacylegacy(server.legacyoptional))
     expectProtocolError(client.legacylegacy(server.optionaloptional))
-    expectProtocolError(client.legacylegacy(server.required_nullableoptional))
+    expectProtocolError(client.legacylegacy(server.requiredNullableoptional))
     expectProtocolError(client.legacyoptional(server.legacyoptional))
     expectProtocolError(client.legacyoptional(server.optionaloptional))
-    expectProtocolError(client.legacyoptional(server.required_nullableoptional))
-    expectProtocolError(client.legacyrequired_nullable(server.legacyoptional))
-    expectProtocolError(client.legacyrequired_nullable(server.optionaloptional))
-    expectProtocolError(client.legacyrequired_nullable(server.required_nullableoptional))
+    expectProtocolError(client.legacyoptional(server.requiredNullableoptional))
+    expectProtocolError(client.legacyrequiredNullable(server.legacyoptional))
+    expectProtocolError(client.legacyrequiredNullable(server.optionaloptional))
+    expectProtocolError(client.legacyrequiredNullable(server.requiredNullableoptional))
 
     // `"legacy": null` incompatible with `optional` decoder
-    expectProtocolError(client.required_nullablelegacy(server.legacyoptional))
-    expectProtocolError(client.required_nullablelegacy(server.optionaloptional))
-    expectProtocolError(client.required_nullablelegacy(server.required_nullableoptional))
-    expectProtocolError(client.required_nullablerequired_nullable(server.legacyoptional))
-    expectProtocolError(client.required_nullablerequired_nullable(server.optionaloptional))
-    expectProtocolError(client.required_nullablerequired_nullable(server.required_nullableoptional))
+    expectProtocolError(client.requiredNullablelegacy(server.legacyoptional))
+    expectProtocolError(client.requiredNullablelegacy(server.optionaloptional))
+    expectProtocolError(client.requiredNullablelegacy(server.requiredNullableoptional))
+    expectProtocolError(client.requiredNullablerequiredNullable(server.legacyoptional))
+    expectProtocolError(client.requiredNullablerequiredNullable(server.optionaloptional))
+    expectProtocolError(client.requiredNullablerequiredNullable(server.requiredNullableoptional))
 
-    // Missing `legacy` incompatible with `required_nullable`
-    expectProtocolError(client.optionallegacy(server.legacyrequired_nullable))
-    expectProtocolError(client.optionallegacy(server.optionalrequired_nullable))
-    expectProtocolError(client.optionallegacy(server.required_nullablerequired_nullable))
-    expectProtocolError(client.optionaloptional(server.legacyrequired_nullable))
-    expectProtocolError(client.optionaloptional(server.optionalrequired_nullable))
-    expectProtocolError(client.optionaloptional(server.required_nullablerequired_nullable))
-    expectProtocolError(client.optionalrequired_nullable(server.legacyrequired_nullable))
-    expectProtocolError(client.optionalrequired_nullable(server.optionalrequired_nullable))
-    expectProtocolError(client.optionalrequired_nullable(server.required_nullablerequired_nullable))
+    // Missing `legacy` incompatible with `requiredNullable`
+    expectProtocolError(client.optionallegacy(server.legacyrequiredNullable))
+    expectProtocolError(client.optionallegacy(server.optionalrequiredNullable))
+    expectProtocolError(client.optionallegacy(server.requiredNullablerequiredNullable))
+    expectProtocolError(client.optionaloptional(server.legacyrequiredNullable))
+    expectProtocolError(client.optionaloptional(server.optionalrequiredNullable))
+    expectProtocolError(client.optionaloptional(server.requiredNullablerequiredNullable))
+    expectProtocolError(client.optionalrequiredNullable(server.legacyrequiredNullable))
+    expectProtocolError(client.optionalrequiredNullable(server.optionalrequiredNullable))
+    expectProtocolError(client.optionalrequiredNullable(server.requiredNullablerequiredNullable))
   }
 
   test("expect success") {
     expectSuccess(client.legacylegacy(server.legacylegacy))
-    expectSuccess(client.legacylegacy(server.legacyrequired_nullable))
+    expectSuccess(client.legacylegacy(server.legacyrequiredNullable))
     expectSuccess(client.legacylegacy(server.optionallegacy))
-    expectSuccess(client.legacylegacy(server.optionalrequired_nullable))
-    expectSuccess(client.legacylegacy(server.required_nullablelegacy))
-    expectSuccess(client.legacylegacy(server.required_nullablerequired_nullable))
+    expectSuccess(client.legacylegacy(server.optionalrequiredNullable))
+    expectSuccess(client.legacylegacy(server.requiredNullablelegacy))
+    expectSuccess(client.legacylegacy(server.requiredNullablerequiredNullable))
     expectSuccess(client.legacyoptional(server.legacylegacy))
-    expectSuccess(client.legacyoptional(server.legacyrequired_nullable))
+    expectSuccess(client.legacyoptional(server.legacyrequiredNullable))
     expectSuccess(client.legacyoptional(server.optionallegacy))
-    expectSuccess(client.legacyoptional(server.optionalrequired_nullable))
-    expectSuccess(client.legacyoptional(server.required_nullablelegacy))
-    expectSuccess(client.legacyoptional(server.required_nullablerequired_nullable))
-    expectSuccess(client.legacyrequired_nullable(server.legacylegacy))
-    expectSuccess(client.legacyrequired_nullable(server.legacyrequired_nullable))
-    expectSuccess(client.legacyrequired_nullable(server.optionallegacy))
-    expectSuccess(client.legacyrequired_nullable(server.optionalrequired_nullable))
-    expectSuccess(client.legacyrequired_nullable(server.required_nullablelegacy))
-    expectSuccess(client.legacyrequired_nullable(server.required_nullablerequired_nullable))
+    expectSuccess(client.legacyoptional(server.optionalrequiredNullable))
+    expectSuccess(client.legacyoptional(server.requiredNullablelegacy))
+    expectSuccess(client.legacyoptional(server.requiredNullablerequiredNullable))
+    expectSuccess(client.legacyrequiredNullable(server.legacylegacy))
+    expectSuccess(client.legacyrequiredNullable(server.legacyrequiredNullable))
+    expectSuccess(client.legacyrequiredNullable(server.optionallegacy))
+    expectSuccess(client.legacyrequiredNullable(server.optionalrequiredNullable))
+    expectSuccess(client.legacyrequiredNullable(server.requiredNullablelegacy))
+    expectSuccess(client.legacyrequiredNullable(server.requiredNullablerequiredNullable))
     expectSuccess(client.optionallegacy(server.legacylegacy))
     expectSuccess(client.optionallegacy(server.legacyoptional))
     expectSuccess(client.optionallegacy(server.optionallegacy))
     expectSuccess(client.optionallegacy(server.optionaloptional))
-    expectSuccess(client.optionallegacy(server.required_nullablelegacy))
-    expectSuccess(client.optionallegacy(server.required_nullableoptional))
+    expectSuccess(client.optionallegacy(server.requiredNullablelegacy))
+    expectSuccess(client.optionallegacy(server.requiredNullableoptional))
     expectSuccess(client.optionaloptional(server.legacylegacy))
     expectSuccess(client.optionaloptional(server.legacyoptional))
     expectSuccess(client.optionaloptional(server.optionallegacy))
     expectSuccess(client.optionaloptional(server.optionaloptional))
-    expectSuccess(client.optionaloptional(server.required_nullablelegacy))
-    expectSuccess(client.optionaloptional(server.required_nullableoptional))
-    expectSuccess(client.optionalrequired_nullable(server.legacylegacy))
-    expectSuccess(client.optionalrequired_nullable(server.legacyoptional))
-    expectSuccess(client.optionalrequired_nullable(server.optionallegacy))
-    expectSuccess(client.optionalrequired_nullable(server.optionaloptional))
-    expectSuccess(client.optionalrequired_nullable(server.required_nullablelegacy))
-    expectSuccess(client.optionalrequired_nullable(server.required_nullableoptional))
-    expectSuccess(client.required_nullablelegacy(server.legacylegacy))
-    expectSuccess(client.required_nullablelegacy(server.legacyrequired_nullable))
-    expectSuccess(client.required_nullablelegacy(server.optionallegacy))
-    expectSuccess(client.required_nullablelegacy(server.optionalrequired_nullable))
-    expectSuccess(client.required_nullablelegacy(server.required_nullablelegacy))
-    expectSuccess(client.required_nullablelegacy(server.required_nullablerequired_nullable))
-    expectSuccess(client.required_nullableoptional(server.legacylegacy))
-    expectSuccess(client.required_nullableoptional(server.legacyrequired_nullable))
-    expectSuccess(client.required_nullableoptional(server.optionallegacy))
-    expectSuccess(client.required_nullableoptional(server.optionalrequired_nullable))
-    expectSuccess(client.required_nullableoptional(server.required_nullablelegacy))
-    expectSuccess(client.required_nullableoptional(server.required_nullablerequired_nullable))
-    expectSuccess(client.required_nullablerequired_nullable(server.legacylegacy))
-    expectSuccess(client.required_nullablerequired_nullable(server.legacyrequired_nullable))
-    expectSuccess(client.required_nullablerequired_nullable(server.optionallegacy))
-    expectSuccess(client.required_nullablerequired_nullable(server.optionalrequired_nullable))
-    expectSuccess(client.required_nullablerequired_nullable(server.required_nullablelegacy))
-    expectSuccess(client.required_nullablerequired_nullable(server.required_nullablerequired_nullable))
+    expectSuccess(client.optionaloptional(server.requiredNullablelegacy))
+    expectSuccess(client.optionaloptional(server.requiredNullableoptional))
+    expectSuccess(client.optionalrequiredNullable(server.legacylegacy))
+    expectSuccess(client.optionalrequiredNullable(server.legacyoptional))
+    expectSuccess(client.optionalrequiredNullable(server.optionallegacy))
+    expectSuccess(client.optionalrequiredNullable(server.optionaloptional))
+    expectSuccess(client.optionalrequiredNullable(server.requiredNullablelegacy))
+    expectSuccess(client.optionalrequiredNullable(server.requiredNullableoptional))
+    expectSuccess(client.requiredNullablelegacy(server.legacylegacy))
+    expectSuccess(client.requiredNullablelegacy(server.legacyrequiredNullable))
+    expectSuccess(client.requiredNullablelegacy(server.optionallegacy))
+    expectSuccess(client.requiredNullablelegacy(server.optionalrequiredNullable))
+    expectSuccess(client.requiredNullablelegacy(server.requiredNullablelegacy))
+    expectSuccess(client.requiredNullablelegacy(server.requiredNullablerequiredNullable))
+    expectSuccess(client.requiredNullableoptional(server.legacylegacy))
+    expectSuccess(client.requiredNullableoptional(server.legacyrequiredNullable))
+    expectSuccess(client.requiredNullableoptional(server.optionallegacy))
+    expectSuccess(client.requiredNullableoptional(server.optionalrequiredNullable))
+    expectSuccess(client.requiredNullableoptional(server.requiredNullablelegacy))
+    expectSuccess(client.requiredNullableoptional(server.requiredNullablerequiredNullable))
+    expectSuccess(client.requiredNullablerequiredNullable(server.legacylegacy))
+    expectSuccess(client.requiredNullablerequiredNullable(server.legacyrequiredNullable))
+    expectSuccess(client.requiredNullablerequiredNullable(server.optionallegacy))
+    expectSuccess(client.requiredNullablerequiredNullable(server.optionalrequiredNullable))
+    expectSuccess(client.requiredNullablerequiredNullable(server.requiredNullablelegacy))
+    expectSuccess(client.requiredNullablerequiredNullable(server.requiredNullablerequiredNullable))
   }
 }

--- a/modules/sample-akkaHttp/src/test/scala/core/issues/Issue325.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/issues/Issue325.scala
@@ -24,8 +24,8 @@ class Issue325Suite extends FunSuite with Matchers with EitherValues with ScalaF
     import issues.issue325.server.akkaHttp.{ Handler, Resource }
     val route = Resource.routes(new Handler {
       override def testMultipleContentTypes(
-          respond: Resource.testMultipleContentTypesResponse.type
-      )(foo: String, bar: Int, baz: Option[Int], file: Option[(java.io.File, Option[String], ContentType)]): Future[Resource.testMultipleContentTypesResponse] =
+          respond: Resource.TestMultipleContentTypesResponse.type
+      )(foo: String, bar: Int, baz: Option[Int], file: Option[(java.io.File, Option[String], ContentType)]): Future[Resource.TestMultipleContentTypesResponse] =
         Future.successful(
           if (foo == foo && bar == 5 && baz.forall(_ == 10)) {
             respond.OK
@@ -36,8 +36,8 @@ class Issue325Suite extends FunSuite with Matchers with EitherValues with ScalaF
       override def testMultipleContentTypesMapFileField(fieldName: String, fileName: Option[String], contentType: ContentType): java.io.File =
         java.io.File.createTempFile("guardrail-issue-325", "dat")
       override def emptyConsumes(
-          respond: Resource.emptyConsumesResponse.type
-      )(foo: String): Future[Resource.emptyConsumesResponse] =
+          respond: Resource.EmptyConsumesResponse.type
+      )(foo: String): Future[Resource.EmptyConsumesResponse] =
         Future.successful(respond.OK)
     })
 

--- a/modules/sample-akkaHttp/src/test/scala/core/issues/Issue357.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/issues/Issue357.scala
@@ -19,21 +19,21 @@ class Issue357Suite extends FunSpec with Matchers with EitherValues with ScalaFu
   describe("akka-http server should") {
     import issues.issue357.server.akkaHttp.{ Handler, Resource }
     val route = Resource.routes(new Handler {
-      def deleteFoo(respond: Resource.deleteFooResponse.type)(path: String, query: String, form: String): Future[Resource.deleteFooResponse] =
+      def deleteFoo(respond: Resource.DeleteFooResponse.type)(path: String, query: String, form: String): Future[Resource.DeleteFooResponse] =
         Future.successful((path, query, form) match {
           case ("1234", "2345", "3456")             => respond.NoContent
           case ("foo", "bar", "baz")                => respond.NoContent
           case ("\"qfoo\"", "\"qbar\"", "\"qbaz\"") => respond.NoContent
           case _                                    => respond.BadRequest
         })
-      def patchFoo(respond: Resource.patchFooResponse.type)(path: String, query: String, form: String): Future[Resource.patchFooResponse] =
+      def patchFoo(respond: Resource.PatchFooResponse.type)(path: String, query: String, form: String): Future[Resource.PatchFooResponse] =
         Future.successful((path, query, form) match {
           case ("1234", "2345", "3456")             => respond.NoContent
           case ("foo", "bar", "baz")                => respond.NoContent
           case ("\"qfoo\"", "\"qbar\"", "\"qbaz\"") => respond.NoContent
           case _                                    => respond.BadRequest
         })
-      def putFoo(respond: Resource.putFooResponse.type)(path: String, query: String, form: String): Future[Resource.putFooResponse] =
+      def putFoo(respond: Resource.PutFooResponse.type)(path: String, query: String, form: String): Future[Resource.PutFooResponse] =
         Future.successful((path, query, form) match {
           case ("1234", "2345", "3456")             => respond.NoContent
           case ("foo", "bar", "baz")                => respond.NoContent

--- a/modules/sample-akkaHttp/src/test/scala/core/issues/Issue405.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/issues/Issue405.scala
@@ -31,7 +31,7 @@ class Issue405 extends FunSuite with Matchers with EitherValues with ScalaFuture
     import issues.issue405.server.akkaHttp.{ Handler, Resource }
 
     val route = Route.seal(Resource.routes(new Handler {
-      override def foo(respond: Resource.fooResponse.type)(bar: String, baz: Option[String]): Future[Resource.fooResponse] =
+      override def foo(respond: Resource.FooResponse.type)(bar: String, baz: Option[String]): Future[Resource.FooResponse] =
         Future.successful(respond.OK(s"Bar is '$bar'"))
     }))
 
@@ -46,7 +46,7 @@ class Issue405 extends FunSuite with Matchers with EitherValues with ScalaFuture
     import issues.issue405.server.akkaHttp.{ Handler, Resource }
 
     val route = Route.seal(Resource.routes(new Handler {
-      override def foo(respond: Resource.fooResponse.type)(bar: String, baz: Option[String]): Future[Resource.fooResponse] = {
+      override def foo(respond: Resource.FooResponse.type)(bar: String, baz: Option[String]): Future[Resource.FooResponse] = {
         val msg = baz.map(s => s"present: '$s'").getOrElse("missing")
         Future.successful(respond.OK(s"Baz is $msg"))
       }
@@ -63,7 +63,7 @@ class Issue405 extends FunSuite with Matchers with EitherValues with ScalaFuture
     import issues.issue405.server.akkaHttp.{ Handler, Resource }
 
     val route = Route.seal(Resource.routes(new Handler {
-      override def foo(respond: Resource.fooResponse.type)(bar: String, baz: Option[String]): Future[Resource.fooResponse] =
+      override def foo(respond: Resource.FooResponse.type)(bar: String, baz: Option[String]): Future[Resource.FooResponse] =
         Future.successful(respond.OK(s"Bar is '$bar'"))
     }))
 
@@ -78,7 +78,7 @@ class Issue405 extends FunSuite with Matchers with EitherValues with ScalaFuture
     import issues.issue405.server.akkaHttp.{ Handler, Resource }
 
     val route = Route.seal(Resource.routes(new Handler {
-      override def foo(respond: Resource.fooResponse.type)(bar: String, baz: Option[String]): Future[Resource.fooResponse] = {
+      override def foo(respond: Resource.FooResponse.type)(bar: String, baz: Option[String]): Future[Resource.FooResponse] = {
         val msg = baz.map(s => s"present: '$s'").getOrElse("missing")
         Future.successful(respond.OK(s"Baz is $msg"))
       }

--- a/modules/sample-akkaHttp/src/test/scala/generators/AkkaHttp/Client/contentType/AkkaHttpTextPlainTest.scala
+++ b/modules/sample-akkaHttp/src/test/scala/generators/AkkaHttp/Client/contentType/AkkaHttpTextPlainTest.scala
@@ -50,19 +50,19 @@ class AkkaHttpTextPlainTest extends FunSuite with Matchers with EitherValues wit
   test("Plain text should be emitted for required parameters") {
     val route: Route = FooResource.routes(new FooHandler {
       def doFoo(
-          respond: tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.doFooResponse.type
-      )(body: String): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.doFooResponse] =
+          respond: tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.DoFooResponse.type
+      )(body: String): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.DoFooResponse] =
         if (body == "sample") {
           Future.successful(respond.Created)
         } else {
           Future.successful(respond.NotAcceptable)
         }
-      def doBar(respond: tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.doBarResponse.type)(
+      def doBar(respond: tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.DoBarResponse.type)(
           body: Option[String]
-      ): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.doBarResponse] = ???
-      def doBaz(respond: FooResource.doBazResponse.type)(
+      ): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.DoBarResponse] = ???
+      def doBaz(respond: FooResource.DoBazResponse.type)(
           body: Option[String]
-      ): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.doBazResponse] = ???
+      ): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.DoBazResponse] = ???
     })
 
     val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
@@ -73,19 +73,19 @@ class AkkaHttpTextPlainTest extends FunSuite with Matchers with EitherValues wit
   test("Plain text should be emitted for present optional parameters") {
     val route: Route = FooResource.routes(new FooHandler {
       def doFoo(
-          respond: tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.doFooResponse.type
-      )(body: String): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.doFooResponse] = ???
-      def doBar(respond: tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.doBarResponse.type)(
+          respond: tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.DoFooResponse.type
+      )(body: String): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.DoFooResponse] = ???
+      def doBar(respond: tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.DoBarResponse.type)(
           body: Option[String]
-      ): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.doBarResponse] =
+      ): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.DoBarResponse] =
         if (body.contains("sample")) {
           Future.successful(respond.Created)
         } else {
           Future.successful(respond.NotAcceptable)
         }
-      def doBaz(respond: FooResource.doBazResponse.type)(
+      def doBaz(respond: FooResource.DoBazResponse.type)(
           body: Option[String]
-      ): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.doBazResponse] = ???
+      ): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.DoBazResponse] = ???
     })
 
     val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
@@ -96,19 +96,19 @@ class AkkaHttpTextPlainTest extends FunSuite with Matchers with EitherValues wit
   test("Plain text should be emitted for missing optional parameters") {
     val route: Route = FooResource.routes(new FooHandler {
       def doFoo(
-          respond: tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.doFooResponse.type
-      )(body: String): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.doFooResponse] = ???
-      def doBar(respond: tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.doBarResponse.type)(
+          respond: tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.DoFooResponse.type
+      )(body: String): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.DoFooResponse] = ???
+      def doBar(respond: tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.DoBarResponse.type)(
           body: Option[String]
-      ): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.doBarResponse] =
+      ): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.DoBarResponse] =
         if (body.isEmpty) {
           Future.successful(respond.Created)
         } else {
           Future.successful(respond.NotAcceptable)
         }
-      def doBaz(respond: FooResource.doBazResponse.type)(
+      def doBaz(respond: FooResource.DoBazResponse.type)(
           body: Option[String]
-      ): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.doBazResponse] = ???
+      ): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.DoBazResponse] = ???
     })
 
     val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)

--- a/modules/sample-akkaHttp/src/test/scala/generators/AkkaHttp/RoundTrip/AkkaHttpCustomHeadersTest.scala
+++ b/modules/sample-akkaHttp/src/test/scala/generators/AkkaHttp/RoundTrip/AkkaHttpCustomHeadersTest.scala
@@ -26,13 +26,13 @@ class AkkaHttpCustomHeadersTest extends FlatSpec with Matchers with ScalaFutures
     implicit val as  = ActorSystem()
     implicit val mat = ActorMaterializer()
     val client = Client.httpClient(Route.asyncHandler(Resource.routes(new Handler {
-      def getFoo(respond: Resource.getFooResponse.type)(
+      def getFoo(respond: Resource.GetFooResponse.type)(
           header: String,
           longHeader: Long,
           customHeader: sdefs.Bar,
           customOptionHeader: Option[sdefs.Bar],
           missingCustomOptionHeader: Option[sdefs.Bar]
-      ): Future[Resource.getFooResponse] =
+      ): Future[Resource.GetFooResponse] =
         (header, longHeader, customHeader, customOptionHeader, missingCustomOptionHeader) match {
           case ("foo", 5L, sdefs.Bar.V1, Some(sdefs.Bar.V2), None) => Future.successful(respond.OK)
           case _                                                   => Future.successful(respond.BadRequest)

--- a/modules/sample-dropwizard/src/test/scala/core/Dropwizard/JavaInvalidCharacterEscapingTest.scala
+++ b/modules/sample-dropwizard/src/test/scala/core/Dropwizard/JavaInvalidCharacterEscapingTest.scala
@@ -1,0 +1,85 @@
+package core.Dropwizard
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.ObjectMapper
+import invalidCharacters.client.dropwizard.invalidCharacters.InvalidCharactersClient
+import invalidCharacters.server.dropwizard.definitions.{InvalidCharacters, InvalidCharactersEnum}
+import io.netty.buffer.Unpooled
+import java.net.{SocketAddress, URI, URLDecoder}
+import java.util.concurrent.{CompletableFuture, CompletionStage}
+import java.util.function
+import org.asynchttpclient.Response.ResponseBuilder
+import org.asynchttpclient.netty.EagerResponseBodyPart
+import org.asynchttpclient.uri.Uri
+import org.asynchttpclient.{HttpResponseStatus, Request, Response}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import scala.collection.JavaConverters._
+
+object JavaInvalidCharacterEscapingTest {
+  private implicit class RichString(private val s: String) extends AnyVal {
+    def dec: String = URLDecoder.decode(s, "UTF-8")
+  }
+
+  private object OkStatus extends HttpResponseStatus(Uri.create("http://localhost:1234/foo?foo^bar=query-param")) {
+    override def getStatusCode = 200
+    override def getStatusText = "OK"
+    override def getProtocolName = "HTTP"
+    override def getProtocolMajorVersion = 1
+    override def getProtocolMinorVersion = 1
+    override def getProtocolText = "HTTP/1.1"
+    override def getRemoteAddress: SocketAddress = ???
+    override def getLocalAddress: SocketAddress = ???
+  }
+}
+
+class JavaInvalidCharacterEscapingTest extends AnyFreeSpec with Matchers {
+  import JavaInvalidCharacterEscapingTest._
+
+  "Invalid characters in Java enums should be escaped" in {
+    InvalidCharactersEnum.NORMAL.getName mustBe "normal"
+    InvalidCharactersEnum.BANG_MOO_COLON_COW_SEMICOLON.getName mustBe "!moo:cow;"
+    InvalidCharactersEnum.POUND_YEAH.getName mustBe "#yeah"
+    InvalidCharactersEnum.WEIRD_AT.getName mustBe "weird@"
+  }
+
+  "Invalid characters in Java POJO properties should be escaped" in {
+    val invChar = new InvalidCharacters.Builder("stuff", InvalidCharactersEnum.POUND_YEAH).build()
+    invChar.getCloseSquareBraceMoo mustBe "stuff"
+    invChar.getSomeEnumAsteriskCaret mustBe InvalidCharactersEnum.POUND_YEAH
+
+    classOf[InvalidCharacters].getDeclaredField("closeSquareBraceMoo").getAnnotation(classOf[JsonProperty]).value mustBe "]moo"
+    classOf[InvalidCharacters].getDeclaredField("someEnumAsteriskCaret").getAnnotation(classOf[JsonProperty]).value mustBe "some-enum*^"
+  }
+
+  "Invalid characters in Java operation param names should be escaped" in {
+    val httpClient = new function.Function[Request, CompletionStage[Response]] {
+      override def apply(request: Request): CompletionStage[Response] = {
+        println(request.getUri)
+        println(request.getQueryParams.asScala.map(_.getName))
+        val qps = request.getQueryParams.asScala.map(p => (p.getName.dec, p.getValue.dec))
+        val fps = request.getFormParams.asScala.map(p => (p.getName.dec, p.getValue.dec))
+        qps.find(_._1 == "foo^bar").map(_._2) mustBe Some("firstarg")
+        fps.find(_._1 == "a*b").map(_._2) mustBe Some("secondarg")
+        fps.find(_._1 == "bc?").map(_._2) mustBe Some("thirdarg")
+        fps.find(_._1 == "d/c").map(_._2) mustBe Some("fourtharg")
+        val response = new ResponseBuilder()
+        response.accumulate(OkStatus)
+        response.accumulate(new EagerResponseBodyPart(
+          Unpooled.copiedBuffer(new ObjectMapper().writeValueAsBytes(new InvalidCharacters.Builder("foo", InvalidCharactersEnum.WEIRD_AT).build())),
+          true
+        ))
+        CompletableFuture.completedFuture(response.build())
+      }
+    }
+
+    val client = new InvalidCharactersClient.Builder(new URI("http://localhost:1234")).withHttpClient(httpClient).build()
+    val response = client.getFoo("firstarg", "secondarg", "thirdarg", "fourtharg").call().toCompletableFuture.get()
+    response.fold(
+      { invChar =>
+        invChar.getCloseSquareBraceMoo mustBe "foo"
+        invChar.getSomeEnumAsteriskCaret mustBe invalidCharacters.client.dropwizard.definitions.InvalidCharactersEnum.WEIRD_AT
+      }
+    )
+  }
+}

--- a/modules/sample/src/main/resources/invalid-characters.yaml
+++ b/modules/sample/src/main/resources/invalid-characters.yaml
@@ -1,0 +1,56 @@
+openapi: 3.0.2
+info:
+  title: Escaping Invalid Characters
+  version: 1.0.0
+paths:
+  /foo:
+    get:
+      x-jvm-package: invalidCharacters
+      operationId: getFoo
+      parameters:
+        - in: query
+          name: foo^bar
+          schema:
+            type: string
+          required: true
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              required:
+                - a*b
+                - bc?
+                - d/c
+              properties:
+                'a*b':
+                  type: string
+                'bc?':
+                  type: string
+                'd/c':
+                  type: string
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InvalidCharacters"
+components:
+  schemas:
+    InvalidCharactersEnum:
+      type: string
+      enum:
+        - normal
+        - weird@
+        - "#yeah"
+        - "!moo:cow;"
+    InvalidCharacters:
+      type: object
+      required:
+        - ']moo'
+        - some-enum*^
+      properties:
+        ']moo':
+          type: string
+        some-enum*^:
+          $ref: "#/components/schemas/InvalidCharactersEnum"


### PR DESCRIPTION
I ran into this when I wanted an enum value called `integer?`, and figured I'd add code for escaping all the various non-identifier characters, at least the ones found on a US keyboard (note that `$` is actually legal in Java identifiers, so it's not included here).

This turned out to be a huge rabbit hole, because, despite the work we did last year to make naming better, there was still a lot of inconsistency and hackery around naming things.  In order to make this a reasonable problem to solve, I added (to `LanguageTerms`) some new methods:

* `formatPackageName`
* `formatTypeName`
* `formatMethodName`
* `formatMethodArgName`
* (we already had) `formatEnumName`

The bonus here is that as we add other languages with different naming conventions, it becomes trivial to have guardrail follow those naming conventions.

In addition, I set things up so some names (for example, the name of a response class) are generated by the core (by calling the above methods) and threading them into the interpreter methods so the interpreters don't keep rebuilding names in an error-prone way.

This doesn't fix everything.  There are still some instances of `.capitalize` and `.uncapitalized` here and there.  There are *fewer* instances than before, which is nice.  And the core no longer does `.toCamelCase`, `.toSnakeCase`, or `.toPascalCase` anywhere.  The one thing I am still not able to eradicate is `ProtocolGenerator`'s `transformProperty`'s `needsCamelSnakeConversion`, because doing so still breaks the conflicting-name fixer-upper, and making that continue to work would require more surgery.  So, sadly, I will yet again punt on that.

This will unfortunately require some user code to change to continue to compile, which is detailed in MIGRATING.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
