### PR TITLE
fix: fallback to string type for unsupported format types

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
@@ -284,7 +284,7 @@ object SwaggerUtil {
             case (Some("string"), Some("date-time"))    => dateTimeType()
             case (Some("string"), Some("byte"))         => bytesType()
             case (Some("string"), fmt @ Some("binary")) => fileType(None).map(log(fmt, _))
-            case (Some("string"), fmt)                  => stringType(fmt).map(log(fmt, _))
+            case (Some("string"), fmt)                  => stringType(None).map(log(fmt, _))
             case (Some("number"), Some("float"))        => floatType()
             case (Some("number"), Some("double"))       => doubleType()
             case (Some("number"), fmt)                  => numberType(fmt).map(log(fmt, _))

--- a/modules/sample/src/main/resources/raw-response.yaml
+++ b/modules/sample/src/main/resources/raw-response.yaml
@@ -24,3 +24,6 @@ definitions:
       id:
         type: integer
         format: int64
+      url:
+        type: string
+        format: url


### PR DESCRIPTION
Falling back to string type that we know works rather than the raw format type specified in the specification. This will ensure
that the unsupported format type will compile, keeping the log message to guide the user on how it can be changed.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
