### PR TITLE
Actually fix DW resource optional collection param unwrapping

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
@@ -348,7 +348,7 @@ object DropwizardServerGenerator {
               }
 
               def stripOptionalFromCollections(parameter: Parameter, param: LanguageParameter[JavaLanguage]): Parameter =
-                if (!param.required && parameter.getType.isNamed("List")) {
+                if (!param.required && parameter.getType.containedType.isNamed("List")) {
                   parameter.setType(parameter.getType.containedType)
                 } else {
                   parameter

--- a/modules/codegen/src/test/scala/tests/generators/dropwizard/server/DropwizardOptionalArrayParamTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/dropwizard/server/DropwizardOptionalArrayParamTest.scala
@@ -1,0 +1,75 @@
+package tests.generators.dropwizard.server
+
+import com.github.javaparser.ast.body.MethodDeclaration
+import com.twilio.guardrail.{ Context, Server, Servers }
+import com.twilio.guardrail.generators.Java.Dropwizard
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import scala.collection.JavaConverters._
+import scala.compat.java8.OptionConverters._
+import support.SwaggerSpecRunner
+
+class DropwizardOptionalArrayParamTest extends AnyFreeSpec with Matchers with SwaggerSpecRunner {
+  private val openapi =
+    """openapi: 3.0.2
+      |info:
+      |  title: Foo
+      |  version: 1.0.0
+      |paths:
+      |  /foo:
+      |    get:
+      |      operationId: getFoo
+      |      parameters:
+      |        - name: optstuff
+      |          in: query
+      |          required: false
+      |          schema:
+      |            type: array
+      |            items:
+      |              type: string
+      |        - name: reqstuff
+      |          in: query
+      |          required: true
+      |          schema:
+      |            type: array
+      |            items:
+      |              type: string
+      |      responses:
+      |        200: {}
+      |""".stripMargin
+
+  "Optional array resource method params should be unwrapped" in {
+    val (
+      _,
+      _,
+      Servers(Server(_, _, _, genResource :: Nil) :: Nil, _)
+    ) = runSwaggerSpec(openapi)(Context.empty, Dropwizard)
+
+    val getFooMethod = genResource
+      .asClassOrInterfaceDeclaration()
+      .getMembers
+      .asScala
+      .collectFirst({
+        case method: MethodDeclaration if method.getNameAsString == "getFoo" => method
+      })
+      .value
+
+    getFooMethod
+      .getParameterByName("optstuff")
+      .asScala
+      .value
+      .getType
+      .asClassOrInterfaceType
+      .getName
+      .getIdentifier mustBe "List"
+
+    getFooMethod
+      .getParameterByName("reqstuff")
+      .asScala
+      .value
+      .getType
+      .asClassOrInterfaceType
+      .getName
+      .getIdentifier mustBe "List"
+  }
+}


### PR DESCRIPTION
Looks like I messed it up when I implemented this fix before; added a test this time to make sure it works.

The background is that Jersey can't support nested collections types as resource method parameters.  So Optional<List<T>> does not work.  Instead, we want to just unwrap that as List<T>, and Jersey will give us an empty list if it's not provided.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
