### PR TITLE
fix for http4s fetch() deprecation warnings

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,2 +1,3 @@
 -Xmx2G
+-Xss4M
 -XX:MaxMetaspaceSize=1G

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
@@ -348,7 +348,7 @@ object DropwizardServerGenerator {
               }
 
               def stripOptionalFromCollections(parameter: Parameter, param: LanguageParameter[JavaLanguage]): Parameter =
-                if (!param.required && parameter.getType.isNamed("List")) {
+                if (!param.required && parameter.getType.containedType.isNamed("List")) {
                   parameter.setType(parameter.getType.containedType)
                 } else {
                   parameter

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sClientGenerator.scala
@@ -279,7 +279,7 @@ object Http4sClientGenerator {
           else p"case resp => F.raiseError[$baseResponseTypeRef](UnexpectedStatus(resp.status))"
           responseTypeRef = if (isGeneric) t"cats.effect.Resource[F, $baseResponseTypeRef[F]]" else t"F[$baseResponseTypeRef]"
           executeReqExpr = if (isGeneric) List(q"""$httpClientName.run(req).evalMap(${Term.PartialFunction(cases :+ unexpectedCase)})""")
-          else List(q"""$httpClientName.fetch(req)(${Term.PartialFunction(cases :+ unexpectedCase)})""")
+          else List(q"""$httpClientName.run(req).use(${Term.PartialFunction(cases :+ unexpectedCase)})""")
           methodBody: Term = q"""
               {
                 ..${tracingExpr ++ multipartExpr ++ headersExpr ++ reqExpr ++ executeReqExpr}

--- a/modules/codegen/src/test/scala/tests/core/FullyQualifiedNames.scala
+++ b/modules/codegen/src/test/scala/tests/core/FullyQualifiedNames.scala
@@ -52,7 +52,7 @@ class FullyQualifiedNames extends AnyFunSuite with Matchers with SwaggerSpecRunn
          def getUser(id: String, headers: List[Header] = List.empty): F[GetUserResponse] = {
            val allHeaders = headers ++ List[Option[Header]]().flatten
            val req = Request[F](method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/user/" + Formatter.addPath(id)), headers = Headers(allHeaders))
-           httpClient.fetch(req)({
+           httpClient.req(req).use({
              case _root_.org.http4s.Status.Ok(resp) =>
                F.map(getUserOkDecoder.decode(resp, strict = false).value.flatMap(F.fromEither))(GetUserResponse.Ok.apply): F[GetUserResponse]
              case resp =>

--- a/modules/codegen/src/test/scala/tests/generators/dropwizard/server/DropwizardOptionalArrayParamTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/dropwizard/server/DropwizardOptionalArrayParamTest.scala
@@ -1,0 +1,75 @@
+package tests.generators.dropwizard.server
+
+import com.github.javaparser.ast.body.MethodDeclaration
+import com.twilio.guardrail.{ Context, Server, Servers }
+import com.twilio.guardrail.generators.Java.Dropwizard
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import scala.collection.JavaConverters._
+import scala.compat.java8.OptionConverters._
+import support.SwaggerSpecRunner
+
+class DropwizardOptionalArrayParamTest extends AnyFreeSpec with Matchers with SwaggerSpecRunner {
+  private val openapi =
+    """openapi: 3.0.2
+      |info:
+      |  title: Foo
+      |  version: 1.0.0
+      |paths:
+      |  /foo:
+      |    get:
+      |      operationId: getFoo
+      |      parameters:
+      |        - name: optstuff
+      |          in: query
+      |          required: false
+      |          schema:
+      |            type: array
+      |            items:
+      |              type: string
+      |        - name: reqstuff
+      |          in: query
+      |          required: true
+      |          schema:
+      |            type: array
+      |            items:
+      |              type: string
+      |      responses:
+      |        200: {}
+      |""".stripMargin
+
+  "Optional array resource method params should be unwrapped" in {
+    val (
+      _,
+      _,
+      Servers(Server(_, _, _, genResource :: Nil) :: Nil, _)
+    ) = runSwaggerSpec(openapi)(Context.empty, Dropwizard)
+
+    val getFooMethod = genResource
+      .asClassOrInterfaceDeclaration()
+      .getMembers
+      .asScala
+      .collectFirst({
+        case method: MethodDeclaration if method.getNameAsString == "getFoo" => method
+      })
+      .value
+
+    getFooMethod
+      .getParameterByName("optstuff")
+      .asScala
+      .value
+      .getType
+      .asClassOrInterfaceType
+      .getName
+      .getIdentifier mustBe "List"
+
+    getFooMethod
+      .getParameterByName("reqstuff")
+      .asScala
+      .value
+      .getType
+      .asClassOrInterfaceType
+      .getName
+      .getIdentifier mustBe "List"
+  }
+}

--- a/modules/codegen/src/test/scala/tests/generators/http4s/BasicTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/http4s/BasicTest.scala
@@ -132,7 +132,7 @@ class BasicTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
       def getBar(headers: List[Header] = List.empty): F[GetBarResponse] = {
         val allHeaders = headers ++ List[Option[Header]]().flatten
         val req = Request[F](method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/bar"), headers = Headers(allHeaders))
-        httpClient.fetch(req)({
+        httpClient.run(req).use({
           case _root_.org.http4s.Status.Ok(_) =>
             F.pure(GetBarResponse.Ok): F[GetBarResponse]
           case resp =>
@@ -142,7 +142,7 @@ class BasicTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
       def getBaz(headers: List[Header] = List.empty): F[GetBazResponse] = {
         val allHeaders = headers ++ List[Option[Header]]().flatten
         val req = Request[F](method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/baz"), headers = Headers(allHeaders))
-        httpClient.fetch(req)({
+        httpClient.run(req).use({
           case _root_.org.http4s.Status.Ok(resp) =>
             F.map(getBazOkDecoder.decode(resp, strict = false).value.flatMap(F.fromEither))(GetBazResponse.Ok.apply): F[GetBazResponse]
           case resp =>
@@ -152,7 +152,7 @@ class BasicTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
       def postFoo(headers: List[Header] = List.empty): F[PostFooResponse] = {
         val allHeaders = headers ++ List[Option[Header]]().flatten
         val req = Request[F](method = Method.POST, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders))
-        httpClient.fetch(req)({
+        httpClient.run(req).use({
           case _root_.org.http4s.Status.Ok(_) =>
             F.pure(PostFooResponse.Ok): F[PostFooResponse]
           case resp =>
@@ -162,7 +162,7 @@ class BasicTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
       def getFoo(headers: List[Header] = List.empty): F[GetFooResponse] = {
         val allHeaders = headers ++ List[Option[Header]]().flatten
         val req = Request[F](method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders))
-        httpClient.fetch(req)({
+        httpClient.run(req).use({
           case _root_.org.http4s.Status.Ok(_) =>
             F.pure(GetFooResponse.Ok): F[GetFooResponse]
           case resp =>
@@ -172,7 +172,7 @@ class BasicTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
       def putFoo(headers: List[Header] = List.empty): F[PutFooResponse] = {
         val allHeaders = headers ++ List[Option[Header]]().flatten
         val req = Request[F](method = Method.PUT, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders))
-        httpClient.fetch(req)({
+        httpClient.run(req).use({
           case _root_.org.http4s.Status.Ok(_) =>
             F.pure(PutFooResponse.Ok): F[PutFooResponse]
           case resp =>
@@ -182,7 +182,7 @@ class BasicTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
       def patchFoo(headers: List[Header] = List.empty): F[PatchFooResponse] = {
         val allHeaders = headers ++ List[Option[Header]]().flatten
         val req = Request[F](method = Method.PATCH, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders))
-        httpClient.fetch(req)({
+        httpClient.run(req).use({
           case _root_.org.http4s.Status.Ok(_) =>
             F.pure(PatchFooResponse.Ok): F[PatchFooResponse]
           case resp =>
@@ -192,7 +192,7 @@ class BasicTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
       def deleteFoo(headers: List[Header] = List.empty): F[DeleteFooResponse] = {
         val allHeaders = headers ++ List[Option[Header]]().flatten
         val req = Request[F](method = Method.DELETE, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders))
-        httpClient.fetch(req)({
+        httpClient.run(req).use({
           case _root_.org.http4s.Status.Ok(_) =>
             F.pure(DeleteFooResponse.Ok): F[DeleteFooResponse]
           case resp =>

--- a/modules/codegen/src/test/scala/tests/generators/http4s/client/DefaultParametersTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/http4s/client/DefaultParametersTest.scala
@@ -149,7 +149,7 @@ class DefaultParametersTest extends AnyFunSuite with Matchers with SwaggerSpecRu
       def getOrderById(orderId: Long, defparmOpt: Option[Int] = Option(1), defparm: Int = 2, headerMeThis: String, headers: List[Header] = List.empty): F[GetOrderByIdResponse] = {
         val allHeaders = headers ++ List[Option[Header]](Some(Header("HeaderMeThis", Formatter.show(headerMeThis)))).flatten
         val req = Request[F](method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/store/order/" + Formatter.addPath(orderId) + "?" + Formatter.addArg("defparm_opt", defparmOpt) + Formatter.addArg("defparm", defparm)), headers = Headers(allHeaders))
-        httpClient.fetch(req)({
+        httpClient.run(req).use({
           case _root_.org.http4s.Status.Ok(resp) =>
             F.map(getOrderByIdOkDecoder.decode(resp, strict = false).value.flatMap(F.fromEither))(GetOrderByIdResponse.Ok.apply): F[GetOrderByIdResponse]
           case _root_.org.http4s.Status.BadRequest(_) =>
@@ -162,7 +162,7 @@ class DefaultParametersTest extends AnyFunSuite with Matchers with SwaggerSpecRu
       def deleteOrder(orderId: Long, headers: List[Header] = List.empty): F[DeleteOrderResponse] = {
         val allHeaders = headers ++ List[Option[Header]]().flatten
         val req = Request[F](method = Method.DELETE, uri = Uri.unsafeFromString(host + basePath + "/store/order/" + Formatter.addPath(orderId)), headers = Headers(allHeaders))
-        httpClient.fetch(req)({
+        httpClient.run(req).use({
           case _root_.org.http4s.Status.BadRequest(_) =>
             F.pure(DeleteOrderResponse.BadRequest): F[DeleteOrderResponse]
           case _root_.org.http4s.Status.NotFound(_) =>

--- a/modules/sample-http4s/src/test/scala/core/issues/Issue121.scala
+++ b/modules/sample-http4s/src/test/scala/core/issues/Issue121.scala
@@ -33,7 +33,8 @@ class Issue121Suite extends AnyFunSuite with Matchers with EitherValues with Sca
     val req = Request[IO](method = Method.DELETE, uri = Uri.unsafeFromString("/entity")).withEntity(UrlForm("id" -> "1234"))
 
     client
-      .fetch(req)({
+      .run(req)
+      .use({
         case Status.NoContent(resp) =>
           IO.pure({
             resp.status should equal(Status.NoContent)

--- a/modules/sample-http4s/src/test/scala/core/issues/Issue148.scala
+++ b/modules/sample-http4s/src/test/scala/core/issues/Issue148.scala
@@ -39,7 +39,7 @@ class Issue148Suite extends AnyFunSuite with Matchers with EitherValues with Sca
     val client = Client.fromHttpApp[IO](route.orNotFound)
     def failedResponseBody(req: Request[IO]): String =
       client
-        .fetch(req)({
+        .run(req).use({
           case Status.BadRequest(resp) =>
             resp.as[String]
           case Status.UnprocessableEntity(resp) =>

--- a/modules/sample-http4s/src/test/scala/core/issues/Issue542.scala
+++ b/modules/sample-http4s/src/test/scala/core/issues/Issue542.scala
@@ -33,7 +33,7 @@ class Issue542Suite extends AnyFunSuite with Matchers with EitherValues with Sca
     val req = Request[IO](method = Method.GET, uri = Uri.unsafeFromString("/foo"))
 
     client
-      .fetch(req)({
+      .run(req).use({
         case Status.Ok(resp) =>
           resp.status should equal(Status.Ok)
           resp.contentType should equal(Some(`Content-Type`(MediaType.application.json)))


### PR DESCRIPTION
http4s 0.21.5+ deprecates 'fetch' operation.
This PR should address it.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
