### PR TITLE
Move Shower class to framework def instead of server/client def

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
@@ -989,7 +989,6 @@ object AsyncHttpClientClientGenerator {
         jacksonSupport <- generateJacksonSupportClass()
         (jacksonSupportImports, jacksonSupportClass) = jacksonSupport
         asyncHttpclientUtils <- asyncHttpClientUtilsSupportDef
-        shower               <- SerializationHelpers.showerSupportDef
       } yield {
         exceptionClasses.map({
           case (imports, cls) =>
@@ -997,8 +996,7 @@ object AsyncHttpClientClientGenerator {
         }) ++ List(
           SupportDefinition[JavaLanguage](new Name(ahcSupportClass.getNameAsString), ahcSupportImports, List(ahcSupportClass)),
           SupportDefinition[JavaLanguage](new Name(jacksonSupportClass.getNameAsString), jacksonSupportImports, List(jacksonSupportClass)),
-          asyncHttpclientUtils,
-          shower
+          asyncHttpclientUtils
         )
       }
     def buildStaticDefns(

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
@@ -652,8 +652,6 @@ object DropwizardServerGenerator {
           "javax.ws.rs.HttpMethod"
         ).traverse(safeParseRawImport)
 
-        shower <- SerializationHelpers.showerSupportDef
-
         jersey <- SerializationHelpers.guardrailJerseySupportDef
       } yield {
         def httpMethodAnnotation(name: String): SupportDefinition[JavaLanguage] = {
@@ -669,7 +667,6 @@ object DropwizardServerGenerator {
           SupportDefinition[JavaLanguage](new Name(name), annotationImports, List(annotationDecl))
         }
         List(
-          shower,
           jersey,
           httpMethodAnnotation("PATCH"),
           httpMethodAnnotation("TRACE")


### PR DESCRIPTION
When generating models only, the framework definitions of the server and client are not rendered.  However, the Shower class is still required for models, so move it into the framework support definitions list.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
