### PR TITLE
Making scala-steward able to update deps for unlinked *Sample projects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -262,7 +262,16 @@ lazy val root = (project in file("."))
     skip in publish := true
   )
   .dependsOn(codegen, microsite)
-  .aggregate(codegen, microsite)
+  .aggregate(allDeps, codegen, microsite)
+
+lazy val allDeps = (project in file("modules/alldeps"))
+  .settings(
+    skip in publish := true,
+    libraryDependencies ++= akkaProjectDependencies,
+    libraryDependencies ++= http4sProjectDependencies,
+    libraryDependencies ++= springProjectDependencies,
+    libraryDependencies ++= dropwizardProjectDependencies,
+  )
 
 lazy val codegen = (project in file("modules/codegen"))
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -261,7 +261,8 @@ lazy val root = (project in file("."))
     libraryDependencies ++= testDependencies,
     skip in publish := true
   )
-  .dependsOn(codegen % "compile;test", microsite % "compile; test")
+  .dependsOn(codegen, microsite)
+  .aggregate(codegen, microsite)
 
 lazy val codegen = (project in file("modules/codegen"))
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -262,7 +262,7 @@ lazy val root = (project in file("."))
     skip in publish := true
   )
   .dependsOn(codegen, microsite)
-  .aggregate(allDeps, codegen, microsite)
+  .aggregate(allDeps, codegen, microsite, endpointsDependencies)
 
 lazy val allDeps = (project in file("modules/alldeps"))
   .settings(
@@ -397,6 +397,24 @@ lazy val dropwizardSample = buildSampleProject("dropwizard", dropwizardProjectDe
 
 lazy val springMvcSample = buildSampleProject("springMvc", springProjectDependencies)
   .settings(javaSampleSettings)
+
+lazy val endpointsDependencies = (project in file("modules/sample-endpoints-deps"))
+  .enablePlugins(ScalaJSPlugin)
+  .settings(
+    libraryDependencies ++= Seq(
+      "io.circe"          %%% "circe-core"                    % circeVersion,
+      "io.circe"          %%% "circe-generic"                 % circeVersion,
+      "io.circe"          %%% "circe-parser"                  % circeVersion,
+      "io.github.cquiroz" %%% "scala-java-time"               % "2.0.0-RC3",
+      "org.julienrf"      %%% "endpoints-algebra"             % endpointsVersion,
+      "org.julienrf"      %%% "endpoints-json-schema-generic" % endpointsVersion,
+      "org.julienrf"      %%% "endpoints-xhr-client"          % endpointsVersion,
+      "org.julienrf"      %%% "endpoints-xhr-client-circe"    % endpointsVersion,
+      "org.julienrf"      %%% "endpoints-xhr-client-faithful" % endpointsVersion,
+      "org.scalatest"     %%% "scalatest"                     % scalatestVersion % Test,
+      "org.typelevel"     %%% "cats-core"                     % catsVersion
+    ),
+  )
 
 lazy val endpointsSample = (project in file("modules/sample-endpoints"))
   .enablePlugins(ScalaJSPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -313,20 +313,59 @@ lazy val codegen = (project in file("modules/codegen"))
     )
   )
 
+val akkaProjectDependencies = Seq(
+  "javax.xml.bind"    %  "jaxb-api"          % jaxbApiVersion, // for jdk11
+  "com.typesafe.akka" %% "akka-http"         % akkaVersion,
+  "com.typesafe.akka" %% "akka-http-testkit" % akkaVersion,
+  "io.circe"          %% "circe-core"        % circeVersion,
+  "io.circe"          %% "circe-generic"     % circeVersion,
+  "io.circe"          %% "circe-jawn"        % circeVersion,
+  "io.circe"          %% "circe-parser"      % circeVersion,
+  "org.scalatest"     %% "scalatest"         % scalatestVersion % Test,
+  "org.typelevel"     %% "cats-core"         % catsVersion
+)
+
+val http4sProjectDependencies = Seq(
+  "javax.xml.bind" % "jaxb-api"            % jaxbApiVersion, // for jdk11
+  "io.circe"      %% "circe-core"          % circeVersion,
+  "io.circe"      %% "circe-generic"       % circeVersion,
+  "io.circe"      %% "circe-parser"        % circeVersion,
+  "org.http4s"    %% "http4s-blaze-client" % http4sVersion,
+  "org.http4s"    %% "http4s-blaze-server" % http4sVersion,
+  "org.http4s"    %% "http4s-circe"        % http4sVersion,
+  "org.http4s"    %% "http4s-dsl"          % http4sVersion,
+  "org.scalatest" %% "scalatest"           % scalatestVersion % Test,
+  "org.typelevel" %% "cats-core"           % catsVersion,
+  "org.typelevel" %% "cats-effect"         % catsEffectVersion
+)
+
+val dropwizardProjectDependencies = Seq(
+  "javax.xml.bind"             %  "jaxb-api"               % jaxbApiVersion, // for jdk11
+  "io.dropwizard"              %  "dropwizard-core"        % dropwizardVersion,
+  "io.dropwizard"              %  "dropwizard-forms"       % dropwizardVersion,
+  "org.asynchttpclient"        %  "async-http-client"      % ahcVersion,
+  "org.scala-lang.modules"     %% "scala-java8-compat"     % "0.9.1"            % Test,
+  "org.scalatest"              %% "scalatest"              % scalatestVersion   % Test,
+  "junit"                      %  "junit"                  % "4.12"             % Test,
+  "com.novocode"               %  "junit-interface"        % "0.11"             % Test,
+  "org.mockito"                %% "mockito-scala"          % "1.12.0"           % Test,
+  "com.github.tomakehurst"     %  "wiremock"               % "1.57"             % Test,
+  "io.dropwizard"              %  "dropwizard-testing"     % dropwizardVersion  % Test,
+  "org.glassfish.jersey.test-framework.providers" % "jersey-test-framework-provider-grizzly2" % jerseyVersion % Test
+)
+
+val springProjectDependencies = Seq(
+  "org.springframework.boot"   %  "spring-boot-starter-web"  % springBootVersion,
+  "org.scala-lang.modules"     %% "scala-java8-compat"       % "0.9.1"            % Test,
+  "org.scalatest"              %% "scalatest"                % scalatestVersion   % Test,
+  "org.mockito"                %% "mockito-scala"            % "1.12.0"           % Test,
+  "org.springframework.boot"   %  "spring-boot-starter-test" % springBootVersion  % Test,
+)
+
 lazy val akkaHttpSample = (project in file("modules/sample-akkaHttp"))
   .settings(
     codegenSettings,
-    libraryDependencies ++= Seq(
-      "javax.xml.bind"    %  "jaxb-api"          % jaxbApiVersion, // for jdk11
-      "com.typesafe.akka" %% "akka-http"         % akkaVersion,
-      "com.typesafe.akka" %% "akka-http-testkit" % akkaVersion,
-      "io.circe"          %% "circe-core"        % circeVersion,
-      "io.circe"          %% "circe-generic"     % circeVersion,
-      "io.circe"          %% "circe-jawn"        % circeVersion,
-      "io.circe"          %% "circe-parser"      % circeVersion,
-      "org.scalatest"     %% "scalatest"         % scalatestVersion % Test,
-      "org.typelevel"     %% "cats-core"         % catsVersion
-    ),
+    libraryDependencies ++= akkaProjectDependencies,
     unmanagedSourceDirectories in Compile += baseDirectory.value / "target" / "generated",
     skip in publish := true,
     scalafmtOnCompile := false
@@ -335,19 +374,7 @@ lazy val akkaHttpSample = (project in file("modules/sample-akkaHttp"))
 lazy val http4sSample = (project in file("modules/sample-http4s"))
   .settings(
     codegenSettings,
-    libraryDependencies ++= Seq(
-      "javax.xml.bind" % "jaxb-api"            % jaxbApiVersion, // for jdk11
-      "io.circe"      %% "circe-core"          % circeVersion,
-      "io.circe"      %% "circe-generic"       % circeVersion,
-      "io.circe"      %% "circe-parser"        % circeVersion,
-      "org.http4s"    %% "http4s-blaze-client" % http4sVersion,
-      "org.http4s"    %% "http4s-blaze-server" % http4sVersion,
-      "org.http4s"    %% "http4s-circe"        % http4sVersion,
-      "org.http4s"    %% "http4s-dsl"          % http4sVersion,
-      "org.scalatest" %% "scalatest"           % scalatestVersion % Test,
-      "org.typelevel" %% "cats-core"           % catsVersion,
-      "org.typelevel" %% "cats-effect"         % catsEffectVersion
-    ),
+    libraryDependencies ++= http4sProjectDependencies,
     unmanagedSourceDirectories in Compile += baseDirectory.value / "target" / "generated",
     skip in publish := true,
     scalafmtOnCompile := false
@@ -383,20 +410,7 @@ lazy val dropwizardSample = (project in file("modules/sample-dropwizard"))
       "-Xlint:all"
     ),
     testOptions in Test += Tests.Argument(TestFrameworks.JUnit, "-a", "-v"),
-    libraryDependencies ++= Seq(
-      "javax.xml.bind"             %  "jaxb-api"               % jaxbApiVersion, // for jdk11
-      "io.dropwizard"              %  "dropwizard-core"        % dropwizardVersion,
-      "io.dropwizard"              %  "dropwizard-forms"       % dropwizardVersion,
-      "org.asynchttpclient"        %  "async-http-client"      % ahcVersion,
-      "org.scala-lang.modules"     %% "scala-java8-compat"     % "0.9.1"            % Test,
-      "org.scalatest"              %% "scalatest"              % scalatestVersion   % Test,
-      "junit"                      %  "junit"                  % "4.12"             % Test,
-      "com.novocode"               %  "junit-interface"        % "0.11"             % Test,
-      "org.mockito"                %% "mockito-scala"          % "1.12.0"           % Test,
-      "com.github.tomakehurst"     %  "wiremock"               % "1.57"             % Test,
-      "io.dropwizard"              %  "dropwizard-testing"     % dropwizardVersion  % Test,
-      "org.glassfish.jersey.test-framework.providers" % "jersey-test-framework-provider-grizzly2" % jerseyVersion % Test
-    ),
+    libraryDependencies ++= dropwizardProjectDependencies,
     unmanagedSourceDirectories in Compile += baseDirectory.value / "target" / "generated",
     crossPaths := false,  // strangely needed to get the JUnit tests to run at all
     skip in publish := true,
@@ -410,13 +424,7 @@ lazy val springMvcSample = (project in file("modules/sample-springMvc"))
       "-Xlint:all"
     ),
     testOptions in Test += Tests.Argument(TestFrameworks.JUnit, "-a", "-v"),
-    libraryDependencies ++= Seq(
-      "org.springframework.boot"   %  "spring-boot-starter-web"  % springBootVersion,
-      "org.scala-lang.modules"     %% "scala-java8-compat"       % "0.9.1"            % Test,
-      "org.scalatest"              %% "scalatest"                % scalatestVersion   % Test,
-      "org.mockito"                %% "mockito-scala"            % "1.12.0"           % Test,
-      "org.springframework.boot"   %  "spring-boot-starter-test" % springBootVersion  % Test,
-    ),
+    libraryDependencies ++= springProjectDependencies,
     unmanagedSourceDirectories in Compile += baseDirectory.value / "target" / "generated",
     crossPaths := false,
     skip in publish := true,

--- a/build.sbt
+++ b/build.sbt
@@ -362,23 +362,32 @@ val springProjectDependencies = Seq(
   "org.springframework.boot"   %  "spring-boot-starter-test" % springBootVersion  % Test,
 )
 
-lazy val akkaHttpSample = (project in file("modules/sample-akkaHttp"))
-  .settings(
-    codegenSettings,
-    libraryDependencies ++= akkaProjectDependencies,
-    unmanagedSourceDirectories in Compile += baseDirectory.value / "target" / "generated",
-    skip in publish := true,
-    scalafmtOnCompile := false
+def buildSampleProject(name: String, extraLibraryDependencies: Seq[sbt.librarymanagement.ModuleID]) =
+  Project(s"${name}Sample", file(s"modules/sample-${name}"))
+    .settings(
+      codegenSettings,
+      libraryDependencies ++= extraLibraryDependencies,
+      unmanagedSourceDirectories in Compile += baseDirectory.value / "target" / "generated",
+      skip in publish := true,
+      scalafmtOnCompile := false
+    )
+
+lazy val akkaHttpSample = buildSampleProject("akkaHttp", akkaProjectDependencies)
+
+lazy val http4sSample = buildSampleProject("http4s", http4sProjectDependencies)
+
+val javaSampleSettings = Seq(
+    testOptions in Test += Tests.Argument(TestFrameworks.JUnit, "-a", "-v"),
+    javacOptions ++= Seq(
+      "-Xlint:all"
+    ),
   )
 
-lazy val http4sSample = (project in file("modules/sample-http4s"))
-  .settings(
-    codegenSettings,
-    libraryDependencies ++= http4sProjectDependencies,
-    unmanagedSourceDirectories in Compile += baseDirectory.value / "target" / "generated",
-    skip in publish := true,
-    scalafmtOnCompile := false
-  )
+lazy val dropwizardSample = buildSampleProject("dropwizard", dropwizardProjectDependencies)
+  .settings(javaSampleSettings)
+
+lazy val springMvcSample = buildSampleProject("springMvc", springProjectDependencies)
+  .settings(javaSampleSettings)
 
 lazy val endpointsSample = (project in file("modules/sample-endpoints"))
   .enablePlugins(ScalaJSPlugin)
@@ -399,34 +408,6 @@ lazy val endpointsSample = (project in file("modules/sample-endpoints"))
       "org.typelevel"     %%% "cats-core"                     % catsVersion
     ),
     unmanagedSourceDirectories in Compile += baseDirectory.value / "target" / "generated",
-    skip in publish := true,
-    scalafmtOnCompile := false
-  )
-
-lazy val dropwizardSample = (project in file("modules/sample-dropwizard"))
-  .settings(
-    codegenSettings,
-    javacOptions ++= Seq(
-      "-Xlint:all"
-    ),
-    testOptions in Test += Tests.Argument(TestFrameworks.JUnit, "-a", "-v"),
-    libraryDependencies ++= dropwizardProjectDependencies,
-    unmanagedSourceDirectories in Compile += baseDirectory.value / "target" / "generated",
-    crossPaths := false,  // strangely needed to get the JUnit tests to run at all
-    skip in publish := true,
-    scalafmtOnCompile := false
-  )
-
-lazy val springMvcSample = (project in file("modules/sample-springMvc"))
-  .settings(
-    codegenSettings,
-    javacOptions ++= Seq(
-      "-Xlint:all"
-    ),
-    testOptions in Test += Tests.Argument(TestFrameworks.JUnit, "-a", "-v"),
-    libraryDependencies ++= springProjectDependencies,
-    unmanagedSourceDirectories in Compile += baseDirectory.value / "target" / "generated",
-    crossPaths := false,
     skip in publish := true,
     scalafmtOnCompile := false
   )


### PR DESCRIPTION
I read through scala-steward in order to figure out why library upgrades for sample subprojects weren't getting opened.

It turns out it's because the `stewardDependencies` task walks `libraryDependencies` for root and aggregated tasks.

Unfortunately, as `*Sample` projects are not designed to be aggregated (they don't pass `compile` unless we're running `testSuite`), it necessitated some hoop jumping.

A more long-term solution would be to modify scala-steward to be able to run the `stewardPlugin` against non-`root` projects, but as this is a fairly niche use case, I'm OK with this solution for now.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.