### PR TITLE
Collections lib terms

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ClientGenerator.scala
@@ -3,10 +3,10 @@ package com.twilio.guardrail
 import cats.data.NonEmptyList
 import cats.implicits._
 import com.twilio.guardrail.languages.LA
-import com.twilio.guardrail.protocol.terms.client.ClientTerms
 import com.twilio.guardrail.protocol.terms.Responses
+import com.twilio.guardrail.protocol.terms.client.ClientTerms
 import com.twilio.guardrail.terms.framework.FrameworkTerms
-import com.twilio.guardrail.terms.{ LanguageTerms, RouteMeta, SecurityScheme, SwaggerTerms }
+import com.twilio.guardrail.terms._
 import java.net.URI
 
 case class Clients[L <: LA](clients: List[Client[L]], supportDefinitions: List[SupportDefinition[L]])
@@ -31,10 +31,10 @@ object ClientGenerator {
   )(
       protocolElems: List[StrictProtocolElems[L]],
       securitySchemes: Map[String, SecurityScheme[L]]
-  )(implicit C: ClientTerms[L, F], Fw: FrameworkTerms[L, F], Sc: LanguageTerms[L, F], Sw: SwaggerTerms[L, F]): F[Clients[L]] = {
+  )(implicit C: ClientTerms[L, F], Fw: FrameworkTerms[L, F], Sc: LanguageTerms[L, F], Cl: CollectionsLibTerms[L, F], Sw: SwaggerTerms[L, F]): F[Clients[L]] = {
     import C._
-    import Sw._
     import Sc._
+    import Sw._
     for {
       clientImports      <- getImports(context.tracing)
       clientExtraImports <- getExtraImports(context.tracing)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -11,7 +11,7 @@ import com.twilio.guardrail.protocol.terms.protocol.{ ArrayProtocolTerms, EnumPr
 import com.twilio.guardrail.terms.framework.FrameworkTerms
 import com.twilio.guardrail.protocol.terms.client.ClientTerms
 import com.twilio.guardrail.protocol.terms.server.ServerTerms
-import com.twilio.guardrail.terms.{ CoreTerms, LanguageTerms, SecurityRequirements, SwaggerTerms }
+import com.twilio.guardrail.terms.{ CollectionsLibTerms, CoreTerms, LanguageTerms, SecurityRequirements, SwaggerTerms }
 import java.nio.file.Path
 import java.net.URI
 
@@ -36,11 +36,12 @@ object Common {
       Pol: PolyProtocolTerms[L, F],
       S: ProtocolSupportTerms[L, F],
       Sc: LanguageTerms[L, F],
+      Cl: CollectionsLibTerms[L, F],
       Se: ServerTerms[L, F],
       Sw: SwaggerTerms[L, F]
   ): F[(ProtocolDefinitions[L], CodegenDefinitions[L])] = {
     import Fw._
-    import Sc._
+    import Cl._
     import Sw._
 
     Sw.log.function("prepareDefinitions")(for {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolElems.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolElems.scala
@@ -3,7 +3,7 @@ package com.twilio.guardrail
 import cats.FlatMap
 import cats.implicits._
 import com.twilio.guardrail.languages.LA
-import com.twilio.guardrail.terms.{ LanguageTerms, SwaggerTerms }
+import com.twilio.guardrail.terms.{ CollectionsLibTerms, LanguageTerms, SwaggerTerms }
 import com.twilio.guardrail.protocol.terms.protocol.ProtocolSupportTerms
 
 case class StaticDefns[L <: LA](className: String, extraImports: List[L#Import], definitions: List[L#Definition])
@@ -44,8 +44,9 @@ object ProtocolElems {
   def resolve[L <: LA, F[_]](
       elems: List[ProtocolElems[L]],
       limit: Int = 10
-  )(implicit Sc: LanguageTerms[L, F], Sw: SwaggerTerms[L, F], P: ProtocolSupportTerms[L, F]): F[List[StrictProtocolElems[L]]] = {
+  )(implicit Sc: LanguageTerms[L, F], Cl: CollectionsLibTerms[L, F], Sw: SwaggerTerms[L, F], P: ProtocolSupportTerms[L, F]): F[List[StrictProtocolElems[L]]] = {
     import Sc._
+    import Cl._
     import Sw._
     log.function(s"resolve(${elems.length} references)")(
       FlatMap[F]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
@@ -11,7 +11,7 @@ import com.twilio.guardrail.generators.RawParameterType
 import com.twilio.guardrail.languages.LA
 import com.twilio.guardrail.protocol.terms.protocol._
 import com.twilio.guardrail.terms.framework.FrameworkTerms
-import com.twilio.guardrail.terms.{ LanguageTerms, SwaggerTerms }
+import com.twilio.guardrail.terms.{ CollectionsLibTerms, LanguageTerms, SwaggerTerms }
 import cats.Foldable
 import com.twilio.guardrail.extract.Default
 import scala.collection.JavaConverters._
@@ -112,6 +112,7 @@ object ProtocolGenerator {
       implicit E: EnumProtocolTerms[L, F],
       F: FrameworkTerms[L, F],
       Sc: LanguageTerms[L, F],
+      Cl: CollectionsLibTerms[L, F],
       Sw: SwaggerTerms[L, F]
   ): F[Either[String, EnumDefinition[L]]] = {
     import E._
@@ -181,6 +182,7 @@ object ProtocolGenerator {
       E: EnumProtocolTerms[L, F],
       M: ModelProtocolTerms[L, F],
       Sc: LanguageTerms[L, F],
+      Cl: CollectionsLibTerms[L, F],
       Sw: SwaggerTerms[L, F]
   ): F[ProtocolElems[L]] = {
     import M._
@@ -254,6 +256,7 @@ object ProtocolGenerator {
       E: EnumProtocolTerms[L, F],
       P: PolyProtocolTerms[L, F],
       Sc: LanguageTerms[L, F],
+      Cl: CollectionsLibTerms[L, F],
       Sw: SwaggerTerms[L, F]
   ): F[List[SuperClass[L]]] = {
     import M._
@@ -335,6 +338,7 @@ object ProtocolGenerator {
       E: EnumProtocolTerms[L, F],
       P: PolyProtocolTerms[L, F],
       Sc: LanguageTerms[L, F],
+      Cl: CollectionsLibTerms[L, F],
       Sw: SwaggerTerms[L, F]
   ): F[Either[String, ClassDefinition[L]]] = {
     import M._
@@ -402,6 +406,7 @@ object ProtocolGenerator {
       E: EnumProtocolTerms[L, F],
       P: PolyProtocolTerms[L, F],
       Sc: LanguageTerms[L, F],
+      Cl: CollectionsLibTerms[L, F],
       Sw: SwaggerTerms[L, F]
   ): F[(List[ProtocolParameter[L]], List[NestedProtocolElems[L]])] = {
     import M._
@@ -537,6 +542,7 @@ object ProtocolGenerator {
       implicit
       Fw: FrameworkTerms[L, F],
       Sc: LanguageTerms[L, F],
+      Cl: CollectionsLibTerms[L, F],
       Sw: SwaggerTerms[L, F]
   ): F[ProtocolElems[L]] = {
     import Fw._
@@ -585,6 +591,7 @@ object ProtocolGenerator {
       F: FrameworkTerms[L, F],
       P: ProtocolSupportTerms[L, F],
       Sc: LanguageTerms[L, F],
+      Cl: CollectionsLibTerms[L, F],
       Sw: SwaggerTerms[L, F]
   ): F[ProtocolElems[L]] = {
     import R._
@@ -684,6 +691,7 @@ object ProtocolGenerator {
       F: FrameworkTerms[L, F],
       P: PolyProtocolTerms[L, F],
       Sc: LanguageTerms[L, F],
+      Cl: CollectionsLibTerms[L, F],
       Sw: SwaggerTerms[L, F]
   ): F[ProtocolDefinitions[L]] = {
     import S._
@@ -787,9 +795,11 @@ object ProtocolGenerator {
       requirement: PropertyRequirement,
       definitions: List[(String, Schema[_])]
   )(
-      implicit Sc: LanguageTerms[L, F]
+      implicit Sc: LanguageTerms[L, F],
+      Cl: CollectionsLibTerms[L, F]
   ): F[Option[L#Term]] = {
     import Sc._
+    import Cl._
     val empty = Option.empty[L#Term].pure[F]
     Option(schema.get$ref()) match {
       case Some(ref) =>

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
@@ -7,7 +7,7 @@ import com.twilio.guardrail.languages.LA
 import com.twilio.guardrail.protocol.terms.Responses
 import com.twilio.guardrail.protocol.terms.server.{ GenerateRouteMeta, ServerTerms }
 import com.twilio.guardrail.terms.framework.FrameworkTerms
-import com.twilio.guardrail.terms.{ LanguageTerms, RouteMeta, SecurityScheme, SwaggerTerms }
+import com.twilio.guardrail.terms.{ CollectionsLibTerms, LanguageTerms, RouteMeta, SecurityScheme, SwaggerTerms }
 
 case class Servers[L <: LA](servers: List[Server[L]], supportDefinitions: List[SupportDefinition[L]])
 case class Server[L <: LA](pkg: List[String], extraImports: List[L#Import], handlerDefinition: L#Definition, serverDefinitions: List[L#Definition])
@@ -26,7 +26,7 @@ object ServerGenerator {
   )(
       protocolElems: List[StrictProtocolElems[L]],
       securitySchemes: Map[String, SecurityScheme[L]]
-  )(implicit Fw: FrameworkTerms[L, F], Sc: LanguageTerms[L, F], S: ServerTerms[L, F], Sw: SwaggerTerms[L, F]): F[Servers[L]] = {
+  )(implicit Fw: FrameworkTerms[L, F], Sc: LanguageTerms[L, F], Cl: CollectionsLibTerms[L, F], S: ServerTerms[L, F], Sw: SwaggerTerms[L, F]): F[Servers[L]] = {
     import S._
     import Sw._
     import Sc._

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala
@@ -9,7 +9,7 @@ import cats.{ FlatMap, Foldable }
 import cats.implicits._
 import com.twilio.guardrail.core.Tracker
 import com.twilio.guardrail.core.implicits._
-import com.twilio.guardrail.terms.{ LanguageTerms, SecurityScheme, SwaggerTerms }
+import com.twilio.guardrail.terms.{ CollectionsLibTerms, LanguageTerms, SecurityScheme, SwaggerTerms }
 import com.twilio.guardrail.terms.framework.FrameworkTerms
 import com.twilio.guardrail.extract.{ CustomArrayTypeName, CustomMapTypeName, CustomTypeName, Default, Extractable, VendorExtension }
 import com.twilio.guardrail.extract.VendorExtension.VendorExtensible._
@@ -31,54 +31,56 @@ object SwaggerUtil {
   object ResolvedType {
     def resolveReferences[L <: LA, F[_]](
         values: List[(String, ResolvedType[L])]
-    )(implicit Sc: LanguageTerms[L, F], Sw: SwaggerTerms[L, F]): F[List[(String, Resolved[L])]] = Sw.log.function("resolveReferences") {
-      import Sc._
-      import Sw._
-      val (lazyTypes, resolvedTypes) = Foldable[List].partitionEither(values) {
-        case (clsName, x: Resolved[L])         => Right((clsName, x))
-        case (clsName, x: LazyResolvedType[L]) => Left((clsName, x))
-      }
-
-      def lookupTypeName(clsName: String, tpeName: String, resolvedTypes: List[(String, Resolved[L])])(
-          f: L#Type => F[L#Type]
-      ): F[Option[(String, Resolved[L])]] =
-        resolvedTypes
-          .find(_._1 == tpeName)
-          .map(_._2)
-          .traverse(x => f(x.tpe).map(tpe => (clsName, x.copy(tpe = tpe))))
-
-      type Continue = (List[(String, LazyResolvedType[L])], List[(String, Resolved[L])])
-      type Stop     = List[(String, Resolved[L])]
-      log.debug(s"resolve ${values.length} references") >> FlatMap[F]
-        .tailRecM[Continue, Stop](
-          (lazyTypes, resolvedTypes)
-        ) {
-          case (lazyTypes, resolvedTypes) =>
-            if (lazyTypes.isEmpty) {
-              (Right(resolvedTypes): Either[Continue, Stop]).pure[F]
-            } else {
-              lazyTypes
-                .partitionEitherM({
-                  case x @ (clsName, Deferred(tpeName)) =>
-                    lookupTypeName(clsName, tpeName, resolvedTypes)(_.pure[F]).map(Either.fromOption(_, x))
-                  case x @ (clsName, DeferredArray(tpeName, containerTpe)) =>
-                    lookupTypeName(clsName, tpeName, resolvedTypes)(liftVectorType(_, containerTpe)).map(Either.fromOption(_, x))
-                  case x @ (clsName, DeferredMap(tpeName, containerTpe)) =>
-                    lookupTypeName(clsName, tpeName, resolvedTypes)(liftMapType(_, containerTpe)).map(Either.fromOption(_, x))
-                })
-                .map({
-                  case (newLazyTypes, newResolvedTypes) =>
-                    Left((newLazyTypes, resolvedTypes ++ newResolvedTypes))
-                })
-            }
+    )(implicit Sc: LanguageTerms[L, F], Cl: CollectionsLibTerms[L, F], Sw: SwaggerTerms[L, F]): F[List[(String, Resolved[L])]] =
+      Sw.log.function("resolveReferences") {
+        import Cl._
+        import Sw._
+        val (lazyTypes, resolvedTypes) = Foldable[List].partitionEither(values) {
+          case (clsName, x: Resolved[L])         => Right((clsName, x))
+          case (clsName, x: LazyResolvedType[L]) => Left((clsName, x))
         }
-    }
+
+        def lookupTypeName(clsName: String, tpeName: String, resolvedTypes: List[(String, Resolved[L])])(
+            f: L#Type => F[L#Type]
+        ): F[Option[(String, Resolved[L])]] =
+          resolvedTypes
+            .find(_._1 == tpeName)
+            .map(_._2)
+            .traverse(x => f(x.tpe).map(tpe => (clsName, x.copy(tpe = tpe))))
+
+        type Continue = (List[(String, LazyResolvedType[L])], List[(String, Resolved[L])])
+        type Stop     = List[(String, Resolved[L])]
+        log.debug(s"resolve ${values.length} references") >> FlatMap[F]
+          .tailRecM[Continue, Stop](
+            (lazyTypes, resolvedTypes)
+          ) {
+            case (lazyTypes, resolvedTypes) =>
+              if (lazyTypes.isEmpty) {
+                (Right(resolvedTypes): Either[Continue, Stop]).pure[F]
+              } else {
+                lazyTypes
+                  .partitionEitherM({
+                    case x @ (clsName, Deferred(tpeName)) =>
+                      lookupTypeName(clsName, tpeName, resolvedTypes)(_.pure[F]).map(Either.fromOption(_, x))
+                    case x @ (clsName, DeferredArray(tpeName, containerTpe)) =>
+                      lookupTypeName(clsName, tpeName, resolvedTypes)(liftVectorType(_, containerTpe)).map(Either.fromOption(_, x))
+                    case x @ (clsName, DeferredMap(tpeName, containerTpe)) =>
+                      lookupTypeName(clsName, tpeName, resolvedTypes)(liftMapType(_, containerTpe)).map(Either.fromOption(_, x))
+                  })
+                  .map({
+                    case (newLazyTypes, newResolvedTypes) =>
+                      Left((newLazyTypes, resolvedTypes ++ newResolvedTypes))
+                  })
+              }
+          }
+      }
 
     def resolve[L <: LA, F[_]](
         value: ResolvedType[L],
         protocolElems: List[StrictProtocolElems[L]]
-    )(implicit Sc: LanguageTerms[L, F], Sw: SwaggerTerms[L, F]): F[Resolved[L]] = {
+    )(implicit Sc: LanguageTerms[L, F], Cl: CollectionsLibTerms[L, F], Sw: SwaggerTerms[L, F]): F[Resolved[L]] = {
       import Sc._
+      import Cl._
       import Sw._
       log.debug(s"value: ${value} in ${protocolElems.length} protocol elements") >> (value match {
         case x @ Resolved(_, _, _, _, _) => x.pure[F]
@@ -131,22 +133,22 @@ object SwaggerUtil {
     }
   }
 
-  def customTypeName[L <: LA, F[_], A: VendorExtension.VendorExtensible](v: A)(implicit S: LanguageTerms[L, F]): F[Option[String]] = {
-    import S._
+  def customTypeName[L <: LA, F[_], A: VendorExtension.VendorExtensible](v: A)(implicit Cl: CollectionsLibTerms[L, F]): F[Option[String]] = {
+    import Cl._
     for {
       prefixes <- vendorPrefixes()
     } yield CustomTypeName(v, prefixes)
   }
 
-  def customArrayTypeName[L <: LA, F[_], A: VendorExtension.VendorExtensible](v: A)(implicit S: LanguageTerms[L, F]): F[Option[String]] = {
-    import S._
+  def customArrayTypeName[L <: LA, F[_], A: VendorExtension.VendorExtensible](v: A)(implicit Cl: CollectionsLibTerms[L, F]): F[Option[String]] = {
+    import Cl._
     for {
       prefixes <- vendorPrefixes()
     } yield CustomArrayTypeName(v, prefixes)
   }
 
-  def customMapTypeName[L <: LA, F[_], A: VendorExtension.VendorExtensible](v: A)(implicit S: LanguageTerms[L, F]): F[Option[String]] = {
-    import S._
+  def customMapTypeName[L <: LA, F[_], A: VendorExtension.VendorExtensible](v: A)(implicit Cl: CollectionsLibTerms[L, F]): F[Option[String]] = {
+    import Cl._
     for {
       prefixes <- vendorPrefixes()
     } yield CustomMapTypeName(v, prefixes)
@@ -155,9 +157,10 @@ object SwaggerUtil {
   sealed class ModelMetaTypePartiallyApplied[L <: LA, F[_]](val dummy: Boolean = true) {
     def apply[T <: Schema[_]](
         model: Tracker[T]
-    )(implicit Sc: LanguageTerms[L, F], Sw: SwaggerTerms[L, F], Fw: FrameworkTerms[L, F]): F[ResolvedType[L]] =
+    )(implicit Sc: LanguageTerms[L, F], Cl: CollectionsLibTerms[L, F], Sw: SwaggerTerms[L, F], Fw: FrameworkTerms[L, F]): F[ResolvedType[L]] =
       Sw.log.function("modelMetaType") {
         import Sc._
+        import Cl._
         import Sw._
         import Fw._
         log.debug(s"model:\n${log.schemaToString(model.get)}") >> (model
@@ -220,7 +223,7 @@ object SwaggerUtil {
 
   def extractConcreteTypes[L <: LA, F[_]](
       definitions: List[(String, Tracker[Schema[_]])]
-  )(implicit Sc: LanguageTerms[L, F], Sw: SwaggerTerms[L, F], F: FrameworkTerms[L, F]): F[List[PropMeta[L]]] = {
+  )(implicit Sc: LanguageTerms[L, F], Cl: CollectionsLibTerms[L, F], Sw: SwaggerTerms[L, F], F: FrameworkTerms[L, F]): F[List[PropMeta[L]]] = {
     import Sc._
     for {
       entries <- definitions.traverse[F, (String, SwaggerUtil.ResolvedType[L])] {
@@ -263,9 +266,10 @@ object SwaggerUtil {
       typeName: Tracker[Option[String]],
       format: Tracker[Option[String]],
       customType: Option[String]
-  )(implicit Sc: LanguageTerms[L, F], Sw: SwaggerTerms[L, F], Fw: FrameworkTerms[L, F]): F[L#Type] =
+  )(implicit Sc: LanguageTerms[L, F], Cl: CollectionsLibTerms[L, F], Sw: SwaggerTerms[L, F], Fw: FrameworkTerms[L, F]): F[L#Type] =
     Sw.log.function(s"typeName(${typeName.unwrapTracker}, ${format.unwrapTracker}, ${customType})") {
       import Sc._
+      import Cl._
       import Fw._
 
       def log(fmt: Option[String], t: L#Type): L#Type = {
@@ -321,6 +325,7 @@ object SwaggerUtil {
 
   def propMeta[L <: LA, F[_]](property: Tracker[Schema[_]])(
       implicit Sc: LanguageTerms[L, F],
+      Cl: CollectionsLibTerms[L, F],
       Sw: SwaggerTerms[L, F],
       Fw: FrameworkTerms[L, F]
   ): F[ResolvedType[L]] = {
@@ -345,6 +350,7 @@ object SwaggerUtil {
 
   def propMetaWithName[L <: LA, F[_]](tpe: L#Type, property: Tracker[Schema[_]])(
       implicit Sc: LanguageTerms[L, F],
+      Cl: CollectionsLibTerms[L, F],
       Sw: SwaggerTerms[L, F],
       Fw: FrameworkTerms[L, F]
   ): F[ResolvedType[L]] = {
@@ -367,10 +373,11 @@ object SwaggerUtil {
 
   private def propMetaImpl[L <: LA, F[_]](property: Tracker[Schema[_]])(
       strategy: PartialFunction[Schema[_], F[ResolvedType[L]]]
-  )(implicit Sc: LanguageTerms[L, F], Sw: SwaggerTerms[L, F], Fw: FrameworkTerms[L, F]): F[ResolvedType[L]] =
+  )(implicit Sc: LanguageTerms[L, F], Cl: CollectionsLibTerms[L, F], Sw: SwaggerTerms[L, F], Fw: FrameworkTerms[L, F]): F[ResolvedType[L]] =
     Sw.log.function("propMeta") {
       import Fw._
       import Sc._
+      import Cl._
       import Sw._
 
       def buildResolveNoDefault[A <: Schema[_]]: Tracker[A] => F[ResolvedType[L]] = { a =>

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Framework.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Framework.scala
@@ -2,11 +2,10 @@ package com.twilio.guardrail
 package generators
 
 import com.twilio.guardrail.languages.LA
-
 import com.twilio.guardrail.protocol.terms.protocol.{ ArrayProtocolTerms, EnumProtocolTerms, ModelProtocolTerms, PolyProtocolTerms, ProtocolSupportTerms }
 import com.twilio.guardrail.protocol.terms.client.ClientTerms
 import com.twilio.guardrail.protocol.terms.server.ServerTerms
-import com.twilio.guardrail.terms.{ LanguageTerms, SwaggerTerms }
+import com.twilio.guardrail.terms.{ CollectionsLibTerms, LanguageTerms, SwaggerTerms }
 import com.twilio.guardrail.terms.framework.FrameworkTerms
 
 trait Framework[L <: LA, F[_]] {
@@ -20,4 +19,5 @@ trait Framework[L <: LA, F[_]] {
   implicit def ServerInterp: ServerTerms[L, F]
   implicit def SwaggerInterp: SwaggerTerms[L, F]
   implicit def LanguageInterp: LanguageTerms[L, F]
+  implicit def CollectionsLibInterp: CollectionsLibTerms[L, F]
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
@@ -28,7 +28,7 @@ import com.twilio.guardrail.protocol.terms.{
 }
 import com.twilio.guardrail.protocol.terms.client._
 import com.twilio.guardrail.shims._
-import com.twilio.guardrail.terms.{ RouteMeta, SecurityScheme }
+import com.twilio.guardrail.terms.{ CollectionsLibTerms, RouteMeta, SecurityScheme }
 import com.twilio.guardrail.{ RenderedClientOperation, StaticDefns, StrictProtocolElems, SupportDefinition, SwaggerUtil, Target }
 import java.net.URI
 
@@ -402,7 +402,7 @@ object AsyncHttpClientClientGenerator {
       (imports, cls)
     }
 
-  object ClientTermInterp extends ClientTerms[JavaLanguage, Target] {
+  class ClientTermInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target]) extends ClientTerms[JavaLanguage, Target] {
     implicit def MonadF: Monad[Target] = Target.targetInstances
 
     def generateClientOperation(

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/Dropwizard.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/Dropwizard.scala
@@ -1,13 +1,14 @@
 package com.twilio.guardrail.generators.Java
 
+import com.twilio.guardrail.Target
 import com.twilio.guardrail.generators.Java.AsyncHttpClientClientGenerator.ClientTermInterp
 import com.twilio.guardrail.generators.Java.DropwizardGenerator.{ FrameworkInterp => DropwizardFrameworkInterp }
 import com.twilio.guardrail.generators.Java.DropwizardServerGenerator.ServerTermInterp
 import com.twilio.guardrail.generators.Java.JacksonGenerator._
 import com.twilio.guardrail.generators.JavaGenerator.JavaInterp
+import com.twilio.guardrail.generators.collections.JavaCollectionsGenerator.JavaCollectionsInterp
 import com.twilio.guardrail.generators.{ Framework, SwaggerGenerator }
 import com.twilio.guardrail.languages.JavaLanguage
-import com.twilio.guardrail.Target
 
 object Dropwizard extends Framework[JavaLanguage, Target] {
   implicit def ArrayProtocolInterp   = ArrayProtocolTermInterp
@@ -20,4 +21,5 @@ object Dropwizard extends Framework[JavaLanguage, Target] {
   implicit def ServerInterp          = ServerTermInterp
   implicit def SwaggerInterp         = SwaggerGenerator[JavaLanguage]
   implicit def LanguageInterp        = JavaInterp
+  implicit def CollectionsLibInterp  = JavaCollectionsInterp
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/Dropwizard.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/Dropwizard.scala
@@ -11,15 +11,15 @@ import com.twilio.guardrail.generators.{ Framework, SwaggerGenerator }
 import com.twilio.guardrail.languages.JavaLanguage
 
 object Dropwizard extends Framework[JavaLanguage, Target] {
-  implicit def ArrayProtocolInterp   = ArrayProtocolTermInterp
-  implicit def ClientInterp          = ClientTermInterp
-  implicit def EnumProtocolInterp    = EnumProtocolTermInterp
-  implicit def FrameworkInterp       = DropwizardFrameworkInterp
-  implicit def ModelProtocolInterp   = ModelProtocolTermInterp
-  implicit def PolyProtocolInterp    = PolyProtocolTermInterp
-  implicit def ProtocolSupportInterp = ProtocolSupportTermInterp
-  implicit def ServerInterp          = ServerTermInterp
+  implicit def CollectionsLibInterp  = JavaCollectionsInterp
+  implicit def ArrayProtocolInterp   = new ArrayProtocolTermInterp
+  implicit def ClientInterp          = new ClientTermInterp
+  implicit def EnumProtocolInterp    = new EnumProtocolTermInterp
+  implicit def FrameworkInterp       = new DropwizardFrameworkInterp
+  implicit def ModelProtocolInterp   = new ModelProtocolTermInterp
+  implicit def PolyProtocolInterp    = new PolyProtocolTermInterp
+  implicit def ProtocolSupportInterp = new ProtocolSupportTermInterp
+  implicit def ServerInterp          = new ServerTermInterp
   implicit def SwaggerInterp         = SwaggerGenerator[JavaLanguage]
   implicit def LanguageInterp        = JavaInterp
-  implicit def CollectionsLibInterp  = JavaCollectionsInterp
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/Dropwizard.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/Dropwizard.scala
@@ -5,13 +5,14 @@ import com.twilio.guardrail.generators.Java.AsyncHttpClientClientGenerator.Clien
 import com.twilio.guardrail.generators.Java.DropwizardGenerator.{ FrameworkInterp => DropwizardFrameworkInterp }
 import com.twilio.guardrail.generators.Java.DropwizardServerGenerator.ServerTermInterp
 import com.twilio.guardrail.generators.Java.JacksonGenerator._
+import com.twilio.guardrail.generators.Java.collectionslib.JavaStdLibCollections
 import com.twilio.guardrail.generators.JavaGenerator.JavaInterp
 import com.twilio.guardrail.generators.collections.JavaCollectionsGenerator.JavaCollectionsInterp
 import com.twilio.guardrail.generators.{ Framework, SwaggerGenerator }
 import com.twilio.guardrail.languages.JavaLanguage
 
 object Dropwizard extends Framework[JavaLanguage, Target] {
-  implicit def CollectionsLibInterp  = JavaCollectionsInterp
+  implicit def CollectionsLibInterp  = new JavaCollectionsInterp with JavaStdLibCollections
   implicit def ArrayProtocolInterp   = new ArrayProtocolTermInterp
   implicit def ClientInterp          = new ClientTermInterp
   implicit def EnumProtocolInterp    = new EnumProtocolTermInterp

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardGenerator.scala
@@ -7,10 +7,11 @@ import com.github.javaparser.ast.expr._
 import com.twilio.guardrail.{ SupportDefinition, Target }
 import com.twilio.guardrail.generators.syntax.Java._
 import com.twilio.guardrail.languages.JavaLanguage
+import com.twilio.guardrail.terms.CollectionsLibTerms
 import com.twilio.guardrail.terms.framework._
 
 object DropwizardGenerator {
-  object FrameworkInterp extends FrameworkTerms[JavaLanguage, Target] {
+  class FrameworkInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target]) extends FrameworkTerms[JavaLanguage, Target] {
     implicit def MonadF = Target.targetInstances
 
     private lazy val supportDefs: Target[List[SupportDefinition[JavaLanguage]]] = List(

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
@@ -32,7 +32,7 @@ import com.twilio.guardrail.protocol.terms.{
 }
 import com.twilio.guardrail.protocol.terms.server._
 import com.twilio.guardrail.shims.OperationExt
-import com.twilio.guardrail.terms.{ RouteMeta, SecurityScheme }
+import com.twilio.guardrail.terms.{ CollectionsLibTerms, RouteMeta, SecurityScheme }
 import scala.compat.java8.OptionConverters._
 import scala.language.existentials
 import _root_.io.swagger.v3.oas.models.Operation
@@ -196,7 +196,7 @@ object DropwizardServerGenerator {
     }
   }
 
-  object ServerTermInterp extends ServerTerms[JavaLanguage, Target] {
+  class ServerTermInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target]) extends ServerTerms[JavaLanguage, Target] {
     implicit def MonadF: Monad[Target] = Target.targetInstances
     override def getExtraImports(tracing: Boolean, supportPackage: List[String]): Target[List[ImportDeclaration]] =
       List(

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
@@ -302,7 +302,7 @@ object DropwizardServerGenerator {
                 val tpe        = if (isOptional) parameter.getType.containedType else parameter.getType
 
                 def transform(to: Type): Parameter = {
-                  parameter.setType(if (isOptional) optionalType(to) else to)
+                  parameter.setType(if (isOptional) javaOptionalType(to) else to)
                   if (!isOptional) {
                     parameter.getAnnotations.add(0, new MarkerAnnotationExpr("UnwrapValidatedValue"))
                   }
@@ -333,7 +333,7 @@ object DropwizardServerGenerator {
               def transformMultipartFile(parameter: Parameter, param: LanguageParameter[JavaLanguage]): Parameter =
                 (param.isFile, param.required) match {
                   case (true, true)  => parameter.setType(FILE_TYPE)
-                  case (true, false) => parameter.setType(optionalType(FILE_TYPE))
+                  case (true, false) => parameter.setType(javaOptionalType(FILE_TYPE))
                   case _             => parameter
                 }
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
@@ -4,38 +4,28 @@ import cats.Monad
 import cats.data.NonEmptyList
 import cats.implicits._
 import com.github.javaparser.StaticJavaParser
-import com.github.javaparser.ast.Modifier._
 import com.github.javaparser.ast.Modifier.Keyword._
-import com.github.javaparser.ast.{ ImportDeclaration, Node, NodeList }
+import com.github.javaparser.ast.Modifier._
 import com.github.javaparser.ast.`type`.{ ClassOrInterfaceType, PrimitiveType, Type, VoidType }
 import com.github.javaparser.ast.body._
-import com.github.javaparser.ast.expr._
+import com.github.javaparser.ast.expr.{ MethodCallExpr, _ }
 import com.github.javaparser.ast.stmt._
-import com.twilio.guardrail.{ RenderedRoutes, StrictProtocolElems, SupportDefinition, Target, TracingField }
+import com.github.javaparser.ast.{ ImportDeclaration, Node, NodeList }
 import com.twilio.guardrail.core.Tracker
 import com.twilio.guardrail.extract.ServerRawResponse
+import com.twilio.guardrail.generators.Java.collectionslib.CollectionsLibType
 import com.twilio.guardrail.generators.LanguageParameter
 import com.twilio.guardrail.generators.helpers.DropwizardHelpers._
 import com.twilio.guardrail.generators.syntax.Java._
 import com.twilio.guardrail.languages.JavaLanguage
-import com.twilio.guardrail.protocol.terms.{
-  ApplicationJson,
-  BinaryContent,
-  ContentType,
-  MultipartFormData,
-  OctetStream,
-  Response,
-  Responses,
-  TextContent,
-  TextPlain,
-  UrlencodedFormData
-}
+import com.twilio.guardrail.protocol.terms._
 import com.twilio.guardrail.protocol.terms.server._
 import com.twilio.guardrail.shims.OperationExt
 import com.twilio.guardrail.terms.{ CollectionsLibTerms, RouteMeta, SecurityScheme }
+import com.twilio.guardrail.{ RenderedRoutes, StrictProtocolElems, SupportDefinition, Target, TracingField }
+import io.swagger.v3.oas.models.Operation
 import scala.compat.java8.OptionConverters._
 import scala.language.existentials
-import _root_.io.swagger.v3.oas.models.Operation
 
 object DropwizardServerGenerator {
   private implicit class ContentTypeExt(private val ct: ContentType) extends AnyVal {
@@ -126,7 +116,7 @@ object DropwizardServerGenerator {
                 new ExpressionStmt(
                   new MethodCallExpr(
                     "super",
-                    new IntegerLiteralExpr(response.statusCode)
+                    new IntegerLiteralExpr(response.statusCode.toString)
                   )
                 )
               )
@@ -150,7 +140,7 @@ object DropwizardServerGenerator {
                   new ExpressionStmt(
                     new MethodCallExpr(
                       "super",
-                      new IntegerLiteralExpr(response.statusCode)
+                      new IntegerLiteralExpr(response.statusCode.toString)
                     )
                   ),
                   new ExpressionStmt(
@@ -196,7 +186,7 @@ object DropwizardServerGenerator {
     }
   }
 
-  class ServerTermInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target]) extends ServerTerms[JavaLanguage, Target] {
+  class ServerTermInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target] with CollectionsLibType) extends ServerTerms[JavaLanguage, Target] {
     implicit def MonadF: Monad[Target] = Target.targetInstances
     override def getExtraImports(tracing: Boolean, supportPackage: List[String]): Target[List[ImportDeclaration]] =
       List(
@@ -219,7 +209,6 @@ object DropwizardServerGenerator {
         "javax.ws.rs.container.Suspended",
         "javax.ws.rs.core.MediaType",
         "javax.ws.rs.core.Response",
-        "java.util.Optional",
         "java.util.concurrent.CompletionStage",
         "org.glassfish.jersey.media.multipart.FormDataParam",
         "org.hibernate.validator.valuehandling.UnwrapValidatedValue",
@@ -246,11 +235,10 @@ object DropwizardServerGenerator {
       for {
         resourceType <- safeParseClassOrInterfaceType(resourceName)
         handlerType  <- safeParseClassOrInterfaceType(handlerName)
-      } yield {
-        val basePathComponents = basePath.toList.flatMap(splitPathComponents)
-        val commonPathPrefix   = findPathPrefix(routes.map(_.routeMeta.path.get))
-        val (routeMethods, handlerMethodSigs) = routes
-          .map({
+        basePathComponents = basePath.toList.flatMap(splitPathComponents)
+        commonPathPrefix   = findPathPrefix(routes.map(_.routeMeta.path.get))
+        routeMethodsAndHandlerMethodSigs <- routes
+          .traverse({
             case GenerateRouteMeta(
                 operationId,
                 methodName,
@@ -297,17 +285,20 @@ object DropwizardServerGenerator {
                     )
                 )
 
-              def transformJsr310Params(parameter: Parameter): Parameter = {
-                val isOptional = parameter.getType.isOptional
+              def transformJsr310Params(parameter: Parameter): Target[Parameter] = {
+                val isOptional = Cl.isOptionalType(parameter.getType)
                 val tpe        = if (isOptional) parameter.getType.containedType else parameter.getType
 
-                def transform(to: Type): Parameter = {
-                  parameter.setType(if (isOptional) javaOptionalType(to) else to)
-                  if (!isOptional) {
-                    parameter.getAnnotations.add(0, new MarkerAnnotationExpr("UnwrapValidatedValue"))
+                def transform(to: Type): Target[Parameter] =
+                  for {
+                    optionalToType <- Cl.liftOptionalType(to)
+                  } yield {
+                    parameter.setType(if (isOptional) optionalToType else to)
+                    if (!isOptional) {
+                      parameter.getAnnotations.add(0, new MarkerAnnotationExpr("UnwrapValidatedValue"))
+                    }
+                    parameter
                   }
-                  parameter
-                }
 
                 tpe match {
                   case cls: ClassOrInterfaceType if cls.getScope.asScala.forall(_.asString == "java.time") =>
@@ -320,9 +311,9 @@ object DropwizardServerGenerator {
                       case "LocalTime"      => transform(LOCAL_TIME_PARAM_TYPE)
                       case "OffsetTime"     => transform(OFFSET_TIME_PARAM_TYPE)
                       case "Duration"       => transform(DURATION_PARAM_TYPE)
-                      case _                => parameter
+                      case _                => Target.pure(parameter)
                     }
-                  case _ => parameter
+                  case _ => Target.pure(parameter)
                 }
               }
 
@@ -330,11 +321,11 @@ object DropwizardServerGenerator {
               // because that will require the server to buffer the entire contents in memory as it
               // reads in the entire body.  Instead we instruct Dropwizard to write it out to a file
               // on disk and use java.io.File.
-              def transformMultipartFile(parameter: Parameter, param: LanguageParameter[JavaLanguage]): Parameter =
+              def transformMultipartFile(parameter: Parameter, param: LanguageParameter[JavaLanguage]): Target[Parameter] =
                 (param.isFile, param.required) match {
-                  case (true, true)  => parameter.setType(FILE_TYPE)
-                  case (true, false) => parameter.setType(javaOptionalType(FILE_TYPE))
-                  case _             => parameter
+                  case (true, true)  => Target.pure(parameter.setType(FILE_TYPE))
+                  case (true, false) => Cl.liftOptionalType(FILE_TYPE).map(parameter.setType)
+                  case _             => Target.pure(parameter)
                 }
 
               def addValidationAnnotations(parameter: Parameter, param: LanguageParameter[JavaLanguage]): Parameter = {
@@ -348,7 +339,7 @@ object DropwizardServerGenerator {
               }
 
               def stripOptionalFromCollections(parameter: Parameter, param: LanguageParameter[JavaLanguage]): Parameter =
-                if (!param.required && parameter.getType.containedType.isNamed("List")) {
+                if (!param.required && Cl.isArrayType(parameter.getType.containedType)) {
                   parameter.setType(parameter.getType.containedType)
                 } else {
                   parameter
@@ -364,39 +355,59 @@ object DropwizardServerGenerator {
                 parameter
               }
 
-              val annotatedMethodParams: List[Parameter] = List(
-                (parameters.pathParams, "PathParam"),
-                (parameters.headerParams, "HeaderParam"),
-                (parameters.queryStringParams, "QueryParam"),
-                (parameters.formParams, if (consumes.contains(MultipartFormData)) "FormDataParam" else "FormParam")
-              ).flatMap({
-                case (params, annotationName) =>
-                  params.map({ param =>
-                    val parameter                  = param.param.clone()
-                    val optionalCollectionStripped = stripOptionalFromCollections(parameter, param)
-                    val annotated                  = addParamAnnotation(optionalCollectionStripped, param, annotationName)
-                    val dateTransformed            = transformJsr310Params(annotated)
-                    val fileTransformed            = transformMultipartFile(dateTransformed, param)
-                    addValidationAnnotations(fileTransformed, param)
-                  })
-              })
+              def transformHandlerArg(parameter: Parameter): Expression = {
+                val isOptional = Cl.isOptionalType(parameter.getType)
+                val typeName   = if (isOptional) parameter.getType.containedType.asString else parameter.getType.asString
+                if (typeName.startsWith("GuardrailJerseySupport.Jsr310.") && typeName.endsWith("Param")) {
+                  if (isOptional) {
+                    new MethodCallExpr(
+                      parameter.getNameAsExpression,
+                      "map",
+                      new NodeList[Expression](new MethodReferenceExpr(new NameExpr(typeName), new NodeList, "get"))
+                    )
+                  } else {
+                    new MethodCallExpr(parameter.getNameAsExpression, "get")
+                  }
+                } else {
+                  parameter.getNameAsExpression
+                }
+              }
 
-              val bareMethodParams: List[Parameter] = parameters.bodyParams.toList
-                .map({ param =>
-                  val parameter                  = param.param.clone()
-                  val optionalCollectionStripped = stripOptionalFromCollections(parameter, param)
-                  val dateTransformed            = transformJsr310Params(optionalCollectionStripped)
-                  addValidationAnnotations(dateTransformed, param)
+              for {
+                annotatedMethodParams <- List(
+                  (parameters.pathParams, "PathParam"),
+                  (parameters.headerParams, "HeaderParam"),
+                  (parameters.queryStringParams, "QueryParam"),
+                  (parameters.formParams, if (consumes.contains(MultipartFormData)) "FormDataParam" else "FormParam")
+                ).flatTraverse({
+                  case (params, annotationName) =>
+                    params.traverse({ param =>
+                      val parameter                  = param.param.clone()
+                      val optionalCollectionStripped = stripOptionalFromCollections(parameter, param)
+                      val annotated                  = addParamAnnotation(optionalCollectionStripped, param, annotationName)
+                      for {
+                        dateTransformed <- transformJsr310Params(annotated)
+                        fileTransformed <- transformMultipartFile(dateTransformed, param)
+                      } yield addValidationAnnotations(fileTransformed, param)
+                    })
                 })
 
-              val methodParams = (annotatedMethodParams ++ bareMethodParams).map(boxParameterTypes)
-              methodParams.foreach(method.addParameter)
-              method.addParameter(
-                new Parameter(new NodeList(finalModifier), ASYNC_RESPONSE_TYPE, new SimpleName("asyncResponse")).addMarkerAnnotation("Suspended")
-              )
+                bareMethodParams <- parameters.bodyParams.toList
+                  .traverse({ param =>
+                    val parameter                  = param.param.clone()
+                    val optionalCollectionStripped = stripOptionalFromCollections(parameter, param)
+                    for {
+                      dateTransformed <- transformJsr310Params(optionalCollectionStripped)
+                    } yield addValidationAnnotations(dateTransformed, param)
+                  })
 
-              val (responseName, responseType, resultResumeBody) =
-                ServerRawResponse(operation)
+                methodParams = (annotatedMethodParams ++ bareMethodParams).map(boxParameterTypes)
+                _            = methodParams.foreach(method.addParameter)
+                _ = method.addParameter(
+                  new Parameter(new NodeList(finalModifier), ASYNC_RESPONSE_TYPE, new SimpleName("asyncResponse")).addMarkerAnnotation("Suspended")
+                )
+
+                (responseType, resultResumeBody) = ServerRawResponse(operation)
                   .filter(_ == true)
                   .fold({
                     val responseName = s"$handlerName.$responseClsName"
@@ -429,7 +440,6 @@ object DropwizardServerGenerator {
                           )
                       }))
                     (
-                      responseName,
                       StaticJavaParser.parseClassOrInterfaceType(responseName),
                       (
                         List[Statement](
@@ -460,7 +470,6 @@ object DropwizardServerGenerator {
                     )
                   })({ _ =>
                     (
-                      "Response",
                       RESPONSE_TYPE,
                       new NodeList(
                         new ExpressionStmt(
@@ -473,101 +482,91 @@ object DropwizardServerGenerator {
                       )
                     )
                   })
-              val whenCompleteLambda = new LambdaExpr(
-                new NodeList(
-                  new Parameter(new NodeList(finalModifier), responseType, new SimpleName("result")),
-                  new Parameter(new NodeList(finalModifier), THROWABLE_TYPE, new SimpleName("err"))
-                ),
-                new BlockStmt(
+                whenCompleteLambda = new LambdaExpr(
                   new NodeList(
-                    new IfStmt(
-                      new BinaryExpr(new NameExpr("err"), new NullLiteralExpr, BinaryExpr.Operator.NOT_EQUALS),
-                      new BlockStmt(
-                        new NodeList(
-                          new ExpressionStmt(
-                            new MethodCallExpr(
-                              new NameExpr("logger"),
-                              "error",
-                              new NodeList[Expression](
-                                new StringLiteralExpr(s"${handlerName}.${methodName} threw an exception ({}): {}"),
-                                new MethodCallExpr(new MethodCallExpr(new NameExpr("err"), "getClass"), "getName"),
-                                new MethodCallExpr(new NameExpr("err"), "getMessage"),
-                                new NameExpr("err")
+                    new Parameter(new NodeList(finalModifier), responseType, new SimpleName("result")),
+                    new Parameter(new NodeList(finalModifier), THROWABLE_TYPE, new SimpleName("err"))
+                  ),
+                  new BlockStmt(
+                    new NodeList(
+                      new IfStmt(
+                        new BinaryExpr(new NameExpr("err"), new NullLiteralExpr, BinaryExpr.Operator.NOT_EQUALS),
+                        new BlockStmt(
+                          new NodeList(
+                            new ExpressionStmt(
+                              new MethodCallExpr(
+                                new NameExpr("logger"),
+                                "error",
+                                new NodeList[Expression](
+                                  new StringLiteralExpr(s"${handlerName}.${methodName} threw an exception ({}): {}"),
+                                  new MethodCallExpr(new MethodCallExpr(new NameExpr("err"), "getClass"), "getName"),
+                                  new MethodCallExpr(new NameExpr("err"), "getMessage"),
+                                  new NameExpr("err")
+                                )
                               )
-                            )
-                          ),
-                          new ExpressionStmt(
-                            new MethodCallExpr(
-                              new NameExpr("asyncResponse"),
-                              "resume",
-                              new NodeList[Expression](
-                                new MethodCallExpr(
+                            ),
+                            new ExpressionStmt(
+                              new MethodCallExpr(
+                                new NameExpr("asyncResponse"),
+                                "resume",
+                                new NodeList[Expression](
                                   new MethodCallExpr(
-                                    new NameExpr("Response"),
-                                    "status",
-                                    new NodeList[Expression](new IntegerLiteralExpr(500))
-                                  ),
-                                  "build"
+                                    new MethodCallExpr(
+                                      new NameExpr("Response"),
+                                      "status",
+                                      new NodeList[Expression](new IntegerLiteralExpr("500"))
+                                    ),
+                                    "build"
+                                  )
                                 )
                               )
                             )
                           )
-                        )
-                      ),
-                      new BlockStmt(resultResumeBody)
+                        ),
+                        new BlockStmt(resultResumeBody)
+                      )
                     )
-                  )
-                ),
-                true
-              )
+                  ),
+                  true
+                )
 
-              def transformHandlerArg(parameter: Parameter): Expression = {
-                val isOptional = parameter.getType.isOptional
-                val typeName   = if (isOptional) parameter.getType.containedType.asString else parameter.getType.asString
-                if (typeName.startsWith("GuardrailJerseySupport.Jsr310.") && typeName.endsWith("Param")) {
-                  if (isOptional) {
-                    new MethodCallExpr(
-                      parameter.getNameAsExpression,
-                      "map",
-                      new NodeList[Expression](new MethodReferenceExpr(new NameExpr(typeName), new NodeList, "get"))
+                handlerCall = new MethodCallExpr(
+                  new FieldAccessExpr(new ThisExpr, "handler"),
+                  methodName,
+                  new NodeList[Expression](methodParams.map(transformHandlerArg): _*)
+                )
+
+                _ = method.setBody(
+                  new BlockStmt(
+                    new NodeList(
+                      new ExpressionStmt(new MethodCallExpr(handlerCall, "whenComplete", new NodeList[Expression](whenCompleteLambda)))
                     )
-                  } else {
-                    new MethodCallExpr(parameter.getNameAsExpression, "get")
-                  }
-                } else {
-                  parameter.getNameAsExpression
-                }
-              }
-
-              val handlerCall = new MethodCallExpr(
-                new FieldAccessExpr(new ThisExpr, "handler"),
-                methodName,
-                new NodeList[Expression](methodParams.map(transformHandlerArg): _*)
-              )
-
-              method.setBody(
-                new BlockStmt(
-                  new NodeList(
-                    new ExpressionStmt(new MethodCallExpr(handlerCall, "whenComplete", new NodeList[Expression](whenCompleteLambda)))
                   )
                 )
-              )
 
-              val futureResponseType = completionStageType(responseType.clone())
-              val handlerMethodSig   = new MethodDeclaration(new NodeList(), futureResponseType, methodName)
-              (
-                (parameters.pathParams ++ parameters.headerParams ++ parameters.queryStringParams ++ parameters.formParams).map({ param =>
+                transformedAnnotatedParams <- (
+                  parameters.pathParams ++
+                      parameters.headerParams ++
+                      parameters.queryStringParams ++
+                      parameters.formParams
+                ).traverse({ param =>
                   val parameter                  = param.param.clone()
                   val optionalCollectionStripped = stripOptionalFromCollections(parameter, param)
                   transformMultipartFile(optionalCollectionStripped, param)
-                }) ++ parameters.bodyParams.map(param => stripOptionalFromCollections(param.param.clone(), param))
-              ).foreach(handlerMethodSig.addParameter)
-              handlerMethodSig.setBody(null)
+                })
+                transformedBodyParams = parameters.bodyParams.map(param => stripOptionalFromCollections(param.param.clone(), param))
+              } yield {
+                val futureResponseType = completionStageType(responseType.clone())
+                val handlerMethodSig   = new MethodDeclaration(new NodeList(), futureResponseType, methodName)
+                (transformedAnnotatedParams ++ transformedBodyParams).foreach(handlerMethodSig.addParameter)
+                handlerMethodSig.setBody(null)
 
-              (method, handlerMethodSig)
+                (method, handlerMethodSig)
+              }
           })
-          .unzip
-
+          .map(_.unzip)
+        (routeMethods, handlerMethodSigs) = routeMethodsAndHandlerMethodSigs
+      } yield {
         val resourceConstructor = new ConstructorDeclaration(new NodeList(publicModifier), resourceName)
         resourceConstructor.addAnnotation(new MarkerAnnotationExpr(new Name("Inject")))
         resourceConstructor.addParameter(new Parameter(new NodeList(finalModifier), handlerType, new SimpleName("handler")))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
@@ -1,11 +1,11 @@
 package com.twilio.guardrail.generators.Java
 
 import _root_.io.swagger.v3.oas.models.media.{ Discriminator => _, _ }
-import cats.Monad
+import cats.{ FlatMap, Monad }
 import cats.data.NonEmptyList
 import cats.implicits._
 import com.github.javaparser.StaticJavaParser
-import com.github.javaparser.ast.`type`.{ ClassOrInterfaceType, PrimitiveType, Type, UnknownType }
+import com.github.javaparser.ast.`type`.{ ClassOrInterfaceType, PrimitiveType, Type }
 import com.github.javaparser.ast.Modifier.Keyword.{ FINAL, PRIVATE, PROTECTED, PUBLIC }
 import com.github.javaparser.ast.Modifier._
 import com.github.javaparser.ast.{ Node, NodeList }
@@ -29,12 +29,14 @@ import com.twilio.guardrail.{
 import com.twilio.guardrail.core.Tracker
 import com.twilio.guardrail.core.implicits._
 import com.twilio.guardrail.extract.{ DataRedaction, EmptyValueIsNull }
+import com.twilio.guardrail.generators.Java.collectionslib.CollectionsLibType
 import com.twilio.guardrail.generators.{ JavaGenerator, RawParameterName, RawParameterType }
 import com.twilio.guardrail.generators.helpers.JacksonHelpers
 import com.twilio.guardrail.generators.syntax.Java._
 import com.twilio.guardrail.languages.JavaLanguage
 import com.twilio.guardrail.protocol.terms.protocol._
 import com.twilio.guardrail.terms.CollectionsLibTerms
+
 import scala.collection.JavaConverters._
 
 object JacksonGenerator {
@@ -54,7 +56,7 @@ object JacksonGenerator {
 
   // returns a tuple of (requiredTerms, optionalTerms)
   // note that required terms _that have a default value_ are conceptually optional.
-  private def sortParams(params: List[ProtocolParameter[JavaLanguage]]): (List[ParameterTerm], List[ParameterTerm]) = {
+  private def sortParams(params: List[ProtocolParameter[JavaLanguage]])(implicit Cl: CollectionsLibType): (List[ParameterTerm], List[ParameterTerm]) = {
     def defaultValueToExpression(defaultValue: Option[Node]): Option[Expression] = defaultValue match {
       case Some(expr: Expression) => Some(expr)
       case _                      => None
@@ -62,7 +64,7 @@ object JacksonGenerator {
 
     params
       .map({ param =>
-        val parameterType = if (param.term.getType.isOptional) {
+        val parameterType = if (Cl.isOptionalType(param.term.getType)) {
           param.term.getType.containedType.unbox
         } else {
           param.term.getType.unbox
@@ -72,7 +74,7 @@ object JacksonGenerator {
         ParameterTerm(param.name.value, param.term.getNameAsString, param.term.getType.unbox, parameterType, param.rawType, defaultValue, param.dataRedaction)
       })
       .partition(
-        pt => !pt.fieldType.isOptional && pt.defaultValue.isEmpty
+        pt => !Cl.isOptionalType(pt.fieldType) && pt.defaultValue.isEmpty
       )
   }
 
@@ -85,11 +87,10 @@ object JacksonGenerator {
         .setImplementedTypes(otherParents.toNodeList)
     })
 
-  private def lookupTypeName(tpeName: String, concreteTypes: List[PropMeta[JavaLanguage]])(f: Type => Target[Type]): Option[Target[Type]] =
+  private def lookupTypeName(tpeName: String, concreteTypes: List[PropMeta[JavaLanguage]]): Option[Type] =
     concreteTypes
       .find(_.clsName == tpeName)
       .map(_.tpe)
-      .map(f)
 
   // TODO: handle emptyToNull in the return for the getters
   private def addParameterGetter(cls: ClassOrInterfaceDeclaration, param: ParameterTerm): Unit = {
@@ -105,8 +106,13 @@ object JacksonGenerator {
       )
   }
 
-  private def dtoConstructorBody(superCall: Expression, terms: List[ParameterTerm]): BlockStmt =
-    new BlockStmt(
+  private def dtoConstructorBody(
+      superCall: Expression,
+      terms: List[ParameterTerm]
+  )(implicit Cl: CollectionsLibTerms[JavaLanguage, Target] with CollectionsLibType, fm: FlatMap[Target]): Target[BlockStmt] =
+    for {
+      emptyOptional <- Cl.emptyOptionalTerm().flatMap(_.toExpression)
+    } yield new BlockStmt(
       (
         List[Statement](new ExpressionStmt(superCall)) ++
             terms
@@ -117,10 +123,10 @@ object JacksonGenerator {
                       new FieldAccessExpr(new ThisExpr, term.parameterName),
                       term.fieldType match {
                         case _: PrimitiveType => new NameExpr(term.parameterName)
-                        case ft if ft.isOptional =>
+                        case ft if Cl.isOptionalType(ft) =>
                           new ConditionalExpr(
                             new BinaryExpr(new NameExpr(term.parameterName), new NullLiteralExpr, BinaryExpr.Operator.EQUALS),
-                            new MethodCallExpr(new NameExpr("Optional"), "empty"),
+                            emptyOptional,
                             new NameExpr(term.parameterName)
                           )
                         case _ => requireNonNullExpr(term.parameterName)
@@ -320,7 +326,9 @@ object JacksonGenerator {
       Target.pure(new Name(s"${clsName}.${termName}"))
   }
 
-  class ModelProtocolTermInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target]) extends ModelProtocolTerms[JavaLanguage, Target] {
+  class ModelProtocolTermInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target] with CollectionsLibType)
+      extends ModelProtocolTerms[JavaLanguage, Target] {
+
     implicit def MonadF: Monad[Target] = Target.targetInstances
 
     def renderDTOClass(
@@ -330,6 +338,22 @@ object JacksonGenerator {
         parents: List[SuperClass[JavaLanguage]]
     ): Target[TypeDeclaration[_ <: TypeDeclaration[_]]] = {
       val parentsWithDiscriminators = parents.collect({ case p if p.discriminators.nonEmpty => p })
+      val discriminators            = parents.flatMap(_.discriminators)
+      val discriminatorNames        = discriminators.map(_.propertyName).toSet
+
+      def withoutDiscriminators(terms: List[ParameterTerm]): List[ParameterTerm] =
+        terms.filterNot(term => discriminatorNames.contains(term.propertyName))
+
+      def parameterGetterCall(term: ParameterTerm, scope: Option[String] = None): MethodCallExpr = {
+        val methodName = s"get${term.parameterName.unescapeIdentifier.capitalize}"
+        scope.fold(new MethodCallExpr(methodName))(s => new MethodCallExpr(new NameExpr(s), methodName))
+      }
+
+      def parameterToStringExpr(term: ParameterTerm, scope: Option[String] = None): Expression = term.dataRedacted match {
+        case DataVisible  => parameterGetterCall(term, scope)
+        case DataRedacted => new StringLiteralExpr("[redacted]")
+      }
+
       for {
         dtoClassType <- safeParseClassOrInterfaceType(clsName)
         parentOpt <- (parentsWithDiscriminators, parents) match {
@@ -342,10 +366,8 @@ object JacksonGenerator {
           case _                                          => Target.pure(None)
         }
 
-        discriminators                             = parents.flatMap(_.discriminators)
-        discriminatorNames                         = discriminators.map(_.propertyName).toSet
         parentParams                               = parentOpt.toList.flatMap(_.params)
-        parentParamNames                           = parentParams.map(_.name)
+        parentParamNames                           = parentParams.map(_.name.value)
         (parentRequiredTerms, parentOptionalTerms) = sortParams(parentParams)
         parentTerms                                = parentRequiredTerms ++ parentOptionalTerms
 
@@ -387,68 +409,56 @@ object JacksonGenerator {
                 .map((term.propertyName, _))
           })
           .map(_.toMap)
-      } yield {
-        val params = parents.filterNot(parent => parentOpt.contains(parent)).flatMap(_.params) ++ selfParams.filterNot(
-                param =>
-                  discriminatorNames.contains(param.term.getName.getIdentifier) || parentParamNames.map(_.value).contains(param.term.getName.getIdentifier)
-              )
-        val (requiredTerms, optionalTerms) = sortParams(params)
-        val terms                          = requiredTerms ++ optionalTerms
 
-        val dtoClass = new ClassOrInterfaceDeclaration(new NodeList(publicModifier), false, clsName)
-        dtoClass.addAnnotation(
-          new NormalAnnotationExpr(
-            new Name("JsonIgnoreProperties"),
-            new NodeList(
-              new MemberValuePair(
-                "ignoreUnknown",
-                new BooleanLiteralExpr(true)
+        params = parents.filterNot(parent => parentOpt.contains(parent)).flatMap(_.params) ++ selfParams.filterNot(
+              param => discriminatorNames.contains(param.term.getName.getIdentifier) || parentParamNames.contains(param.term.getName.getIdentifier)
+            )
+        (requiredTerms, optionalTerms) = sortParams(params)
+        terms                          = requiredTerms ++ optionalTerms
+
+        dtoClass = new ClassOrInterfaceDeclaration(new NodeList(publicModifier), false, clsName)
+          .addAnnotation(
+            new NormalAnnotationExpr(
+              new Name("JsonIgnoreProperties"),
+              new NodeList(
+                new MemberValuePair(
+                  "ignoreUnknown",
+                  new BooleanLiteralExpr(true)
+                )
               )
             )
           )
-        )
 
-        addParents(dtoClass, parentOpt)
+        _ = addParents(dtoClass, parentOpt)
 
-        def withoutDiscriminators(terms: List[ParameterTerm]): List[ParameterTerm] =
-          terms.filterNot(term => discriminatorNames.contains(term.propertyName))
-
-        terms.foreach({
+        _ = terms.foreach({
           case ParameterTerm(propertyName, parameterName, fieldType, _, _, _, _) =>
             val field: FieldDeclaration = dtoClass.addField(fieldType, parameterName, PRIVATE, FINAL)
             field.addSingleMemberAnnotation("JsonProperty", new StringLiteralExpr(propertyName))
         })
 
-        val primaryConstructor = dtoClass.addConstructor(PROTECTED)
-        primaryConstructor.addMarkerAnnotation("JsonCreator")
-        primaryConstructor.setParameters(
-          new NodeList(
-            withoutDiscriminators(parentTerms ++ terms).map({
-              case ParameterTerm(propertyName, parameterName, fieldType, _, _, _, _) =>
-                new Parameter(new NodeList(finalModifier), fieldType, new SimpleName(parameterName))
-                  .addAnnotation(new SingleMemberAnnotationExpr(new Name("JsonProperty"), new StringLiteralExpr(propertyName)))
-            }): _*
+        primaryConstructor = dtoClass
+          .addConstructor(PROTECTED)
+          .addMarkerAnnotation("JsonCreator")
+          .setParameters(
+            new NodeList(
+              withoutDiscriminators(parentTerms ++ terms).map({
+                case ParameterTerm(propertyName, parameterName, fieldType, _, _, _, _) =>
+                  new Parameter(new NodeList(finalModifier), fieldType, new SimpleName(parameterName))
+                    .addAnnotation(new SingleMemberAnnotationExpr(new Name("JsonProperty"), new StringLiteralExpr(propertyName)))
+              }): _*
+            )
           )
-        )
-        val superCall = new MethodCallExpr(
+        superCall = new MethodCallExpr(
           "super",
           parentTerms.map(term => discriminatorValues.getOrElse(term.propertyName, new NameExpr(term.parameterName))): _*
         )
-        primaryConstructor.setBody(dtoConstructorBody(superCall, terms))
+        primaryConstructorBody <- dtoConstructorBody(superCall, terms)
+        _ = primaryConstructor.setBody(primaryConstructorBody)
 
-        terms.foreach(addParameterGetter(dtoClass, _))
+        _ = terms.foreach(addParameterGetter(dtoClass, _))
 
-        def parameterGetterCall(term: ParameterTerm, scope: Option[String] = None): MethodCallExpr = {
-          val methodName = s"get${term.parameterName.unescapeIdentifier.capitalize}"
-          scope.fold(new MethodCallExpr(methodName))(s => new MethodCallExpr(new NameExpr(s), methodName))
-        }
-
-        def parameterToStringExpr(term: ParameterTerm, scope: Option[String] = None): Expression = term.dataRedacted match {
-          case DataVisible  => parameterGetterCall(term, scope)
-          case DataRedacted => new StringLiteralExpr("[redacted]")
-        }
-
-        val toStringFieldExprs = NonEmptyList
+        toStringFieldExprs = NonEmptyList
           .fromList(parentTerms ++ terms)
           .toList
           .flatMap(
@@ -463,32 +473,32 @@ object JacksonGenerator {
                   )
           )
 
-        val toStringMethod = dtoClass
+        _ = dtoClass
           .addMethod("toString", PUBLIC)
           .setType(STRING_TYPE)
           .addMarkerAnnotation("Override")
-        toStringMethod.setBody(
-          new BlockStmt(
-            new NodeList(
-              new ReturnStmt(
-                new BinaryExpr(
-                  toStringFieldExprs.foldLeft[Expression](new StringLiteralExpr(s"${clsName}{"))({
-                    case (prevExpr, (strExpr, fieldExpr)) =>
-                      new BinaryExpr(
-                        new BinaryExpr(prevExpr, strExpr, BinaryExpr.Operator.PLUS),
-                        fieldExpr,
-                        BinaryExpr.Operator.PLUS
-                      )
-                  }),
-                  new StringLiteralExpr("}"),
-                  BinaryExpr.Operator.PLUS
+          .setBody(
+            new BlockStmt(
+              new NodeList(
+                new ReturnStmt(
+                  new BinaryExpr(
+                    toStringFieldExprs.foldLeft[Expression](new StringLiteralExpr(s"${clsName}{"))({
+                      case (prevExpr, (strExpr, fieldExpr)) =>
+                        new BinaryExpr(
+                          new BinaryExpr(prevExpr, strExpr, BinaryExpr.Operator.PLUS),
+                          fieldExpr,
+                          BinaryExpr.Operator.PLUS
+                        )
+                    }),
+                    new StringLiteralExpr("}"),
+                    BinaryExpr.Operator.PLUS
+                  )
                 )
               )
             )
           )
-        )
 
-        val equalsConditions: List[Expression] = terms.map(
+        equalsConditions: List[Expression] = terms.map(
           term =>
             term.fieldType match {
               case _: PrimitiveType =>
@@ -505,7 +515,7 @@ object JacksonGenerator {
                 )
             }
         )
-        val returnExpr = NonEmptyList
+        returnExpr = NonEmptyList
           .fromList(equalsConditions)
           .map(
             _.reduceLeft(
@@ -514,112 +524,115 @@ object JacksonGenerator {
           )
           .getOrElse(new BooleanLiteralExpr(true))
 
-        val equalsMethod = dtoClass
+        _ = dtoClass
           .addMethod("equals", PUBLIC)
           .setType(PrimitiveType.booleanType)
           .addMarkerAnnotation("Override")
           .addParameter(new Parameter(new NodeList(finalModifier), OBJECT_TYPE, new SimpleName("o")))
-        equalsMethod.setBody(
-          new BlockStmt(
-            new NodeList(
-              new IfStmt(
-                new BinaryExpr(new ThisExpr, new NameExpr("o"), BinaryExpr.Operator.EQUALS),
-                new BlockStmt(new NodeList(new ReturnStmt(new BooleanLiteralExpr(true)))),
-                null
-              ),
-              new IfStmt(
-                new BinaryExpr(
-                  new BinaryExpr(new NameExpr("o"), new NullLiteralExpr, BinaryExpr.Operator.EQUALS),
-                  new BinaryExpr(new MethodCallExpr("getClass"), new MethodCallExpr(new NameExpr("o"), "getClass"), BinaryExpr.Operator.NOT_EQUALS),
-                  BinaryExpr.Operator.OR
+          .setBody(
+            new BlockStmt(
+              new NodeList(
+                new IfStmt(
+                  new BinaryExpr(new ThisExpr, new NameExpr("o"), BinaryExpr.Operator.EQUALS),
+                  new BlockStmt(new NodeList(new ReturnStmt(new BooleanLiteralExpr(true)))),
+                  null
                 ),
-                new BlockStmt(new NodeList(new ReturnStmt(new BooleanLiteralExpr(false)))),
-                null
-              ),
-              new ExpressionStmt(
-                new VariableDeclarationExpr(
-                  new VariableDeclarator(
-                    dtoClassType,
-                    "other",
-                    new CastExpr(dtoClassType, new NameExpr("o"))
+                new IfStmt(
+                  new BinaryExpr(
+                    new BinaryExpr(new NameExpr("o"), new NullLiteralExpr, BinaryExpr.Operator.EQUALS),
+                    new BinaryExpr(new MethodCallExpr("getClass"), new MethodCallExpr(new NameExpr("o"), "getClass"), BinaryExpr.Operator.NOT_EQUALS),
+                    BinaryExpr.Operator.OR
                   ),
-                  finalModifier
-                )
-              ),
-              new ReturnStmt(returnExpr)
+                  new BlockStmt(new NodeList(new ReturnStmt(new BooleanLiteralExpr(false)))),
+                  null
+                ),
+                new ExpressionStmt(
+                  new VariableDeclarationExpr(
+                    new VariableDeclarator(
+                      dtoClassType,
+                      "other",
+                      new CastExpr(dtoClassType, new NameExpr("o"))
+                    ),
+                    finalModifier
+                  )
+                ),
+                new ReturnStmt(returnExpr)
+              )
             )
           )
-        )
 
-        val hashCodeMethod = dtoClass
+        _ = dtoClass
           .addMethod("hashCode", PUBLIC)
           .setType(PrimitiveType.intType)
           .addMarkerAnnotation("Override")
-        hashCodeMethod.setBody(
-          new BlockStmt(
-            new NodeList(
-              new ReturnStmt(
-                new MethodCallExpr(
-                  new NameExpr("java.util.Objects"),
-                  "hash",
-                  new NodeList[Expression]((parentTerms ++ terms).map(parameterGetterCall(_, None)): _*)
+          .setBody(
+            new BlockStmt(
+              new NodeList(
+                new ReturnStmt(
+                  new MethodCallExpr(
+                    new NameExpr("java.util.Objects"),
+                    "hash",
+                    new NodeList[Expression]((parentTerms ++ terms).map(parameterGetterCall(_, None)): _*)
+                  )
                 )
               )
             )
           )
-        )
 
-        val builderClass = new ClassOrInterfaceDeclaration(new NodeList(publicModifier, staticModifier), false, "Builder")
+        builderClass = new ClassOrInterfaceDeclaration(new NodeList(publicModifier, staticModifier), false, "Builder")
 
-        withoutDiscriminators(parentRequiredTerms ++ requiredTerms).foreach({
+        _ = withoutDiscriminators(parentRequiredTerms ++ requiredTerms).foreach({
           case ParameterTerm(_, parameterName, fieldType, _, _, _, _) =>
             builderClass.addField(fieldType, parameterName, PRIVATE)
         })
-        withoutDiscriminators(parentOptionalTerms ++ optionalTerms).foreach({
+        _ <- withoutDiscriminators(parentOptionalTerms ++ optionalTerms).traverse({
           case ParameterTerm(_, parameterName, fieldType, _, _, defaultValue, _) =>
-            val initializer = defaultValue.fold[Expression](
-              new MethodCallExpr(new NameExpr("Optional"), "empty")
-            )(
-              dv =>
-                if (fieldType.isOptional) {
-                  optionalOfNullableExpr(dv)
-                } else {
-                  dv
-                }
-            )
-            builderClass.addFieldWithInitializer(fieldType, parameterName, initializer, PRIVATE)
+            for {
+              initializer <- defaultValue.fold[Target[Expression]](
+                Cl.emptyOptionalTerm().flatMap(_.toExpression)
+              )(
+                dv =>
+                  if (Cl.isOptionalType(fieldType)) {
+                    Cl.liftOptionalTerm(dv).flatMap(_.toExpression)
+                  } else {
+                    Target.pure(dv)
+                  }
+              )
+              _ = builderClass.addFieldWithInitializer(fieldType, parameterName, initializer, PRIVATE)
+            } yield ()
         })
 
-        val builderConstructor = builderClass.addConstructor(PUBLIC)
-        builderConstructor.setParameters(
-          new NodeList(
-            withoutDiscriminators(parentRequiredTerms ++ requiredTerms).map({
-              case ParameterTerm(_, parameterName, _, parameterType, _, _, _) =>
-                new Parameter(new NodeList(finalModifier), parameterType, new SimpleName(parameterName))
-            }): _*
-          )
-        )
-        builderConstructor.setBody(
-          new BlockStmt(
+        _ = builderClass
+          .addConstructor(PUBLIC)
+          .setParameters(
             new NodeList(
               withoutDiscriminators(parentRequiredTerms ++ requiredTerms).map({
-                case ParameterTerm(_, parameterName, fieldType, _, _, _, _) =>
-                  new ExpressionStmt(
-                    new AssignExpr(
-                      new FieldAccessExpr(new ThisExpr, parameterName),
-                      fieldType match {
-                        case _: PrimitiveType => new NameExpr(parameterName)
-                        case _                => requireNonNullExpr(parameterName)
-                      },
-                      AssignExpr.Operator.ASSIGN
-                    )
-                  )
+                case ParameterTerm(_, parameterName, _, parameterType, _, _, _) =>
+                  new Parameter(new NodeList(finalModifier), parameterType, new SimpleName(parameterName))
               }): _*
             )
           )
-        )
+          .setBody(
+            new BlockStmt(
+              new NodeList(
+                withoutDiscriminators(parentRequiredTerms ++ requiredTerms).map({
+                  case ParameterTerm(_, parameterName, fieldType, _, _, _, _) =>
+                    new ExpressionStmt(
+                      new AssignExpr(
+                        new FieldAccessExpr(new ThisExpr, parameterName),
+                        fieldType match {
+                          case _: PrimitiveType => new NameExpr(parameterName)
+                          case _                => requireNonNullExpr(parameterName)
+                        },
+                        AssignExpr.Operator.ASSIGN
+                      )
+                    )
+                }): _*
+              )
+            )
+          )
 
-        builderClass
+        _ = builderClass
           .addConstructor(PUBLIC)
           .setParameters(new NodeList(new Parameter(new NodeList(finalModifier), dtoClassType, new SimpleName("template"))))
           .setBody(
@@ -640,85 +653,92 @@ object JacksonGenerator {
           )
 
         // TODO: leave out with${name}() if readOnlyKey?
-        withoutDiscriminators(parentTerms ++ terms).foreach({
+        _ <- withoutDiscriminators(parentTerms ++ terms).traverse({
           case ParameterTerm(_, parameterName, fieldType, parameterType, _, _, _) =>
             val methodName = s"with${parameterName.unescapeIdentifier.capitalize}"
-
-            builderClass
-              .addMethod(methodName, PUBLIC)
-              .setType(BUILDER_TYPE)
-              .addParameter(new Parameter(new NodeList(finalModifier), parameterType, new SimpleName(parameterName)))
-              .setBody(
-                new BlockStmt(
-                  new NodeList(
-                    new ExpressionStmt(
-                      new AssignExpr(
-                        new FieldAccessExpr(new ThisExpr, parameterName),
-                        (fieldType, parameterType) match {
-                          case (_: PrimitiveType, _) => new NameExpr(parameterName)
-                          case (ft, pt) if ft.isOptional && pt.isPrimitiveType =>
-                            new MethodCallExpr(new NameExpr("Optional"), "of", new NodeList[Expression](new NameExpr(parameterName)))
-                          case (ft, _) if ft.isOptional => optionalOfNullableExpr(new NameExpr(parameterName))
-                          case _                        => requireNonNullExpr(parameterName)
-                        },
-                        AssignExpr.Operator.ASSIGN
-                      )
-                    ),
-                    new ReturnStmt(new ThisExpr)
-                  )
-                )
-              )
-
-            if (!parameterType.isOptional) {
-              val newParameterName = s"optional${parameterName.unescapeIdentifier.capitalize}"
-              val newParameterType = fieldType match {
-                case pt: PrimitiveType   => optionalType(pt.toBoxedType)
-                case ft if ft.isOptional => ft
-                case ft                  => optionalType(ft)
+            for {
+              fieldInitializer <- (fieldType, parameterType) match {
+                case (_: PrimitiveType, _) =>
+                  Target.pure[Expression](new NameExpr(parameterName))
+                case (ft, pt) if Cl.isOptionalType(ft) && pt.isPrimitiveType =>
+                  Cl.liftSomeTerm(new NameExpr(parameterName)).flatMap(_.toExpression)
+                case (ft, _) if Cl.isOptionalType(ft) =>
+                  Cl.liftOptionalTerm(new NameExpr(parameterName)).flatMap(_.toExpression)
+                case _ =>
+                  Target.pure(requireNonNullExpr(parameterName))
               }
-              builderClass
+
+              _ = builderClass
                 .addMethod(methodName, PUBLIC)
                 .setType(BUILDER_TYPE)
-                .addParameter(new Parameter(new NodeList(finalModifier), newParameterType, new SimpleName(newParameterName)))
+                .addParameter(new Parameter(new NodeList(finalModifier), parameterType, new SimpleName(parameterName)))
                 .setBody(
                   new BlockStmt(
                     new NodeList(
                       new ExpressionStmt(
-                        if (fieldType.isOptional) {
-                          new AssignExpr(
-                            new FieldAccessExpr(new ThisExpr, parameterName),
-                            requireNonNullExpr(newParameterName),
-                            AssignExpr.Operator.ASSIGN
-                          )
-                        } else {
-                          new MethodCallExpr(
-                            requireNonNullExpr(newParameterName),
-                            "ifPresent",
-                            new NodeList[Expression](
-                              new LambdaExpr(
-                                new NodeList(new Parameter(new UnknownType, parameterName)),
-                                new ExpressionStmt(
-                                  new AssignExpr(
-                                    new FieldAccessExpr(new ThisExpr, parameterName),
-                                    new NameExpr(parameterName),
-                                    AssignExpr.Operator.ASSIGN
-                                  )
-                                ),
-                                false
-                              )
-                            )
-                          )
-                        }
+                        new AssignExpr(
+                          new FieldAccessExpr(new ThisExpr, parameterName),
+                          fieldInitializer,
+                          AssignExpr.Operator.ASSIGN
+                        )
                       ),
                       new ReturnStmt(new ThisExpr)
                     )
                   )
                 )
-            }
+
+              _ = if (!Cl.isOptionalType(parameterType)) {
+                val newParameterName = s"optional${parameterName.unescapeIdentifier.capitalize}"
+                for {
+                  newParameterType <- (fieldType match {
+                    case pt: PrimitiveType           => Cl.liftOptionalType(pt.toBoxedType)
+                    case ft if Cl.isOptionalType(ft) => Target.pure(ft)
+                    case ft                          => Cl.liftOptionalType(ft)
+                  })
+                } yield {
+                  builderClass
+                    .addMethod(methodName, PUBLIC)
+                    .setType(BUILDER_TYPE)
+                    .addParameter(new Parameter(new NodeList(finalModifier), newParameterType, new SimpleName(newParameterName)))
+                    .setBody(
+                      new BlockStmt(
+                        new NodeList(
+                          new ExpressionStmt(
+                            if (Cl.isOptionalType(fieldType)) {
+                              new AssignExpr(
+                                new FieldAccessExpr(new ThisExpr, parameterName),
+                                requireNonNullExpr(newParameterName),
+                                AssignExpr.Operator.ASSIGN
+                              )
+                            } else {
+                              Cl.optionalSideEffect(
+                                requireNonNullExpr(newParameterName),
+                                parameterName,
+                                List(
+                                  new ExpressionStmt(
+                                    new AssignExpr(
+                                      new FieldAccessExpr(new ThisExpr, parameterName),
+                                      new NameExpr(parameterName),
+                                      AssignExpr.Operator.ASSIGN
+                                    )
+                                  )
+                                )
+                              )
+                            }
+                          ),
+                          new ReturnStmt(new ThisExpr)
+                        )
+                      )
+                    )
+                }
+              } else {
+                ()
+              }
+            } yield ()
         })
 
-        val builderBuildTerms = withoutDiscriminators(parentTerms ++ terms)
-        builderClass
+        builderBuildTerms = withoutDiscriminators(parentTerms ++ terms)
+        _ = builderClass
           .addMethod("build", PUBLIC)
           .setType(clsName)
           .setBody(
@@ -739,10 +759,9 @@ object JacksonGenerator {
             )
           )
 
-        dtoClass.addMember(builderClass)
+        _ = dtoClass.addMember(builderClass)
 
-        dtoClass
-      }
+      } yield dtoClass
     }
 
     def extractProperties(swagger: Tracker[Schema[_]]) =
@@ -798,23 +817,17 @@ object JacksonGenerator {
               }
               tpe.map((_, Option.empty))
             case SwaggerUtil.DeferredArray(tpeName, containerTpe) =>
+              val concreteType = lookupTypeName(tpeName, concreteTypes)
               for {
-                fqListType <- containerTpe.fold(safeParseClassOrInterfaceType("java.util.List")) {
-                  case ci: ClassOrInterfaceType => Target.pure(ci)
-                  case t                        => Target.raiseUserError(s"Supplied type was not supported: ${t}")
-                }
-                concreteType = lookupTypeName(tpeName, concreteTypes)(Target.pure)
-                innerType <- concreteType.getOrElse(safeParseType(tpeName))
-              } yield (fqListType.setTypeArguments(innerType), Option.empty)
+                innerType <- concreteType.fold(safeParseType(tpeName))(Target.pure)
+                tpe       <- Cl.liftVectorType(innerType, containerTpe)
+              } yield (tpe, Option.empty)
             case SwaggerUtil.DeferredMap(tpeName, containerTpe) =>
+              val concreteType = lookupTypeName(tpeName, concreteTypes)
               for {
-                fqMapType <- containerTpe.fold(safeParseClassOrInterfaceType("java.util.Map")) {
-                  case ci: ClassOrInterfaceType => Target.pure(ci)
-                  case t                        => Target.raiseUserError(s"Supplied type was not supported: ${t}")
-                }
-                concreteType = lookupTypeName(tpeName, concreteTypes)(Target.pure)
-                innerType <- concreteType.getOrElse(safeParseType(tpeName))
-              } yield (fqMapType.setTypeArguments(STRING_TYPE, innerType), Option.empty)
+                innerType <- concreteType.fold(safeParseType(tpeName))(Target.pure)
+                tpe       <- Cl.liftMapType(innerType, containerTpe)
+              } yield (tpe, Option.empty)
           }
           (tpe, classDep) = tpeClassDep
 
@@ -826,24 +839,18 @@ object JacksonGenerator {
               Target.log.warning(s"Can't generate default value for class $clsName and property $name.") >> Target.pure(None)
             case None => Target.pure(None)
           }
-          (finalDeclType, finalDefaultValue) <- Option(requirement)
+          finalDefaultTypeValue <- Option(requirement)
             .filter {
               case PropertyRequirement.Required => true
               case _                            => false
             }
             .fold[Target[(Type, Option[Expression])]](
-              (
-                safeParseType(s"Optional<${tpe}>"),
-                Target.pure(
-                  Option(
-                    expressionDefaultValue
-                      .fold(
-                        new MethodCallExpr(new NameExpr(s"Optional"), "empty"): Expression
-                      )(t => optionalOfExpr(t))
-                  )
-                )
-              ).mapN((_, _))
+              for {
+                optionalTpe      <- Cl.liftOptionalType(tpe)
+                defaultValueExpr <- defaultValue.fold(Target.pure(Option.empty[Expression]))(dv => dv.toExpression.map(Option.apply))
+              } yield (optionalTpe, defaultValueExpr)
             )(Function.const(Target.pure((tpe, expressionDefaultValue))) _)
+          (finalDeclType, finalDefaultValue) = finalDefaultTypeValue
           term <- safeParseParameter(s"final ${finalDeclType} $fieldName")
           dep = classDep.filterNot(_.asString == clsName) // Filter out our own class name
         } yield ProtocolParameter[JavaLanguage](
@@ -856,7 +863,7 @@ object JacksonGenerator {
           emptyToNull,
           dataRedaction,
           requirement,
-          defaultValue
+          finalDefaultValue
         )
       }
 
@@ -896,30 +903,14 @@ object JacksonGenerator {
         result <- arr match {
           case SwaggerUtil.Resolved(tpe, dep, default, _, _) => Target.pure(tpe)
           case SwaggerUtil.Deferred(tpeName) =>
-            Target.fromOption(lookupTypeName(tpeName, concreteTypes)(Target.pure(_)), UserError(s"Unresolved reference ${tpeName}")).flatten
+            Target.fromOption(lookupTypeName(tpeName, concreteTypes), UserError(s"Unresolved reference ${tpeName}"))
           case SwaggerUtil.DeferredArray(tpeName, containerTpe) =>
-            for {
-              tpe <- containerTpe.fold(safeParseClassOrInterfaceType("java.util.List")) {
-                case ci: ClassOrInterfaceType => Target.pure(ci)
-                case t                        => Target.raiseUserError(s"Supplied type was not supported: ${t}")
-              }
-              res <- Target
-                .fromOption(lookupTypeName(tpeName, concreteTypes)(t => Target.pure(tpe.setTypeArguments(t))), UserError(s"Unresolved reference ${tpeName}"))
-                .flatten
-            } yield res
+            lookupTypeName(tpeName, concreteTypes)
+              .fold[Target[Type]](Target.raiseUserError(s"Unresolved reference ${tpeName}"))(Cl.liftVectorType(_, containerTpe))
           case SwaggerUtil.DeferredMap(tpeName, containerTpe) =>
-            for {
-              tpe <- containerTpe.fold(safeParseClassOrInterfaceType("java.util.Map")) {
-                case ci: ClassOrInterfaceType => Target.pure(ci)
-                case t                        => Target.raiseUserError(s"Supplied type was not supported: ${t}")
-              }
-              res <- Target
-                .fromOption(
-                  lookupTypeName(tpeName, concreteTypes)(t => safeParseType("java.util.List<${tpe}<String, ${t}>>")),
-                  UserError(s"Unresolved reference ${tpeName}")
-                )
-                .flatten
-            } yield res
+            lookupTypeName(tpeName, concreteTypes).fold[Target[Type]](
+              Target.raiseUserError(s"Unresolved reference ${tpeName}")
+            )(tpe => Cl.liftMapType(tpe, None).flatMap(mapTpe => Cl.liftVectorType(mapTpe, containerTpe)))
         }
       } yield result
   }
@@ -934,8 +925,7 @@ object JacksonGenerator {
         "com.fasterxml.jackson.annotation.JsonCreator",
         "com.fasterxml.jackson.annotation.JsonIgnoreProperties",
         "com.fasterxml.jackson.annotation.JsonProperty",
-        "com.fasterxml.jackson.annotation.JsonValue",
-        "java.util.Optional"
+        "com.fasterxml.jackson.annotation.JsonValue"
       ).map(safeParseRawImport) ++ List(
             "java.util.Objects.requireNonNull"
           ).map(safeParseRawStaticImport)).sequence
@@ -956,7 +946,7 @@ object JacksonGenerator {
       Target.pure(None)
   }
 
-  class PolyProtocolTermInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target]) extends PolyProtocolTerms[JavaLanguage, Target] {
+  class PolyProtocolTermInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target] with CollectionsLibType) extends PolyProtocolTerms[JavaLanguage, Target] {
     implicit def MonadF: Monad[Target] = Target.targetInstances
 
     def renderSealedTrait(
@@ -977,94 +967,93 @@ object JacksonGenerator {
           case _ if parents.length == 1                   => Target.pure(parents.headOption)
           case _                                          => Target.pure(None)
         }
-      } yield {
-        val parentParams                               = parentOpt.toList.flatMap(_.params)
-        val parentParamNames                           = parentParams.map(_.name)
-        val (parentRequiredTerms, parentOptionalTerms) = sortParams(parentParams)
-        val parentTerms                                = parentRequiredTerms ++ parentOptionalTerms
-        val params = parents.filterNot(parent => parentOpt.contains(parent)).flatMap(_.params) ++ selfParams.filterNot(
-                param => parentParamNames.contains(param.term.getName.getIdentifier)
-              )
-        val (requiredTerms, optionalTerms) = sortParams(params)
-        val terms                          = requiredTerms ++ optionalTerms
 
-        val abstractClass = new ClassOrInterfaceDeclaration(new NodeList(publicModifier, abstractModifier), false, className)
-        abstractClass.addAnnotation(
-          new NormalAnnotationExpr(
-            new Name("JsonIgnoreProperties"),
-            new NodeList(
-              new MemberValuePair(
-                "ignoreUnknown",
-                new BooleanLiteralExpr(true)
+        parentParams                               = parentOpt.toList.flatMap(_.params)
+        parentParamNames                           = parentParams.map(_.name.value)
+        (parentRequiredTerms, parentOptionalTerms) = sortParams(parentParams)
+        parentTerms                                = parentRequiredTerms ++ parentOptionalTerms
+        params = parents.filterNot(parent => parentOpt.contains(parent)).flatMap(_.params) ++ selfParams.filterNot(
+              param => parentParamNames.contains(param.term.getName.getIdentifier)
+            )
+        (requiredTerms, optionalTerms) = sortParams(params)
+        terms                          = requiredTerms ++ optionalTerms
+
+        abstractClass = new ClassOrInterfaceDeclaration(new NodeList(publicModifier, abstractModifier), false, className)
+          .addAnnotation(
+            new NormalAnnotationExpr(
+              new Name("JsonIgnoreProperties"),
+              new NodeList(
+                new MemberValuePair(
+                  "ignoreUnknown",
+                  new BooleanLiteralExpr(true)
+                )
               )
             )
           )
-        )
-        abstractClass.addAnnotation(
-          new NormalAnnotationExpr(
-            new Name("JsonTypeInfo"),
-            new NodeList(
-              new MemberValuePair(
-                "use",
-                new FieldAccessExpr(new NameExpr("JsonTypeInfo.Id"), "NAME")
-              ),
-              new MemberValuePair(
-                "include",
-                new FieldAccessExpr(new NameExpr("JsonTypeInfo.As"), "PROPERTY")
-              ),
-              new MemberValuePair(
-                "property",
-                new StringLiteralExpr(discriminator.propertyName)
+          .addAnnotation(
+            new NormalAnnotationExpr(
+              new Name("JsonTypeInfo"),
+              new NodeList(
+                new MemberValuePair(
+                  "use",
+                  new FieldAccessExpr(new NameExpr("JsonTypeInfo.Id"), "NAME")
+                ),
+                new MemberValuePair(
+                  "include",
+                  new FieldAccessExpr(new NameExpr("JsonTypeInfo.As"), "PROPERTY")
+                ),
+                new MemberValuePair(
+                  "property",
+                  new StringLiteralExpr(discriminator.propertyName)
+                )
               )
             )
           )
-        )
-        abstractClass.addSingleMemberAnnotation(
-          "JsonSubTypes",
-          new ArrayInitializerExpr(
-            new NodeList(
-              children.map(
-                child =>
-                  new NormalAnnotationExpr(
-                    new Name("JsonSubTypes.Type"),
-                    new NodeList(
-                      new MemberValuePair(
-                        "name",
-                        new StringLiteralExpr(
-                          discriminator.mapping
-                            .collectFirst({ case (value, elem) if elem.name == child => value })
-                            .getOrElse(child)
-                        )
-                      ),
-                      new MemberValuePair("value", new ClassExpr(StaticJavaParser.parseType(child)))
+          .addSingleMemberAnnotation(
+            "JsonSubTypes",
+            new ArrayInitializerExpr(
+              new NodeList(
+                children.map(
+                  child =>
+                    new NormalAnnotationExpr(
+                      new Name("JsonSubTypes.Type"),
+                      new NodeList(
+                        new MemberValuePair(
+                          "name",
+                          new StringLiteralExpr(
+                            discriminator.mapping
+                              .collectFirst({ case (value, elem) if elem.name == child => value })
+                              .getOrElse(child)
+                          )
+                        ),
+                        new MemberValuePair("value", new ClassExpr(StaticJavaParser.parseType(child)))
+                      )
                     )
-                  )
-              ): _*
+                ): _*
+              )
             )
           )
-        )
 
-        addParents(abstractClass, parentOpt)
+        _ = addParents(abstractClass, parentOpt)
 
-        terms.foreach({ term =>
+        _ = terms.foreach({ term =>
           val field = abstractClass.addField(term.fieldType, term.parameterName, PRIVATE, FINAL)
           field.addAnnotation(new SingleMemberAnnotationExpr(new Name("JsonProperty"), new StringLiteralExpr(term.propertyName)))
         })
 
-        val superCall = new MethodCallExpr("super", parentTerms.map(term => new NameExpr(term.parameterName)): _*)
-        abstractClass
+        superCall = new MethodCallExpr("super", parentTerms.map(term => new NameExpr(term.parameterName)): _*)
+        constructorBody <- dtoConstructorBody(superCall, requiredTerms ++ optionalTerms)
+        _ = abstractClass
           .addConstructor(PROTECTED)
           .setParameters(
             (parentTerms ++ terms)
               .map(term => new Parameter(new NodeList(finalModifier), term.fieldType, new SimpleName(term.parameterName)))
               .toNodeList
           )
-          .setBody(dtoConstructorBody(superCall, requiredTerms ++ optionalTerms))
+          .setBody(constructorBody)
 
-        terms.foreach(addParameterGetter(abstractClass, _))
-
-        abstractClass
-      }
+        _ = terms.foreach(addParameterGetter(abstractClass, _))
+      } yield abstractClass
     }
 
     def extractSuperClass(

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvc.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvc.scala
@@ -1,20 +1,14 @@
 package com.twilio.guardrail.generators.Java
 
-import com.twilio.guardrail.generators.Framework
+import com.twilio.guardrail.Target
+import com.twilio.guardrail.generators.Java.JacksonGenerator._
 import com.twilio.guardrail.generators.Java.SpringMvcClientGenerator.ClientTermInterp
 import com.twilio.guardrail.generators.Java.SpringMvcGenerator.{ FrameworkInterp => FrameworkTermInterp }
 import com.twilio.guardrail.generators.Java.SpringMvcServerGenerator.ServerTermInterp
-import com.twilio.guardrail.generators.Java.JacksonGenerator.{
-  ArrayProtocolTermInterp,
-  EnumProtocolTermInterp,
-  ModelProtocolTermInterp,
-  PolyProtocolTermInterp,
-  ProtocolSupportTermInterp
-}
 import com.twilio.guardrail.generators.JavaGenerator.JavaInterp
-import com.twilio.guardrail.generators.SwaggerGenerator
+import com.twilio.guardrail.generators.{ Framework, SwaggerGenerator }
+import com.twilio.guardrail.generators.collections.JavaCollectionsGenerator.JavaCollectionsInterp
 import com.twilio.guardrail.languages.JavaLanguage
-import com.twilio.guardrail.Target
 
 object SpringMvc extends Framework[JavaLanguage, Target] {
   implicit def ArrayProtocolInterp   = ArrayProtocolTermInterp
@@ -27,4 +21,5 @@ object SpringMvc extends Framework[JavaLanguage, Target] {
   implicit def ServerInterp          = ServerTermInterp
   implicit def SwaggerInterp         = SwaggerGenerator[JavaLanguage]
   implicit def LanguageInterp        = JavaInterp
+  implicit def CollectionsLibInterp  = JavaCollectionsInterp
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvc.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvc.scala
@@ -6,20 +6,20 @@ import com.twilio.guardrail.generators.Java.SpringMvcClientGenerator.ClientTermI
 import com.twilio.guardrail.generators.Java.SpringMvcGenerator.{ FrameworkInterp => FrameworkTermInterp }
 import com.twilio.guardrail.generators.Java.SpringMvcServerGenerator.ServerTermInterp
 import com.twilio.guardrail.generators.JavaGenerator.JavaInterp
-import com.twilio.guardrail.generators.{ Framework, SwaggerGenerator }
 import com.twilio.guardrail.generators.collections.JavaCollectionsGenerator.JavaCollectionsInterp
+import com.twilio.guardrail.generators.{ Framework, SwaggerGenerator }
 import com.twilio.guardrail.languages.JavaLanguage
 
 object SpringMvc extends Framework[JavaLanguage, Target] {
-  implicit def ArrayProtocolInterp   = ArrayProtocolTermInterp
-  implicit def ClientInterp          = ClientTermInterp
-  implicit def EnumProtocolInterp    = EnumProtocolTermInterp
-  implicit def FrameworkInterp       = FrameworkTermInterp
-  implicit def ModelProtocolInterp   = ModelProtocolTermInterp
-  implicit def PolyProtocolInterp    = PolyProtocolTermInterp
-  implicit def ProtocolSupportInterp = ProtocolSupportTermInterp
-  implicit def ServerInterp          = ServerTermInterp
+  implicit def CollectionsLibInterp  = JavaCollectionsInterp
+  implicit def ArrayProtocolInterp   = new ArrayProtocolTermInterp
+  implicit def ClientInterp          = new ClientTermInterp
+  implicit def EnumProtocolInterp    = new EnumProtocolTermInterp
+  implicit def FrameworkInterp       = new FrameworkTermInterp
+  implicit def ModelProtocolInterp   = new ModelProtocolTermInterp
+  implicit def PolyProtocolInterp    = new PolyProtocolTermInterp
+  implicit def ProtocolSupportInterp = new ProtocolSupportTermInterp
+  implicit def ServerInterp          = new ServerTermInterp
   implicit def SwaggerInterp         = SwaggerGenerator[JavaLanguage]
   implicit def LanguageInterp        = JavaInterp
-  implicit def CollectionsLibInterp  = JavaCollectionsInterp
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvc.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvc.scala
@@ -5,13 +5,14 @@ import com.twilio.guardrail.generators.Java.JacksonGenerator._
 import com.twilio.guardrail.generators.Java.SpringMvcClientGenerator.ClientTermInterp
 import com.twilio.guardrail.generators.Java.SpringMvcGenerator.{ FrameworkInterp => FrameworkTermInterp }
 import com.twilio.guardrail.generators.Java.SpringMvcServerGenerator.ServerTermInterp
+import com.twilio.guardrail.generators.Java.collectionslib.JavaStdLibCollections
 import com.twilio.guardrail.generators.JavaGenerator.JavaInterp
 import com.twilio.guardrail.generators.collections.JavaCollectionsGenerator.JavaCollectionsInterp
 import com.twilio.guardrail.generators.{ Framework, SwaggerGenerator }
 import com.twilio.guardrail.languages.JavaLanguage
 
 object SpringMvc extends Framework[JavaLanguage, Target] {
-  implicit def CollectionsLibInterp  = JavaCollectionsInterp
+  implicit def CollectionsLibInterp  = new JavaCollectionsInterp with JavaStdLibCollections
   implicit def ArrayProtocolInterp   = new ArrayProtocolTermInterp
   implicit def ClientInterp          = new ClientTermInterp
   implicit def EnumProtocolInterp    = new EnumProtocolTermInterp

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvcClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvcClientGenerator.scala
@@ -6,13 +6,13 @@ import com.twilio.guardrail.protocol.terms.client._
 import cats.data.NonEmptyList
 import com.twilio.guardrail.generators.LanguageParameters
 import com.twilio.guardrail.protocol.terms.Responses
-import com.twilio.guardrail.terms.{ RouteMeta, SecurityScheme }
+import com.twilio.guardrail.terms.{ CollectionsLibTerms, RouteMeta, SecurityScheme }
 import com.twilio.guardrail.StrictProtocolElems
 import java.net.URI
 
 object SpringMvcClientGenerator {
 
-  object ClientTermInterp extends ClientTerms[JavaLanguage, Target] {
+  class ClientTermInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target]) extends ClientTerms[JavaLanguage, Target] {
     def MonadF = Target.targetInstances
     def generateClientOperation(
         className: List[String],

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvcGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvcGenerator.scala
@@ -5,10 +5,11 @@ import com.github.javaparser.ast.expr.Name
 import com.twilio.guardrail.Target
 import com.twilio.guardrail.generators.syntax.Java.{ safeParseName, safeParseType }
 import com.twilio.guardrail.languages.JavaLanguage
+import com.twilio.guardrail.terms.CollectionsLibTerms
 import com.twilio.guardrail.terms.framework.FrameworkTerms
 
 object SpringMvcGenerator {
-  object FrameworkInterp extends FrameworkTerms[JavaLanguage, Target] {
+  class FrameworkInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target]) extends FrameworkTerms[JavaLanguage, Target] {
     implicit def MonadF                    = Target.targetInstances
     def fileType(format: Option[String])   = safeParseType(format.getOrElse("MultipartFile"))
     def objectType(format: Option[String]) = safeParseType("com.fasterxml.jackson.databind.JsonNode")

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvcServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvcServerGenerator.scala
@@ -4,40 +4,30 @@ import cats.Monad
 import cats.data.NonEmptyList
 import cats.implicits._
 import com.github.javaparser.StaticJavaParser
-import com.github.javaparser.ast.Modifier._
 import com.github.javaparser.ast.Modifier.Keyword._
-import com.github.javaparser.ast.{ Node, NodeList }
+import com.github.javaparser.ast.Modifier._
 import com.github.javaparser.ast.`type`.{ ClassOrInterfaceType, PrimitiveType, Type }
 import com.github.javaparser.ast.body._
 import com.github.javaparser.ast.expr._
 import com.github.javaparser.ast.stmt._
-import com.twilio.guardrail.{ ADT, ClassDefinition, EnumDefinition, RandomType, RenderedRoutes, StrictProtocolElems, Target }
+import com.github.javaparser.ast.{ Node, NodeList }
 import com.twilio.guardrail.core.Tracker
 import com.twilio.guardrail.extract.ServerRawResponse
-import com.twilio.guardrail.generators.{ LanguageParameter, LanguageParameters }
+import com.twilio.guardrail.generators.Java.collectionslib.CollectionsLibType
 import com.twilio.guardrail.generators.syntax.Java._
+import com.twilio.guardrail.generators.{ LanguageParameter, LanguageParameters }
 import com.twilio.guardrail.languages.JavaLanguage
-import com.twilio.guardrail.protocol.terms.{
-  ApplicationJson,
-  BinaryContent,
-  ContentType,
-  MultipartFormData,
-  OctetStream,
-  Response,
-  Responses,
-  TextContent,
-  TextPlain,
-  UrlencodedFormData
-}
+import com.twilio.guardrail.protocol.terms._
 import com.twilio.guardrail.protocol.terms.server._
 import com.twilio.guardrail.shims.OperationExt
 import com.twilio.guardrail.terms.{ CollectionsLibTerms, RouteMeta, SecurityScheme }
+import com.twilio.guardrail.{ ADT, ClassDefinition, EnumDefinition, RandomType, RenderedRoutes, StrictProtocolElems, Target }
+import io.swagger.v3.oas.models.Operation
 import io.swagger.v3.oas.models.responses.ApiResponse
 import scala.collection.JavaConverters._
 import scala.compat.java8.OptionConverters._
 import scala.language.existentials
 import scala.util.Try
-import _root_.io.swagger.v3.oas.models.Operation
 
 object SpringMvcServerGenerator {
   private implicit class ContentTypeExt(private val ct: ContentType) extends AnyVal {
@@ -275,7 +265,7 @@ object SpringMvcServerGenerator {
     }
   }
 
-  class ServerTermInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target]) extends ServerTerms[JavaLanguage, Target] {
+  class ServerTermInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target] with CollectionsLibType) extends ServerTerms[JavaLanguage, Target] {
     implicit def MonadF: Monad[Target] = Target.targetInstances
     def getExtraImports(tracing: Boolean, supportPackage: List[String]) =
       List(
@@ -380,7 +370,7 @@ object SpringMvcServerGenerator {
               }
 
               def transformJsr310Params(parameter: Parameter): Parameter = {
-                val isOptional = parameter.getType.isOptional
+                val isOptional = Cl.isOptionalType(parameter.getType)
                 val tpe        = if (isOptional) parameter.getType.containedType else parameter.getType
                 def transform(dateTimeFormat: String): Parameter = {
                   parameter.getAnnotations.addLast(

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvcServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvcServerGenerator.scala
@@ -31,7 +31,7 @@ import com.twilio.guardrail.protocol.terms.{
 }
 import com.twilio.guardrail.protocol.terms.server._
 import com.twilio.guardrail.shims.OperationExt
-import com.twilio.guardrail.terms.{ RouteMeta, SecurityScheme }
+import com.twilio.guardrail.terms.{ CollectionsLibTerms, RouteMeta, SecurityScheme }
 import io.swagger.v3.oas.models.responses.ApiResponse
 import scala.collection.JavaConverters._
 import scala.compat.java8.OptionConverters._
@@ -275,7 +275,7 @@ object SpringMvcServerGenerator {
     }
   }
 
-  object ServerTermInterp extends ServerTerms[JavaLanguage, Target] {
+  class ServerTermInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target]) extends ServerTerms[JavaLanguage, Target] {
     implicit def MonadF: Monad[Target] = Target.targetInstances
     def getExtraImports(tracing: Boolean, supportPackage: List[String]) =
       List(

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/collectionslib/CollectionsLibType.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/collectionslib/CollectionsLibType.scala
@@ -11,7 +11,9 @@ import scala.compat.java8.OptionConverters._
 
 sealed trait CollectionsLibType {
   def optionalSideEffect(on: Expression, sideEffectParamName: String, sideEffectBody: List[Statement]): Expression
+  def optionalGetOrElse: String
   def isOptionalType(tpe: Type): Boolean
+  def isArrayType(tpe: Type): Boolean
 }
 
 object CollectionsLibType {
@@ -30,10 +32,10 @@ object CollectionsLibType {
     )
   }
 
-  private[collectionslib] def isOptional(tpe: Type, optionalClsScope: String, optionalClsName: String): Boolean = tpe match {
+  private[collectionslib] def isContainerOfType(tpe: Type, containerClsScope: String, containerClsName: String): Boolean = tpe match {
     case cls: ClassOrInterfaceType =>
       val tpeScope = cls.getScope.asScala
-      cls.getNameAsString == optionalClsName && (tpeScope.isEmpty || tpeScope.map(_.asString).contains(optionalClsScope))
+      cls.getNameAsString == containerClsName && (tpeScope.isEmpty || tpeScope.map(_.asString).contains(containerClsScope))
     case _ => false
   }
 }
@@ -42,5 +44,7 @@ trait JavaStdLibCollections extends CollectionsLibType {
   override def optionalSideEffect(on: Expression, sideEffectParamName: String, sideEffectBody: List[Statement]): Expression =
     CollectionsLibType.lambdaMethodCall(on, sideEffectParamName, sideEffectBody, "ifPresent")
 
-  override def isOptionalType(tpe: Type): Boolean = CollectionsLibType.isOptional(tpe, "java.util", "Optional")
+  override def optionalGetOrElse: String          = "orElseGet"
+  override def isOptionalType(tpe: Type): Boolean = CollectionsLibType.isContainerOfType(tpe, "java.util", "Optional")
+  override def isArrayType(tpe: Type): Boolean    = CollectionsLibType.isContainerOfType(tpe, "java.util", "List")
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/collectionslib/CollectionsLibType.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/collectionslib/CollectionsLibType.scala
@@ -1,0 +1,46 @@
+package com.twilio.guardrail.generators.Java.collectionslib
+
+import com.github.javaparser.ast.NodeList
+import com.github.javaparser.ast.`type`.{ ClassOrInterfaceType, Type, UnknownType }
+import com.github.javaparser.ast.body.Parameter
+import com.github.javaparser.ast.expr.{ Expression, LambdaExpr, MethodCallExpr }
+import com.github.javaparser.ast.stmt.{ BlockStmt, ExpressionStmt, Statement }
+import com.twilio.guardrail.generators.syntax.Java._
+
+import scala.compat.java8.OptionConverters._
+
+sealed trait CollectionsLibType {
+  def optionalSideEffect(on: Expression, sideEffectParamName: String, sideEffectBody: List[Statement]): Expression
+  def isOptionalType(tpe: Type): Boolean
+}
+
+object CollectionsLibType {
+  private[collectionslib] def lambdaMethodCall(on: Expression, sideEffectParamName: String, sideEffectBody: List[Statement], methodName: String): Expression = {
+    val parameter = new Parameter(new UnknownType, sideEffectParamName)
+    new MethodCallExpr(
+      on,
+      methodName,
+      new NodeList[Expression](
+        sideEffectBody match {
+          case (exprStmt: ExpressionStmt) :: Nil => new LambdaExpr(parameter, exprStmt.getExpression)
+          case (blockStmt: BlockStmt) :: Nil     => new LambdaExpr(parameter, blockStmt)
+          case stmts                             => new LambdaExpr(parameter, new BlockStmt(stmts.toNodeList))
+        }
+      )
+    )
+  }
+
+  private[collectionslib] def isOptional(tpe: Type, optionalClsScope: String, optionalClsName: String): Boolean = tpe match {
+    case cls: ClassOrInterfaceType =>
+      val tpeScope = cls.getScope.asScala
+      cls.getNameAsString == optionalClsName && (tpeScope.isEmpty || tpeScope.map(_.asString).contains(optionalClsScope))
+    case _ => false
+  }
+}
+
+trait JavaStdLibCollections extends CollectionsLibType {
+  override def optionalSideEffect(on: Expression, sideEffectParamName: String, sideEffectBody: List[Statement]): Expression =
+    CollectionsLibType.lambdaMethodCall(on, sideEffectParamName, sideEffectBody, "ifPresent")
+
+  override def isOptionalType(tpe: Type): Boolean = CollectionsLibType.isOptional(tpe, "java.util", "Optional")
+}

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaModule.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaModule.scala
@@ -9,6 +9,7 @@ import com.twilio.guardrail.generators.Java.SpringMvcGenerator
 import com.twilio.guardrail.generators.Java.DropwizardServerGenerator
 import com.twilio.guardrail.generators.Java.SpringMvcServerGenerator
 import cats.data.NonEmptyList
+import com.twilio.guardrail.generators.Java.collectionslib.{ CollectionsLibType, JavaStdLibCollections }
 import com.twilio.guardrail.generators.collections.JavaCollectionsGenerator
 import com.twilio.guardrail.protocol.terms.protocol.{ ArrayProtocolTerms, EnumProtocolTerms, ModelProtocolTerms, PolyProtocolTerms, ProtocolSupportTerms }
 import com.twilio.guardrail.protocol.terms.client.ClientTerms
@@ -17,7 +18,7 @@ import com.twilio.guardrail.terms.{ CollectionsLibTerms, LanguageTerms, SwaggerT
 import com.twilio.guardrail.terms.framework.FrameworkTerms
 
 object JavaModule extends AbstractModule[JavaLanguage] {
-  def jackson(implicit Cl: CollectionsLibTerms[JavaLanguage, Target]): (
+  def jackson(implicit Cl: CollectionsLibTerms[JavaLanguage, Target] with CollectionsLibType): (
       ProtocolSupportTerms[JavaLanguage, Target],
       ModelProtocolTerms[JavaLanguage, Target],
       EnumProtocolTerms[JavaLanguage, Target],
@@ -43,7 +44,7 @@ object JavaModule extends AbstractModule[JavaLanguage] {
     new AsyncHttpClientClientGenerator.ClientTermInterp
 
   def extract(modules: NonEmptyList[String]): Target[Framework[JavaLanguage, Target]] = {
-    implicit val collections = JavaCollectionsGenerator.JavaCollectionsInterp
+    implicit val collections = new JavaCollectionsGenerator.JavaCollectionsInterp with JavaStdLibCollections
     (for {
       (protocol, model, enum, array, poly) <- popModule("json", ("jackson", jackson))
       client                               <- popModule("client", ("async-http-client", asyncHttpClient))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaModule.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaModule.scala
@@ -32,7 +32,7 @@ object JavaModule extends AbstractModule[JavaLanguage] {
     new JacksonGenerator.PolyProtocolTermInterp
   )
 
-  def dropwizard(implicit Cl: CollectionsLibTerms[JavaLanguage, Target]): (
+  def dropwizard(implicit Cl: CollectionsLibTerms[JavaLanguage, Target] with CollectionsLibType): (
       ServerTerms[JavaLanguage, Target],
       FrameworkTerms[JavaLanguage, Target]
   ) = (new DropwizardServerGenerator.ServerTermInterp, new DropwizardGenerator.FrameworkInterp)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaModule.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaModule.scala
@@ -36,7 +36,7 @@ object JavaModule extends AbstractModule[JavaLanguage] {
       ServerTerms[JavaLanguage, Target],
       FrameworkTerms[JavaLanguage, Target]
   ) = (new DropwizardServerGenerator.ServerTermInterp, new DropwizardGenerator.FrameworkInterp)
-  def spring(implicit Cl: CollectionsLibTerms[JavaLanguage, Target]): (
+  def spring(implicit Cl: CollectionsLibTerms[JavaLanguage, Target] with CollectionsLibType): (
       ServerTerms[JavaLanguage, Target],
       FrameworkTerms[JavaLanguage, Target]
   ) = (new SpringMvcServerGenerator.ServerTermInterp, new SpringMvcGenerator.FrameworkInterp)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaModule.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaModule.scala
@@ -40,7 +40,7 @@ object JavaModule extends AbstractModule[JavaLanguage] {
       ServerTerms[JavaLanguage, Target],
       FrameworkTerms[JavaLanguage, Target]
   ) = (new SpringMvcServerGenerator.ServerTermInterp, new SpringMvcGenerator.FrameworkInterp)
-  def asyncHttpClient(implicit Cl: CollectionsLibTerms[JavaLanguage, Target]): ClientTerms[JavaLanguage, Target] =
+  def asyncHttpClient(implicit Cl: CollectionsLibTerms[JavaLanguage, Target] with CollectionsLibType): ClientTerms[JavaLanguage, Target] =
     new AsyncHttpClientClientGenerator.ClientTermInterp
 
   def extract(modules: NonEmptyList[String]): Target[Framework[JavaLanguage, Target]] = {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaModule.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaModule.scala
@@ -9,11 +9,11 @@ import com.twilio.guardrail.generators.Java.SpringMvcGenerator
 import com.twilio.guardrail.generators.Java.DropwizardServerGenerator
 import com.twilio.guardrail.generators.Java.SpringMvcServerGenerator
 import cats.data.NonEmptyList
-
+import com.twilio.guardrail.generators.collections.JavaCollectionsGenerator
 import com.twilio.guardrail.protocol.terms.protocol.{ ArrayProtocolTerms, EnumProtocolTerms, ModelProtocolTerms, PolyProtocolTerms, ProtocolSupportTerms }
 import com.twilio.guardrail.protocol.terms.client.ClientTerms
 import com.twilio.guardrail.protocol.terms.server.ServerTerms
-import com.twilio.guardrail.terms.{ LanguageTerms, SwaggerTerms }
+import com.twilio.guardrail.terms.{ CollectionsLibTerms, LanguageTerms, SwaggerTerms }
 import com.twilio.guardrail.terms.framework.FrameworkTerms
 
 object JavaModule extends AbstractModule[JavaLanguage] {
@@ -57,5 +57,6 @@ object JavaModule extends AbstractModule[JavaLanguage] {
       def ServerInterp: ServerTerms[JavaLanguage, Target]                   = server
       def SwaggerInterp: SwaggerTerms[JavaLanguage, Target]                 = SwaggerGenerator[JavaLanguage]
       def LanguageInterp: LanguageTerms[JavaLanguage, Target]               = JavaGenerator.JavaInterp
+      def CollectionsLibInterp: CollectionsLibTerms[JavaLanguage, Target]   = JavaCollectionsGenerator.JavaCollectionsInterp
     }).runA(modules.toList.toSet)
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/LanguageParameter.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/LanguageParameter.scala
@@ -8,7 +8,7 @@ import com.twilio.guardrail.extract.{ Default, FileHashAlgorithm }
 import com.twilio.guardrail.generators.syntax._
 import com.twilio.guardrail.languages.LA
 import com.twilio.guardrail.shims._
-import com.twilio.guardrail.terms.{ LanguageTerms, SwaggerTerms }
+import com.twilio.guardrail.terms.{ CollectionsLibTerms, LanguageTerms, SwaggerTerms }
 import com.twilio.guardrail.terms.framework.FrameworkTerms
 import cats.implicits._
 import com.twilio.guardrail.SwaggerUtil.ResolvedType
@@ -49,9 +49,15 @@ object LanguageParameter {
 
   def fromParameter[L <: LA, F[_]](
       protocolElems: List[StrictProtocolElems[L]]
-  )(implicit Fw: FrameworkTerms[L, F], Sc: LanguageTerms[L, F], Sw: SwaggerTerms[L, F]): Tracker[Parameter] => F[LanguageParameter[L]] = { parameter =>
+  )(
+      implicit Fw: FrameworkTerms[L, F],
+      Sc: LanguageTerms[L, F],
+      Cl: CollectionsLibTerms[L, F],
+      Sw: SwaggerTerms[L, F]
+  ): Tracker[Parameter] => F[LanguageParameter[L]] = { parameter =>
     import Fw._
     import Sc._
+    import Cl._
     import Sw._
 
     def paramMeta(param: Tracker[Parameter]): F[SwaggerUtil.ResolvedType[L]] = {
@@ -159,7 +165,12 @@ object LanguageParameter {
 
   def fromParameters[L <: LA, F[_]](
       protocolElems: List[StrictProtocolElems[L]]
-  )(implicit Fw: FrameworkTerms[L, F], Sc: LanguageTerms[L, F], Sw: SwaggerTerms[L, F]): List[Tracker[Parameter]] => F[List[LanguageParameter[L]]] = { params =>
+  )(
+      implicit Fw: FrameworkTerms[L, F],
+      Sc: LanguageTerms[L, F],
+      Cl: CollectionsLibTerms[L, F],
+      Sw: SwaggerTerms[L, F]
+  ): List[Tracker[Parameter]] => F[List[LanguageParameter[L]]] = { params =>
     import Sc._
     for {
       parameters <- params.traverse(fromParameter(protocolElems))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttp.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttp.scala
@@ -7,6 +7,7 @@ import com.twilio.guardrail.generators.Scala.AkkaHttpServerGenerator._
 import com.twilio.guardrail.generators.Scala.CirceProtocolGenerator._
 import com.twilio.guardrail.generators.Scala.model.CirceModelGenerator
 import com.twilio.guardrail.generators.ScalaGenerator._
+import com.twilio.guardrail.generators.collections.ScalaCollectionsGenerator.ScalaCollectionsInterp
 import com.twilio.guardrail.generators.{ Framework, SwaggerGenerator }
 import com.twilio.guardrail.languages.ScalaLanguage
 
@@ -21,4 +22,5 @@ object AkkaHttp extends Framework[ScalaLanguage, Target] {
   implicit def ServerInterp          = new ServerTermInterp(CirceModelGenerator.V012)
   implicit def SwaggerInterp         = SwaggerGenerator[ScalaLanguage]
   implicit def LanguageInterp        = ScalaInterp
+  implicit def CollectionsLibInterp  = ScalaCollectionsInterp
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttp.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttp.scala
@@ -12,15 +12,15 @@ import com.twilio.guardrail.generators.{ Framework, SwaggerGenerator }
 import com.twilio.guardrail.languages.ScalaLanguage
 
 object AkkaHttp extends Framework[ScalaLanguage, Target] {
-  implicit def ArrayProtocolInterp   = ArrayProtocolTermInterp
+  implicit def CollectionsLibInterp  = ScalaCollectionsInterp
+  implicit def ArrayProtocolInterp   = new ArrayProtocolTermInterp
   implicit def ClientInterp          = new ClientTermInterp(CirceModelGenerator.V012)
-  implicit def EnumProtocolInterp    = EnumProtocolTermInterp
+  implicit def EnumProtocolInterp    = new EnumProtocolTermInterp
   implicit def FrameworkInterp       = new FrameworkInterp(CirceModelGenerator.V012)
   implicit def ModelProtocolInterp   = new ModelProtocolTermInterp(CirceModelGenerator.V012)
-  implicit def PolyProtocolInterp    = PolyProtocolTermInterp
-  implicit def ProtocolSupportInterp = ProtocolSupportTermInterp
+  implicit def PolyProtocolInterp    = new PolyProtocolTermInterp
+  implicit def ProtocolSupportInterp = new ProtocolSupportTermInterp
   implicit def ServerInterp          = new ServerTermInterp(CirceModelGenerator.V012)
   implicit def SwaggerInterp         = SwaggerGenerator[ScalaLanguage]
   implicit def LanguageInterp        = ScalaInterp
-  implicit def CollectionsLibInterp  = ScalaCollectionsInterp
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpClientGenerator.scala
@@ -11,7 +11,7 @@ import com.twilio.guardrail.generators.syntax._
 import com.twilio.guardrail.protocol.terms.{ ApplicationJson, ContentType, Header, MultipartFormData, Responses, TextPlain }
 import com.twilio.guardrail.protocol.terms.client._
 import com.twilio.guardrail.shims._
-import com.twilio.guardrail.terms.{ RouteMeta, SecurityScheme }
+import com.twilio.guardrail.terms.{ CollectionsLibTerms, RouteMeta, SecurityScheme }
 import com.twilio.guardrail.languages.ScalaLanguage
 import scala.meta._
 import _root_.io.swagger.v3.oas.models.PathItem.HttpMethod
@@ -20,7 +20,8 @@ import java.net.URI
 
 object AkkaHttpClientGenerator {
 
-  class ClientTermInterp(modelGeneratorType: ModelGeneratorType) extends ClientTerms[ScalaLanguage, Target] {
+  class ClientTermInterp(modelGeneratorType: ModelGeneratorType)(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target])
+      extends ClientTerms[ScalaLanguage, Target] {
     implicit def MonadF: Monad[Target] = Target.targetInstances
 
     def splitOperationParts(operationId: String): (List[String], String) = {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpGenerator.scala
@@ -3,11 +3,13 @@ package com.twilio.guardrail.generators.Scala
 import com.twilio.guardrail.Target
 import com.twilio.guardrail.generators.Scala.model.{ CirceModelGenerator, JacksonModelGenerator, ModelGeneratorType }
 import com.twilio.guardrail.languages.ScalaLanguage
+import com.twilio.guardrail.terms.CollectionsLibTerms
 import com.twilio.guardrail.terms.framework._
 import scala.meta._
 
 object AkkaHttpGenerator {
-  class FrameworkInterp(modelGeneratorType: ModelGeneratorType) extends FrameworkTerms[ScalaLanguage, Target] {
+  class FrameworkInterp(modelGeneratorType: ModelGeneratorType)(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target])
+      extends FrameworkTerms[ScalaLanguage, Target] {
     implicit def MonadF                  = Target.targetInstances
     def fileType(format: Option[String]) = Target.pure(format.fold[Type](t"BodyPartEntity")(Type.Name(_)))
     def objectType(format: Option[String]) =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpJackson.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpJackson.scala
@@ -1,6 +1,7 @@
 package com.twilio.guardrail.generators.Scala
 
 import com.twilio.guardrail.Target
+import com.twilio.guardrail.generators.collections.ScalaCollectionsGenerator
 import com.twilio.guardrail.generators.Scala.AkkaHttpClientGenerator._
 import com.twilio.guardrail.generators.Scala.AkkaHttpGenerator._
 import com.twilio.guardrail.generators.Scala.AkkaHttpServerGenerator._
@@ -21,4 +22,5 @@ object AkkaHttpJackson extends Framework[ScalaLanguage, Target] {
   implicit def ServerInterp          = new ServerTermInterp(JacksonModelGenerator)
   implicit def SwaggerInterp         = SwaggerGenerator[ScalaLanguage]
   implicit def LanguageInterp        = ScalaInterp
+  implicit def CollectionsLibInterp  = ScalaCollectionsGenerator.ScalaCollectionsInterp
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpJackson.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpJackson.scala
@@ -12,6 +12,7 @@ import com.twilio.guardrail.generators.{ Framework, SwaggerGenerator }
 import com.twilio.guardrail.languages.ScalaLanguage
 
 object AkkaHttpJackson extends Framework[ScalaLanguage, Target] {
+  implicit def CollectionsLibInterp  = ScalaCollectionsGenerator.ScalaCollectionsInterp
   implicit def ArrayProtocolInterp   = ArrayProtocolTermInterp
   implicit def ClientInterp          = new ClientTermInterp(JacksonModelGenerator)
   implicit def EnumProtocolInterp    = EnumProtocolTermInterp
@@ -22,5 +23,4 @@ object AkkaHttpJackson extends Framework[ScalaLanguage, Target] {
   implicit def ServerInterp          = new ServerTermInterp(JacksonModelGenerator)
   implicit def SwaggerInterp         = SwaggerGenerator[ScalaLanguage]
   implicit def LanguageInterp        = ScalaInterp
-  implicit def CollectionsLibInterp  = ScalaCollectionsGenerator.ScalaCollectionsInterp
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpServerGenerator.scala
@@ -15,14 +15,15 @@ import com.twilio.guardrail.generators.operations.TracingLabelFormatter
 import com.twilio.guardrail.languages.ScalaLanguage
 import com.twilio.guardrail.protocol.terms.{ ApplicationJson, BinaryContent, ContentType, MultipartFormData, Responses, TextContent, UrlencodedFormData }
 import com.twilio.guardrail.protocol.terms.server._
-import com.twilio.guardrail.terms.{ RouteMeta, SecurityScheme }
+import com.twilio.guardrail.terms.{ CollectionsLibTerms, RouteMeta, SecurityScheme }
 import com.twilio.guardrail.shims._
 import scala.meta._
 import _root_.io.swagger.v3.oas.models.PathItem.HttpMethod
 import _root_.io.swagger.v3.oas.models.Operation
 
 object AkkaHttpServerGenerator {
-  class ServerTermInterp(modelGeneratorType: ModelGeneratorType) extends ServerTerms[ScalaLanguage, Target] {
+  class ServerTermInterp(modelGeneratorType: ModelGeneratorType)(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target])
+      extends ServerTerms[ScalaLanguage, Target] {
     def splitOperationParts(operationId: String): (List[String], String) = {
       val parts = operationId.split('.')
       (parts.drop(1).toList, parts.last)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Dropwizard.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Dropwizard.scala
@@ -16,13 +16,13 @@ import com.twilio.guardrail.terms.{ CollectionsLibTerms, LanguageTerms, SwaggerT
 
 object Dropwizard extends Framework[ScalaLanguage, Target] {
   override implicit def ArrayProtocolInterp: ArrayProtocolTerms[ScalaLanguage, Target]     = ArrayProtocolTermInterp
-  override implicit def ClientInterp: ClientTerms[ScalaLanguage, Target]                   = ClientTermInterp
+  override implicit def ClientInterp: ClientTerms[ScalaLanguage, Target]                   = new ClientTermInterp
   override implicit def EnumProtocolInterp: EnumProtocolTerms[ScalaLanguage, Target]       = EnumProtocolTermInterp
-  override implicit def FrameworkInterp: FrameworkTerms[ScalaLanguage, Target]             = DropwizardGenerator.FrameworkInterp
+  override implicit def FrameworkInterp: FrameworkTerms[ScalaLanguage, Target]             = new DropwizardGenerator.FrameworkInterp
   override implicit def ModelProtocolInterp: ModelProtocolTerms[ScalaLanguage, Target]     = ModelProtocolTermInterp
   override implicit def PolyProtocolInterp: PolyProtocolTerms[ScalaLanguage, Target]       = PolyProtocolTermInterp
   override implicit def ProtocolSupportInterp: ProtocolSupportTerms[ScalaLanguage, Target] = ProtocolSupportTermInterp
-  override implicit def ServerInterp: ServerTerms[ScalaLanguage, Target]                   = ServerTermInterp
+  override implicit def ServerInterp: ServerTerms[ScalaLanguage, Target]                   = new ServerTermInterp
   override implicit def SwaggerInterp: SwaggerTerms[ScalaLanguage, Target]                 = SwaggerGenerator[ScalaLanguage]()
   override implicit def LanguageInterp: LanguageTerms[ScalaLanguage, Target]               = ScalaInterp
   override implicit def CollectionsLibInterp: CollectionsLibTerms[ScalaLanguage, Target]   = ScalaCollectionsGenerator.ScalaCollectionsInterp

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Dropwizard.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Dropwizard.scala
@@ -5,13 +5,14 @@ import com.twilio.guardrail.generators.Scala.DropwizardClientGenerator.ClientTer
 import com.twilio.guardrail.generators.Scala.DropwizardServerGenerator.ServerTermInterp
 import com.twilio.guardrail.generators.Scala.JacksonProtocolGenerator._
 import com.twilio.guardrail.generators.ScalaGenerator.ScalaInterp
+import com.twilio.guardrail.generators.collections.ScalaCollectionsGenerator
 import com.twilio.guardrail.generators.{ Framework, SwaggerGenerator }
 import com.twilio.guardrail.languages.ScalaLanguage
 import com.twilio.guardrail.protocol.terms.client.ClientTerms
 import com.twilio.guardrail.protocol.terms.protocol._
 import com.twilio.guardrail.protocol.terms.server.ServerTerms
 import com.twilio.guardrail.terms.framework.FrameworkTerms
-import com.twilio.guardrail.terms.{ LanguageTerms, SwaggerTerms }
+import com.twilio.guardrail.terms.{ CollectionsLibTerms, LanguageTerms, SwaggerTerms }
 
 object Dropwizard extends Framework[ScalaLanguage, Target] {
   override implicit def ArrayProtocolInterp: ArrayProtocolTerms[ScalaLanguage, Target]     = ArrayProtocolTermInterp
@@ -24,4 +25,5 @@ object Dropwizard extends Framework[ScalaLanguage, Target] {
   override implicit def ServerInterp: ServerTerms[ScalaLanguage, Target]                   = ServerTermInterp
   override implicit def SwaggerInterp: SwaggerTerms[ScalaLanguage, Target]                 = SwaggerGenerator[ScalaLanguage]()
   override implicit def LanguageInterp: LanguageTerms[ScalaLanguage, Target]               = ScalaInterp
+  override implicit def CollectionsLibInterp: CollectionsLibTerms[ScalaLanguage, Target]   = ScalaCollectionsGenerator.ScalaCollectionsInterp
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/DropwizardClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/DropwizardClientGenerator.scala
@@ -7,12 +7,13 @@ import com.twilio.guardrail.generators.LanguageParameters
 import com.twilio.guardrail.languages.ScalaLanguage
 import com.twilio.guardrail.protocol.terms.Responses
 import com.twilio.guardrail.protocol.terms.client.ClientTerms
-import com.twilio.guardrail.terms.{ RouteMeta, SecurityScheme }
+import com.twilio.guardrail.terms.{ CollectionsLibTerms, RouteMeta, SecurityScheme }
 import java.net.URI
+
 import scala.meta.{ Defn, Import, Term }
 
 object DropwizardClientGenerator {
-  object ClientTermInterp extends ClientTerms[ScalaLanguage, Target] {
+  class ClientTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]) extends ClientTerms[ScalaLanguage, Target] {
     override def MonadF: Monad[Target]                                   = Target.targetInstances
     override def getImports(tracing: Boolean): Target[List[Import]]      = Target.raiseError(RuntimeFailure("Dropwizard Scala clients are not yet supported"))
     override def getExtraImports(tracing: Boolean): Target[List[Import]] = Target.raiseError(RuntimeFailure("Dropwizard Scala clients are not yet supported"))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/DropwizardGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/DropwizardGenerator.scala
@@ -3,12 +3,14 @@ package com.twilio.guardrail.generators.Scala
 import cats.Monad
 import com.twilio.guardrail.{ Target, UserError }
 import com.twilio.guardrail.languages.ScalaLanguage
+import com.twilio.guardrail.terms.CollectionsLibTerms
 import com.twilio.guardrail.terms.framework.FrameworkTerms
+
 import scala.meta._
 import scala.util.Try
 
 object DropwizardGenerator {
-  object FrameworkInterp extends FrameworkTerms[ScalaLanguage, Target] {
+  class FrameworkInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]) extends FrameworkTerms[ScalaLanguage, Target] {
     override def MonadF: Monad[Target] = Target.targetInstances
 
     override def objectType(format: Option[String]): Target[Type] = Target.pure(t"com.fasterxml.jackson.databind.JsonNode")

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/DropwizardServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/DropwizardServerGenerator.scala
@@ -10,9 +10,10 @@ import com.twilio.guardrail.languages.ScalaLanguage
 import com.twilio.guardrail.protocol.terms.server.{ GenerateRouteMeta, ServerTerms }
 import com.twilio.guardrail.protocol.terms._
 import com.twilio.guardrail.shims.OperationExt
-import com.twilio.guardrail.terms.{ RouteMeta, SecurityScheme }
+import com.twilio.guardrail.terms.{ CollectionsLibTerms, RouteMeta, SecurityScheme }
 import com.twilio.guardrail.{ RenderedRoutes, StrictProtocolElems, SupportDefinition, Target, TracingField }
 import io.swagger.v3.oas.models.Operation
+
 import scala.meta._
 
 object DropwizardServerGenerator {
@@ -130,7 +131,7 @@ object DropwizardServerGenerator {
       buildTransformers(param, httpParameterAnnotation).foldLeft(param.param)((accum, next) => next(accum))
   }
 
-  object ServerTermInterp extends ServerTerms[ScalaLanguage, Target] {
+  class ServerTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]) extends ServerTerms[ScalaLanguage, Target] {
     override def MonadF: Monad[Target] = Target.targetInstances
 
     override def getExtraImports(tracing: Boolean, supportPackage: List[String]): Target[List[Import]] =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Endpoints.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Endpoints.scala
@@ -7,6 +7,7 @@ import com.twilio.guardrail.generators.Scala.EndpointsGenerator.{ FrameworkInter
 import com.twilio.guardrail.generators.Scala.EndpointsServerGenerator._
 import com.twilio.guardrail.generators.Scala.model.CirceModelGenerator
 import com.twilio.guardrail.generators.ScalaGenerator._
+import com.twilio.guardrail.generators.collections.ScalaCollectionsGenerator.ScalaCollectionsInterp
 import com.twilio.guardrail.generators.{ Framework, SwaggerGenerator }
 import com.twilio.guardrail.languages.ScalaLanguage
 
@@ -21,4 +22,5 @@ object Endpoints extends Framework[ScalaLanguage, Target] {
   implicit def ServerInterp          = ServerTermInterp
   implicit def SwaggerInterp         = SwaggerGenerator[ScalaLanguage]
   implicit def LanguageInterp        = ScalaInterp
+  implicit def CollectionsLibInterp  = ScalaCollectionsInterp
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Endpoints.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Endpoints.scala
@@ -12,15 +12,15 @@ import com.twilio.guardrail.generators.{ Framework, SwaggerGenerator }
 import com.twilio.guardrail.languages.ScalaLanguage
 
 object Endpoints extends Framework[ScalaLanguage, Target] {
-  implicit def ArrayProtocolInterp   = ArrayProtocolTermInterp
-  implicit def ClientInterp          = ClientTermInterp
-  implicit def EnumProtocolInterp    = EnumProtocolTermInterp
-  implicit def FrameworkInterp       = EndpointsFrameworkInterp
+  implicit def CollectionsLibInterp  = ScalaCollectionsInterp
+  implicit def ArrayProtocolInterp   = new ArrayProtocolTermInterp
+  implicit def ClientInterp          = new ClientTermInterp
+  implicit def EnumProtocolInterp    = new EnumProtocolTermInterp
+  implicit def FrameworkInterp       = new EndpointsFrameworkInterp
   implicit def ModelProtocolInterp   = new ModelProtocolTermInterp(CirceModelGenerator.V012)
-  implicit def PolyProtocolInterp    = PolyProtocolTermInterp
-  implicit def ProtocolSupportInterp = ProtocolSupportTermInterp
-  implicit def ServerInterp          = ServerTermInterp
+  implicit def PolyProtocolInterp    = new PolyProtocolTermInterp
+  implicit def ProtocolSupportInterp = new ProtocolSupportTermInterp
+  implicit def ServerInterp          = new ServerTermInterp
   implicit def SwaggerInterp         = SwaggerGenerator[ScalaLanguage]
   implicit def LanguageInterp        = ScalaInterp
-  implicit def CollectionsLibInterp  = ScalaCollectionsInterp
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/EndpointsClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/EndpointsClientGenerator.scala
@@ -11,13 +11,13 @@ import com.twilio.guardrail.generators.syntax._
 import com.twilio.guardrail.languages.ScalaLanguage
 import com.twilio.guardrail.protocol.terms.{ ContentType, MultipartFormData, Responses, TextPlain }
 import com.twilio.guardrail.protocol.terms.client._
-import com.twilio.guardrail.terms.{ RouteMeta, SecurityScheme }
+import com.twilio.guardrail.terms.{ CollectionsLibTerms, RouteMeta, SecurityScheme }
 import com.twilio.guardrail.shims._
 import java.net.URI
 import scala.meta._
 
 object EndpointsClientGenerator {
-  object ClientTermInterp extends ClientTerms[ScalaLanguage, Target] {
+  class ClientTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]) extends ClientTerms[ScalaLanguage, Target] {
     implicit def MonadF: Monad[Target] = Target.targetInstances
 
     private[this] def formatClientName(clientName: Option[String]): Term.Param =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/EndpointsGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/EndpointsGenerator.scala
@@ -4,9 +4,10 @@ import com.twilio.guardrail.terms.framework._
 import scala.meta._
 import com.twilio.guardrail.languages.ScalaLanguage
 import com.twilio.guardrail.Target
+import com.twilio.guardrail.terms.CollectionsLibTerms
 
 object EndpointsGenerator {
-  object FrameworkInterp extends FrameworkTerms[ScalaLanguage, Target] {
+  class FrameworkInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]) extends FrameworkTerms[ScalaLanguage, Target] {
     implicit def MonadF                    = Target.targetInstances
     def fileType(format: Option[String])   = Target.pure(format.fold[Type](t"org.scalajs.dom.raw.File")(Type.Name(_)))
     def objectType(format: Option[String]) = Target.pure(t"io.circe.Json")

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/EndpointsServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/EndpointsServerGenerator.scala
@@ -6,11 +6,11 @@ import com.twilio.guardrail.core.Tracker
 import com.twilio.guardrail.languages.ScalaLanguage
 import com.twilio.guardrail.protocol.terms.Responses
 import com.twilio.guardrail.protocol.terms.server._
-import com.twilio.guardrail.terms.SecurityScheme
+import com.twilio.guardrail.terms.{ CollectionsLibTerms, SecurityScheme }
 import com.twilio.guardrail.{ StrictProtocolElems, Target }
 
 object EndpointsServerGenerator {
-  object ServerTermInterp extends ServerTerms[ScalaLanguage, Target] {
+  class ServerTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]) extends ServerTerms[ScalaLanguage, Target] {
     implicit def MonadF: Monad[Target] = Target.targetInstances
     def generateResponseDefinitions(responseClsName: String, responses: Responses[ScalaLanguage], protocolElems: List[StrictProtocolElems[ScalaLanguage]]) =
       Target.raiseUserError("endpoints server generation is not currently supported")

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4s.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4s.scala
@@ -9,6 +9,7 @@ import Http4sClientGenerator._
 import Http4sServerGenerator._
 import Http4sGenerator.{ FrameworkInterp => Http4sFrameworkInterp }
 import CirceProtocolGenerator._
+import com.twilio.guardrail.generators.collections.ScalaCollectionsGenerator.ScalaCollectionsInterp
 
 object Http4s extends Framework[ScalaLanguage, Target] {
   implicit def ArrayProtocolInterp   = ArrayProtocolTermInterp
@@ -21,4 +22,5 @@ object Http4s extends Framework[ScalaLanguage, Target] {
   implicit def ServerInterp          = ServerTermInterp
   implicit def SwaggerInterp         = SwaggerGenerator[ScalaLanguage]
   implicit def LanguageInterp        = ScalaInterp
+  implicit def CollectionsLibInterp  = ScalaCollectionsInterp
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4s.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4s.scala
@@ -12,15 +12,15 @@ import CirceProtocolGenerator._
 import com.twilio.guardrail.generators.collections.ScalaCollectionsGenerator.ScalaCollectionsInterp
 
 object Http4s extends Framework[ScalaLanguage, Target] {
-  implicit def ArrayProtocolInterp   = ArrayProtocolTermInterp
-  implicit def ClientInterp          = ClientTermInterp
-  implicit def EnumProtocolInterp    = EnumProtocolTermInterp
-  implicit def FrameworkInterp       = Http4sFrameworkInterp
+  implicit def CollectionsLibInterp  = ScalaCollectionsInterp
+  implicit def ArrayProtocolInterp   = new ArrayProtocolTermInterp
+  implicit def ClientInterp          = new ClientTermInterp
+  implicit def EnumProtocolInterp    = new EnumProtocolTermInterp
+  implicit def FrameworkInterp       = new Http4sFrameworkInterp
   implicit def ModelProtocolInterp   = new ModelProtocolTermInterp(CirceModelGenerator.V012)
-  implicit def PolyProtocolInterp    = PolyProtocolTermInterp
-  implicit def ProtocolSupportInterp = ProtocolSupportTermInterp
-  implicit def ServerInterp          = ServerTermInterp
+  implicit def PolyProtocolInterp    = new PolyProtocolTermInterp
+  implicit def ProtocolSupportInterp = new ProtocolSupportTermInterp
+  implicit def ServerInterp          = new ServerTermInterp
   implicit def SwaggerInterp         = SwaggerGenerator[ScalaLanguage]
   implicit def LanguageInterp        = ScalaInterp
-  implicit def CollectionsLibInterp  = ScalaCollectionsInterp
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sClientGenerator.scala
@@ -11,7 +11,7 @@ import com.twilio.guardrail.languages.ScalaLanguage
 import com.twilio.guardrail.protocol.terms.{ ContentType, Header, MultipartFormData, Responses }
 import com.twilio.guardrail.protocol.terms.client._
 import com.twilio.guardrail.shims._
-import com.twilio.guardrail.terms.{ RouteMeta, SecurityScheme }
+import com.twilio.guardrail.terms.{ CollectionsLibTerms, RouteMeta, SecurityScheme }
 import com.twilio.guardrail.generators.{ LanguageParameter, LanguageParameters, RawParameterName }
 import scala.meta._
 import _root_.io.swagger.v3.oas.models.PathItem.HttpMethod
@@ -19,7 +19,7 @@ import java.net.URI
 
 object Http4sClientGenerator {
 
-  object ClientTermInterp extends ClientTerms[ScalaLanguage, Target] {
+  class ClientTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]) extends ClientTerms[ScalaLanguage, Target] {
     implicit def MonadF: Monad[Target] = Target.targetInstances
 
     def splitOperationParts(operationId: String): (List[String], String) = {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sGenerator.scala
@@ -2,11 +2,12 @@ package com.twilio.guardrail.generators.Scala
 
 import com.twilio.guardrail.Target
 import com.twilio.guardrail.languages.ScalaLanguage
+import com.twilio.guardrail.terms.CollectionsLibTerms
 import com.twilio.guardrail.terms.framework._
 import scala.meta._
 
 object Http4sGenerator {
-  object FrameworkInterp extends FrameworkTerms[ScalaLanguage, Target] {
+  class FrameworkInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]) extends FrameworkTerms[ScalaLanguage, Target] {
     implicit def MonadF = Target.targetInstances
     def fileType(format: Option[String]) =
       Target.pure(format.fold[Type](t"fs2.Stream[F,Byte]")(Type.Name(_)))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sServerGenerator.scala
@@ -15,13 +15,13 @@ import com.twilio.guardrail.languages.ScalaLanguage
 import com.twilio.guardrail.protocol.terms.{ ContentType, Header, Response, Responses }
 import com.twilio.guardrail.protocol.terms.server._
 import com.twilio.guardrail.shims._
-import com.twilio.guardrail.terms.{ RouteMeta, SecurityScheme }
+import com.twilio.guardrail.terms.{ CollectionsLibTerms, RouteMeta, SecurityScheme }
 import scala.meta.{ Term, _ }
 import _root_.io.swagger.v3.oas.models.PathItem.HttpMethod
 import _root_.io.swagger.v3.oas.models.Operation
 
 object Http4sServerGenerator {
-  object ServerTermInterp extends ServerTerms[ScalaLanguage, Target] {
+  class ServerTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]) extends ServerTerms[ScalaLanguage, Target] {
     def splitOperationParts(operationId: String): (List[String], String) = {
       val parts = operationId.split('.')
       (parts.drop(1).toList, parts.last)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
@@ -4,7 +4,6 @@ import cats.Monad
 import cats.data.NonEmptyList
 import cats.implicits._
 import com.twilio.guardrail.Common.resolveFile
-import com.twilio.guardrail.SwaggerUtil.LazyResolvedType
 import com.twilio.guardrail._
 import com.twilio.guardrail.generators.syntax.RichString
 import com.twilio.guardrail.generators.syntax.Scala._
@@ -33,25 +32,14 @@ object ScalaGenerator {
     val buildPkgTerm: List[String] => Term.Ref =
       _.map(Term.Name.apply _).reduceLeft(Term.Select.apply _)
 
-    implicit def MonadF: Monad[Target]         = Target.targetInstances
-    def vendorPrefixes(): Target[List[String]] = Target.pure(List("x-scala", "x-jvm"))
+    implicit def MonadF: Monad[Target] = Target.targetInstances
 
-    def litString(value: String): Target[scala.meta.Term]                 = Target.pure(Lit.String(value))
-    def litFloat(value: Float): Target[scala.meta.Term]                   = Target.pure(Lit.Float(value))
-    def litDouble(value: Double): Target[scala.meta.Term]                 = Target.pure(Lit.Double(value))
-    def litInt(value: Int): Target[scala.meta.Term]                       = Target.pure(Lit.Int(value))
-    def litLong(value: Long): Target[scala.meta.Term]                     = Target.pure(Lit.Long(value))
-    def litBoolean(value: Boolean): Target[scala.meta.Term]               = Target.pure(Lit.Boolean(value))
-    def liftOptionalType(value: scala.meta.Type): Target[scala.meta.Type] = Target.pure(t"Option[$value]")
-    def liftOptionalTerm(value: scala.meta.Term): Target[scala.meta.Term] = Target.pure(q"Option($value)")
-    def emptyArray(): Target[scala.meta.Term]                             = Target.pure(q"Vector.empty")
-    def emptyMap(): Target[scala.meta.Term]                               = Target.pure(q"Map.empty")
-    def emptyOptionalTerm(): Target[scala.meta.Term]                      = Target.pure(q"None")
-    def liftVectorType(value: scala.meta.Type, customTpe: Option[scala.meta.Type]): Target[scala.meta.Type] =
-      Target.pure(t"${customTpe.getOrElse(t"Vector")}[$value]")
-    def liftVectorTerm(value: scala.meta.Term): Target[scala.meta.Term] = Target.pure(q"Vector($value)")
-    def liftMapType(value: scala.meta.Type, customTpe: Option[scala.meta.Type]): Target[scala.meta.Type] =
-      Target.pure(t"${customTpe.getOrElse(t"Map")}[String, $value]")
+    def litString(value: String): Target[scala.meta.Term]   = Target.pure(Lit.String(value))
+    def litFloat(value: Float): Target[scala.meta.Term]     = Target.pure(Lit.Float(value))
+    def litDouble(value: Double): Target[scala.meta.Term]   = Target.pure(Lit.Double(value))
+    def litInt(value: Int): Target[scala.meta.Term]         = Target.pure(Lit.Int(value))
+    def litLong(value: Long): Target[scala.meta.Term]       = Target.pure(Lit.Long(value))
+    def litBoolean(value: Boolean): Target[scala.meta.Term] = Target.pure(Lit.Boolean(value))
 
     def fullyQualifyPackageName(rawPkgName: List[String]): Target[List[String]] = Target.pure("_root_" +: rawPkgName)
 
@@ -75,23 +63,6 @@ object ScalaGenerator {
     def formatMethodName(methodName: String): Target[String]                            = Target.pure(methodName.toCamelCase)
     def formatMethodArgName(methodArgName: String): Target[String]                      = Target.pure(methodArgName.toCamelCase)
     def formatEnumName(enumValue: String): Target[String]                               = Target.pure(enumValue.toPascalCase)
-
-    def embedArray(tpe: LazyResolvedType[ScalaLanguage], containerTpe: Option[scala.meta.Type]): Target[LazyResolvedType[ScalaLanguage]] = tpe match {
-      case SwaggerUtil.Deferred(tpe) =>
-        Target.pure(SwaggerUtil.DeferredArray[ScalaLanguage](tpe, containerTpe))
-      case SwaggerUtil.DeferredArray(_, _) =>
-        Target.raiseUserError("FIXME: Got an Array of Arrays, currently not supported")
-      case SwaggerUtil.DeferredMap(_, _) =>
-        Target.raiseUserError("FIXME: Got an Array of Maps, currently not supported")
-    }
-    def embedMap(tpe: LazyResolvedType[ScalaLanguage], containerTpe: Option[scala.meta.Type]): Target[LazyResolvedType[ScalaLanguage]] = tpe match {
-      case SwaggerUtil.Deferred(inner) =>
-        Target.pure(SwaggerUtil.DeferredMap[ScalaLanguage](inner, containerTpe))
-      case SwaggerUtil.DeferredMap(_, _) =>
-        Target.raiseUserError("FIXME: Got a map of maps, currently not supported")
-      case SwaggerUtil.DeferredArray(_, _) =>
-        Target.raiseUserError("FIXME: Got a map of arrays, currently not supported")
-    }
 
     def parseType(tpe: String): Target[Option[scala.meta.Type]] =
       Target.pure(
@@ -157,7 +128,6 @@ object ScalaGenerator {
     def longType(): Target[scala.meta.Type]                                                = Target.pure(t"Long")
     def integerType(format: Option[String]): Target[scala.meta.Type]                       = Target.pure(t"BigInt")
     def booleanType(format: Option[String]): Target[scala.meta.Type]                       = Target.pure(t"Boolean")
-    def arrayType(format: Option[String]): Target[scala.meta.Type]                         = Target.pure(t"Iterable[String]")
     def fallbackType(tpe: Option[String], format: Option[String]): Target[scala.meta.Type] = Target.fromOption(tpe, UserError("Missing type")).map(Type.Name(_))
 
     def widenTypeName(tpe: scala.meta.Type.Name): Target[scala.meta.Type]             = Target.pure(tpe)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaModule.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaModule.scala
@@ -1,54 +1,58 @@
 package com.twilio.guardrail
 package generators
 
-import com.twilio.guardrail.languages.ScalaLanguage
 import cats.data.NonEmptyList
 import cats.implicits._
-import com.twilio.guardrail.protocol.terms.protocol.{ ArrayProtocolTerms, EnumProtocolTerms, ModelProtocolTerms, PolyProtocolTerms, ProtocolSupportTerms }
-import com.twilio.guardrail.protocol.terms.client.ClientTerms
-import com.twilio.guardrail.protocol.terms.server.ServerTerms
 import com.twilio.guardrail.generators.Scala._
 import com.twilio.guardrail.generators.Scala.model.{ CirceModelGenerator, JacksonModelGenerator, ModelGeneratorType }
 import com.twilio.guardrail.generators.collections.ScalaCollectionsGenerator
-import com.twilio.guardrail.terms.{ CollectionsLibTerms, LanguageTerms, SwaggerTerms }
+import com.twilio.guardrail.languages.ScalaLanguage
+import com.twilio.guardrail.protocol.terms.client.ClientTerms
+import com.twilio.guardrail.protocol.terms.protocol._
+import com.twilio.guardrail.protocol.terms.server.ServerTerms
 import com.twilio.guardrail.terms.framework.FrameworkTerms
+import com.twilio.guardrail.terms.{ CollectionsLibTerms, LanguageTerms, SwaggerTerms }
 
 object ScalaModule extends AbstractModule[ScalaLanguage] {
-  def circe(circeModelGenerator: CirceModelGenerator): (
+  def circe(circeModelGenerator: CirceModelGenerator)(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): (
       ProtocolSupportTerms[ScalaLanguage, Target],
       ModelProtocolTerms[ScalaLanguage, Target],
       EnumProtocolTerms[ScalaLanguage, Target],
       ArrayProtocolTerms[ScalaLanguage, Target],
       PolyProtocolTerms[ScalaLanguage, Target]
   ) = (
-    CirceProtocolGenerator.ProtocolSupportTermInterp,
+    new CirceProtocolGenerator.ProtocolSupportTermInterp,
     new CirceProtocolGenerator.ModelProtocolTermInterp(circeModelGenerator),
-    CirceProtocolGenerator.EnumProtocolTermInterp,
-    CirceProtocolGenerator.ArrayProtocolTermInterp,
-    CirceProtocolGenerator.PolyProtocolTermInterp
+    new CirceProtocolGenerator.EnumProtocolTermInterp,
+    new CirceProtocolGenerator.ArrayProtocolTermInterp,
+    new CirceProtocolGenerator.PolyProtocolTermInterp
   )
 
-  def circeJava8(circeModelGenerator: CirceModelGenerator): (
+  def circeJava8(circeModelGenerator: CirceModelGenerator)(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): (
       ProtocolSupportTerms[ScalaLanguage, Target],
       ModelProtocolTerms[ScalaLanguage, Target],
       EnumProtocolTerms[ScalaLanguage, Target],
       ArrayProtocolTerms[ScalaLanguage, Target],
       PolyProtocolTerms[ScalaLanguage, Target]
-  ) = (
-    CirceProtocolGenerator.ProtocolSupportTermInterp.copy(newPackageObjectImports =
-      () =>
-        CirceProtocolGenerator.ProtocolSupportTermInterp.packageObjectImports().map { values =>
+  ) = {
+    val stockProtocolSupportInterp = new CirceProtocolGenerator.ProtocolSupportTermInterp
+    val protocolSupportInterp = stockProtocolSupportInterp.copy(
+      newPackageObjectImports = () =>
+        stockProtocolSupportInterp.packageObjectImports().map { values =>
           import scala.meta._
           values :+ q"import io.circe.java8.time._"
         }
-    ),
-    new CirceProtocolGenerator.ModelProtocolTermInterp(circeModelGenerator),
-    CirceProtocolGenerator.EnumProtocolTermInterp,
-    CirceProtocolGenerator.ArrayProtocolTermInterp,
-    CirceProtocolGenerator.PolyProtocolTermInterp
-  )
+    )
+    (
+      protocolSupportInterp,
+      new CirceProtocolGenerator.ModelProtocolTermInterp(circeModelGenerator),
+      new CirceProtocolGenerator.EnumProtocolTermInterp,
+      new CirceProtocolGenerator.ArrayProtocolTermInterp,
+      new CirceProtocolGenerator.PolyProtocolTermInterp
+    )
+  }
 
-  def jackson: (
+  def jackson(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): (
       ProtocolSupportTerms[ScalaLanguage, Target],
       ModelProtocolTerms[ScalaLanguage, Target],
       EnumProtocolTerms[ScalaLanguage, Target],
@@ -62,7 +66,7 @@ object ScalaModule extends AbstractModule[ScalaLanguage] {
     JacksonProtocolGenerator.PolyProtocolTermInterp
   )
 
-  def akkaHttp(modelGeneratorType: ModelGeneratorType): (
+  def akkaHttp(modelGeneratorType: ModelGeneratorType)(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): (
       ClientTerms[ScalaLanguage, Target],
       ServerTerms[ScalaLanguage, Target],
       FrameworkTerms[ScalaLanguage, Target]
@@ -72,37 +76,38 @@ object ScalaModule extends AbstractModule[ScalaLanguage] {
     new AkkaHttpGenerator.FrameworkInterp(modelGeneratorType)
   )
 
-  def endpoints(modelGeneratorType: ModelGeneratorType): (
+  def endpoints(modelGeneratorType: ModelGeneratorType)(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): (
       ClientTerms[ScalaLanguage, Target],
       ServerTerms[ScalaLanguage, Target],
       FrameworkTerms[ScalaLanguage, Target]
   ) = (
-    EndpointsClientGenerator.ClientTermInterp,
-    EndpointsServerGenerator.ServerTermInterp,
-    EndpointsGenerator.FrameworkInterp
+    new EndpointsClientGenerator.ClientTermInterp,
+    new EndpointsServerGenerator.ServerTermInterp,
+    new EndpointsGenerator.FrameworkInterp
   )
 
-  def http4s: (
+  def http4s(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): (
       ClientTerms[ScalaLanguage, Target],
       ServerTerms[ScalaLanguage, Target],
       FrameworkTerms[ScalaLanguage, Target]
   ) = (
-    Http4sClientGenerator.ClientTermInterp,
-    Http4sServerGenerator.ServerTermInterp,
-    Http4sGenerator.FrameworkInterp
+    new Http4sClientGenerator.ClientTermInterp,
+    new Http4sServerGenerator.ServerTermInterp,
+    new Http4sGenerator.FrameworkInterp
   )
 
-  def dropwizard: (
+  def dropwizard(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): (
       ClientTerms[ScalaLanguage, Target],
       ServerTerms[ScalaLanguage, Target],
       FrameworkTerms[ScalaLanguage, Target]
   ) = (
-    DropwizardClientGenerator.ClientTermInterp,
-    DropwizardServerGenerator.ServerTermInterp,
-    DropwizardGenerator.FrameworkInterp
+    new DropwizardClientGenerator.ClientTermInterp,
+    new DropwizardServerGenerator.ServerTermInterp,
+    new DropwizardGenerator.FrameworkInterp
   )
 
-  def extract(modules: NonEmptyList[String]): Target[Framework[ScalaLanguage, Target]] =
+  def extract(modules: NonEmptyList[String]): Target[Framework[ScalaLanguage, Target]] = {
+    implicit val collections = ScalaCollectionsGenerator.ScalaCollectionsInterp
     (for {
       (modelGeneratorType, (protocol, model, enum, array, poly)) <- popModule(
         "json",
@@ -131,6 +136,7 @@ object ScalaModule extends AbstractModule[ScalaLanguage] {
       def ServerInterp: ServerTerms[ScalaLanguage, Target]                   = server
       def SwaggerInterp: SwaggerTerms[ScalaLanguage, Target]                 = SwaggerGenerator[ScalaLanguage]
       def LanguageInterp: LanguageTerms[ScalaLanguage, Target]               = ScalaGenerator.ScalaInterp
-      def CollectionsLibInterp: CollectionsLibTerms[ScalaLanguage, Target]   = ScalaCollectionsGenerator.ScalaCollectionsInterp
+      def CollectionsLibInterp: CollectionsLibTerms[ScalaLanguage, Target]   = collections
     }).runA(modules.toList.toSet)
+  }
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaModule.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaModule.scala
@@ -9,7 +9,8 @@ import com.twilio.guardrail.protocol.terms.client.ClientTerms
 import com.twilio.guardrail.protocol.terms.server.ServerTerms
 import com.twilio.guardrail.generators.Scala._
 import com.twilio.guardrail.generators.Scala.model.{ CirceModelGenerator, JacksonModelGenerator, ModelGeneratorType }
-import com.twilio.guardrail.terms.{ LanguageTerms, SwaggerTerms }
+import com.twilio.guardrail.generators.collections.ScalaCollectionsGenerator
+import com.twilio.guardrail.terms.{ CollectionsLibTerms, LanguageTerms, SwaggerTerms }
 import com.twilio.guardrail.terms.framework.FrameworkTerms
 
 object ScalaModule extends AbstractModule[ScalaLanguage] {
@@ -130,5 +131,6 @@ object ScalaModule extends AbstractModule[ScalaLanguage] {
       def ServerInterp: ServerTerms[ScalaLanguage, Target]                   = server
       def SwaggerInterp: SwaggerTerms[ScalaLanguage, Target]                 = SwaggerGenerator[ScalaLanguage]
       def LanguageInterp: LanguageTerms[ScalaLanguage, Target]               = ScalaGenerator.ScalaInterp
+      def CollectionsLibInterp: CollectionsLibTerms[ScalaLanguage, Target]   = ScalaCollectionsGenerator.ScalaCollectionsInterp
     }).runA(modules.toList.toSet)
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/collections/JavaCollectionsGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/collections/JavaCollectionsGenerator.scala
@@ -1,0 +1,89 @@
+package com.twilio.guardrail.generators.collections
+
+import cats.Monad
+import cats.implicits._
+import com.github.javaparser.StaticJavaParser
+import com.github.javaparser.ast.`type`.{ ClassOrInterfaceType, Type }
+import com.github.javaparser.ast.{ Node, NodeList }
+import com.github.javaparser.ast.expr.ObjectCreationExpr
+import com.twilio.guardrail.SwaggerUtil.LazyResolvedType
+import com.twilio.guardrail.{ SwaggerUtil, Target }
+import com.twilio.guardrail.generators.syntax.Java._
+import com.twilio.guardrail.languages.JavaLanguage
+import com.twilio.guardrail.terms.CollectionsLibTerms
+
+object JavaCollectionsGenerator {
+
+  object JavaCollectionsInterp extends CollectionsLibTerms[JavaLanguage, Target] {
+    implicit def MonadF: Monad[Target] = Target.targetInstances
+
+    def vendorPrefixes(): Target[List[String]] = Target.pure(List("x-java", "x-jvm"))
+
+    def liftOptionalType(value: Type): Target[Type] =
+      safeParseClassOrInterfaceType(s"java.util.Optional").map(_.setTypeArguments(new NodeList(value)))
+
+    def liftOptionalTerm(value: Node): Target[Node] =
+      buildMethodCall("java.util.Optional.ofNullable", Some(value))
+
+    def liftSomeTerm(value: Node): Target[Node] =
+      buildMethodCall("java.util.Optional.of", Some(value))
+
+    def emptyOptionalTerm(): Target[Node] = buildMethodCall("java.util.Optional.empty")
+
+    def arrayType(format: Option[String]): Target[Type] =
+      safeParseClassOrInterfaceType("java.util.List").map(_.setTypeArguments(new NodeList[Type](STRING_TYPE)))
+
+    def liftVectorType(value: Type, customTpe: Option[Type]): Target[Type] =
+      customTpe
+        .fold[Target[ClassOrInterfaceType]](safeParseClassOrInterfaceType("java.util.List").map(identity))({
+          case t: ClassOrInterfaceType =>
+            Target.pure(t)
+          case x =>
+            Target.raiseUserError(s"Unsure how to map $x")
+        })
+        .map(_.setTypeArguments(new NodeList(value)))
+
+    def liftVectorTerm(value: Node): Target[Node] =
+      buildMethodCall("java.util.Collections.singletonList", Some(value))
+
+    def emptyArray(): Target[Node] =
+      for {
+        cls <- safeParseClassOrInterfaceType("java.util.ArrayList")
+      } yield new ObjectCreationExpr(null, cls.setTypeArguments(new NodeList[Type]), new NodeList())
+
+    def embedArray(tpe: LazyResolvedType[JavaLanguage], containerTpe: Option[Type]): Target[LazyResolvedType[JavaLanguage]] =
+      tpe match {
+        case SwaggerUtil.Deferred(tpe) =>
+          Target.pure(SwaggerUtil.DeferredArray[JavaLanguage](tpe, containerTpe))
+        case SwaggerUtil.DeferredArray(_, _) =>
+          Target.raiseUserError("FIXME: Got an Array of Arrays, currently not supported")
+        case SwaggerUtil.DeferredMap(_, _) =>
+          Target.raiseUserError("FIXME: Got an Array of Maps, currently not supported")
+      }
+
+    def liftMapType(value: Type, customTpe: Option[Type]): Target[Type] =
+      customTpe
+        .fold[Target[ClassOrInterfaceType]](safeParseClassOrInterfaceType("java.util.Map").map(identity))({
+          case t: ClassOrInterfaceType =>
+            Target.pure(t)
+          case x =>
+            Target.raiseUserError(s"Unsure how to map $x")
+        })
+        .map(_.setTypeArguments(STRING_TYPE, value))
+
+    def emptyMap(): Target[Node] =
+      Target.pure(
+        new ObjectCreationExpr(null, StaticJavaParser.parseClassOrInterfaceType("java.util.HashMap").setTypeArguments(new NodeList[Type]), new NodeList())
+      )
+
+    def embedMap(tpe: LazyResolvedType[JavaLanguage], containerTpe: Option[Type]): Target[LazyResolvedType[JavaLanguage]] =
+      tpe match {
+        case SwaggerUtil.Deferred(inner) =>
+          Target.pure(SwaggerUtil.DeferredMap[JavaLanguage](inner, containerTpe))
+        case SwaggerUtil.DeferredMap(_, _) =>
+          Target.raiseUserError("FIXME: Got a map of maps, currently not supported")
+        case SwaggerUtil.DeferredArray(_, _) =>
+          Target.raiseUserError("FIXME: Got a map of arrays, currently not supported")
+      }
+  }
+}

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/collections/JavaCollectionsGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/collections/JavaCollectionsGenerator.scala
@@ -14,7 +14,7 @@ import com.twilio.guardrail.terms.CollectionsLibTerms
 
 object JavaCollectionsGenerator {
 
-  object JavaCollectionsInterp extends CollectionsLibTerms[JavaLanguage, Target] {
+  class JavaCollectionsInterp extends CollectionsLibTerms[JavaLanguage, Target] {
     implicit def MonadF: Monad[Target] = Target.targetInstances
 
     def vendorPrefixes(): Target[List[String]] = Target.pure(List("x-java", "x-jvm"))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/collections/ScalaCollectionsGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/collections/ScalaCollectionsGenerator.scala
@@ -1,0 +1,47 @@
+package com.twilio.guardrail.generators.collections
+
+import cats.Monad
+import com.twilio.guardrail.SwaggerUtil.LazyResolvedType
+import com.twilio.guardrail.languages.ScalaLanguage
+import com.twilio.guardrail.terms.CollectionsLibTerms
+import com.twilio.guardrail.{ SwaggerUtil, Target }
+import scala.meta._
+
+object ScalaCollectionsGenerator {
+  object ScalaCollectionsInterp extends CollectionsLibTerms[ScalaLanguage, Target] {
+    implicit def MonadF: Monad[Target] = Target.targetInstances
+
+    def vendorPrefixes(): Target[List[String]] = Target.pure(List("x-scala", "x-jvm"))
+
+    def liftOptionalType(value: Type): Target[Type] = Target.pure(t"Option[$value]")
+    def liftOptionalTerm(value: Term): Target[Term] = Target.pure(q"Option($value)")
+    def liftSomeTerm(value: Term): Target[Term]     = Target.pure(q"Some($value)")
+    def emptyOptionalTerm(): Target[Term]           = Target.pure(q"None")
+
+    def arrayType(format: Option[String]): Target[Type] = Target.pure(t"Iterable[String]")
+    def liftVectorType(value: Type, customTpe: Option[Type]): Target[Type] =
+      Target.pure(t"${customTpe.getOrElse(t"Vector")}[$value]")
+    def liftVectorTerm(value: Term): Target[Term] = Target.pure(q"Vector($value)")
+    def emptyArray(): Target[Term]                = Target.pure(q"Vector.empty")
+    def embedArray(tpe: LazyResolvedType[ScalaLanguage], containerTpe: Option[Type]): Target[LazyResolvedType[ScalaLanguage]] = tpe match {
+      case SwaggerUtil.Deferred(tpe) =>
+        Target.pure(SwaggerUtil.DeferredArray[ScalaLanguage](tpe, containerTpe))
+      case SwaggerUtil.DeferredArray(_, _) =>
+        Target.raiseUserError("FIXME: Got an Array of Arrays, currently not supported")
+      case SwaggerUtil.DeferredMap(_, _) =>
+        Target.raiseUserError("FIXME: Got an Array of Maps, currently not supported")
+    }
+
+    def liftMapType(value: Type, customTpe: Option[Type]): Target[Type] =
+      Target.pure(t"${customTpe.getOrElse(t"Map")}[String, $value]")
+    def emptyMap(): Target[Term] = Target.pure(q"Map.empty")
+    def embedMap(tpe: LazyResolvedType[ScalaLanguage], containerTpe: Option[Type]): Target[LazyResolvedType[ScalaLanguage]] = tpe match {
+      case SwaggerUtil.Deferred(inner) =>
+        Target.pure(SwaggerUtil.DeferredMap[ScalaLanguage](inner, containerTpe))
+      case SwaggerUtil.DeferredMap(_, _) =>
+        Target.raiseUserError("FIXME: Got a map of maps, currently not supported")
+      case SwaggerUtil.DeferredArray(_, _) =>
+        Target.raiseUserError("FIXME: Got a map of arrays, currently not supported")
+    }
+  }
+}

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/Java.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/Java.scala
@@ -18,8 +18,9 @@ import scala.util.{ Failure, Success, Try }
 
 object Java {
   implicit class RichType(private val tpe: Type) extends AnyVal {
-    // This should be replaced with something more generic that doesn't rely on type naming, but will
+    // These two should be replaced with something more generic that doesn't rely on type naming, but will
     // likely require a bit of surgery to do so
+
     def isOptional: Boolean =
       tpe match {
         case cls: ClassOrInterfaceType =>
@@ -136,7 +137,7 @@ object Java {
   def safeParseRawStaticImport(s: String): Target[ImportDeclaration] = safeParse("safeParseStaticImport")(StaticJavaParser.parseImport, s"import static ${s};")
 
   def completionStageType(of: Type): ClassOrInterfaceType     = StaticJavaParser.parseClassOrInterfaceType("CompletionStage").setTypeArguments(of)
-  def optionalType(of: Type): ClassOrInterfaceType            = StaticJavaParser.parseClassOrInterfaceType("Optional").setTypeArguments(of)
+  def javaOptionalType(of: Type): ClassOrInterfaceType        = StaticJavaParser.parseClassOrInterfaceType("java.util.Optional").setTypeArguments(of)
   def functionType(in: Type, out: Type): ClassOrInterfaceType = StaticJavaParser.parseClassOrInterfaceType("Function").setTypeArguments(in, out)
   def supplierType(of: Type): ClassOrInterfaceType            = StaticJavaParser.parseClassOrInterfaceType("Supplier").setTypeArguments(of)
   def listType(of: Type): ClassOrInterfaceType                = StaticJavaParser.parseClassOrInterfaceType("List").setTypeArguments(of)
@@ -169,7 +170,7 @@ object Java {
   def requireNonNullExpr(paramName: String): Expression = requireNonNullExpr(new NameExpr(paramName))
 
   def optionalOfExpr(param: Expression): Expression = new MethodCallExpr(
-    new NameExpr("Optional"),
+    new NameExpr("java.util.Optional"),
     "of",
     new NodeList[Expression](
       requireNonNullExpr(param)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/Java.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/Java.scala
@@ -173,6 +173,12 @@ object Java {
     new NodeList[Expression](param)
   )
 
+  def buildMethodCall(name: String, arg: Option[Node] = None): Target[Node] = arg match {
+    case Some(expr: Expression) => Target.pure(new MethodCallExpr(name, expr))
+    case None                   => Target.pure(new MethodCallExpr(name))
+    case other                  => Target.raiseUserError(s"Need expression to call '${name}' but got a ${other.getClass.getName} instead")
+  }
+
   val GENERATED_CODE_COMMENT: Comment = new BlockComment(GENERATED_CODE_COMMENT_LINES.mkString("\n * ", "\n * ", "\n"))
 
   // from https://en.wikipedia.org/wiki/List_of_Java_keywords

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/Java.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/Java.scala
@@ -18,17 +18,6 @@ import scala.util.{ Failure, Success, Try }
 
 object Java {
   implicit class RichType(private val tpe: Type) extends AnyVal {
-    // These two should be replaced with something more generic that doesn't rely on type naming, but will
-    // likely require a bit of surgery to do so
-
-    def isOptional: Boolean =
-      tpe match {
-        case cls: ClassOrInterfaceType =>
-          val scope = cls.getScope.asScala
-          cls.getNameAsString == "Optional" && (scope.isEmpty || scope.map(_.asString).contains("java.util"))
-        case _ => false
-      }
-
     def containedType: Type =
       tpe match {
         case cls: ClassOrInterfaceType => cls.getTypeArguments.asScala.filter(_.size == 1).fold(tpe)(_.get(0))
@@ -140,10 +129,6 @@ object Java {
   def javaOptionalType(of: Type): ClassOrInterfaceType        = StaticJavaParser.parseClassOrInterfaceType("java.util.Optional").setTypeArguments(of)
   def functionType(in: Type, out: Type): ClassOrInterfaceType = StaticJavaParser.parseClassOrInterfaceType("Function").setTypeArguments(in, out)
   def supplierType(of: Type): ClassOrInterfaceType            = StaticJavaParser.parseClassOrInterfaceType("Supplier").setTypeArguments(of)
-  def listType(of: Type): ClassOrInterfaceType                = StaticJavaParser.parseClassOrInterfaceType("List").setTypeArguments(of)
-  def mapType(key: Type, value: Type): ClassOrInterfaceType   = StaticJavaParser.parseClassOrInterfaceType("Map").setTypeArguments(key, value)
-  def mapEntryType(key: Type, value: Type): ClassOrInterfaceType =
-    StaticJavaParser.parseClassOrInterfaceType("Map.Entry").setTypeArguments(new NodeList(key, value))
 
   val VOID_TYPE: ClassOrInterfaceType            = StaticJavaParser.parseClassOrInterfaceType("Void")
   val OBJECT_TYPE: ClassOrInterfaceType          = StaticJavaParser.parseClassOrInterfaceType("Object")

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/package.scala
@@ -6,7 +6,7 @@ import com.twilio.guardrail.protocol.terms.client.ClientTerms
 import com.twilio.guardrail.protocol.terms.protocol._
 import com.twilio.guardrail.protocol.terms.server.ServerTerms
 import com.twilio.guardrail.terms.framework.FrameworkTerms
-import com.twilio.guardrail.terms.{ CoreTerms, LanguageTerms, SwaggerTerms }
+import com.twilio.guardrail.terms.{ CollectionsLibTerms, CoreTerms, LanguageTerms, SwaggerTerms }
 
 package guardrail {
   case class CodegenDefinitions[L <: LA](
@@ -17,7 +17,10 @@ package guardrail {
   )
 }
 
-trait MonadChain11 {
+trait MonadChain12 {
+  implicit def monadForCollectionsLib[L <: LA, F[_]](implicit ev: CollectionsLibTerms[L, F]): Monad[F] = ev.MonadF
+}
+trait MonadChain11 extends MonadChain12 {
   implicit def monadForProtocolSupportTerms[L <: LA, F[_]](implicit ev: ProtocolSupportTerms[L, F]): Monad[F] = ev.MonadF
 }
 trait MonadChain10 extends MonadChain11 {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/Responses.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/Responses.scala
@@ -4,7 +4,7 @@ import cats.implicits._
 import com.twilio.guardrail.core.Tracker
 import com.twilio.guardrail.languages.LA
 import com.twilio.guardrail.terms.framework.FrameworkTerms
-import com.twilio.guardrail.terms.{ LanguageTerms, SwaggerTerms }
+import com.twilio.guardrail.terms.{ CollectionsLibTerms, LanguageTerms, SwaggerTerms }
 import com.twilio.guardrail.{ StrictProtocolElems, SwaggerUtil, monadForFrameworkTerms }
 import io.swagger.v3.oas.models.Operation
 import scala.collection.JavaConverters._
@@ -24,8 +24,10 @@ object Responses {
   def getResponses[L <: LA, F[_]](operationId: String, operation: Tracker[Operation], protocolElems: List[StrictProtocolElems[L]])(
       implicit Fw: FrameworkTerms[L, F],
       Sc: LanguageTerms[L, F],
+      Cl: CollectionsLibTerms[L, F],
       Sw: SwaggerTerms[L, F]
   ): F[Responses[L]] = Sw.log.function("getResponses") {
+    import Cl._
     import Fw._
     import Sc._
     for {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/client/ClientTerms.scala
@@ -5,11 +5,11 @@ import cats.data.NonEmptyList
 import com.twilio.guardrail.generators.LanguageParameters
 import com.twilio.guardrail.languages.LA
 import com.twilio.guardrail.protocol.terms.Responses
-import com.twilio.guardrail.terms.{ RouteMeta, SecurityScheme }
+import com.twilio.guardrail.terms.{ CollectionsLibTerms, RouteMeta, SecurityScheme }
 import com.twilio.guardrail.{ RenderedClientOperation, StaticDefns, StrictProtocolElems, SupportDefinition }
 import java.net.URI
 
-abstract class ClientTerms[L <: LA, F[_]] {
+abstract class ClientTerms[L <: LA, F[_]](implicit Cl: CollectionsLibTerms[L, F]) {
   def MonadF: Monad[F]
   def generateClientOperation(
       className: List[String],

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ArrayProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ArrayProtocolTerms.scala
@@ -3,8 +3,9 @@ package com.twilio.guardrail.protocol.terms.protocol
 import cats.Monad
 import com.twilio.guardrail.languages.LA
 import com.twilio.guardrail.SwaggerUtil
+import com.twilio.guardrail.terms.CollectionsLibTerms
 
-abstract class ArrayProtocolTerms[L <: LA, F[_]] {
+abstract class ArrayProtocolTerms[L <: LA, F[_]](implicit Cl: CollectionsLibTerms[L, F]) {
   def MonadF: Monad[F]
   def extractArrayType(arr: SwaggerUtil.ResolvedType[L], concreteTypes: List[PropMeta[L]]): F[L#Type]
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/EnumProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/EnumProtocolTerms.scala
@@ -4,8 +4,9 @@ import _root_.io.swagger.v3.oas.models.media.Schema
 import cats.Monad
 import com.twilio.guardrail.StaticDefns
 import com.twilio.guardrail.languages.LA
+import com.twilio.guardrail.terms.CollectionsLibTerms
 
-abstract class EnumProtocolTerms[L <: LA, F[_]] {
+abstract class EnumProtocolTerms[L <: LA, F[_]](implicit Cl: CollectionsLibTerms[L, F]) {
   def MonadF: Monad[F]
   def extractEnum(swagger: Schema[_]): F[Either[String, List[String]]]
   def renderMembers(clsName: String, elems: List[(String, L#TermName, L#TermSelect)]): F[Option[L#ObjectDefinition]]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerms.scala
@@ -1,13 +1,14 @@
 package com.twilio.guardrail.protocol.terms.protocol
 
-import io.swagger.v3.oas.models.media.Schema
 import cats.Monad
-import com.twilio.guardrail.{ ProtocolParameter, StaticDefns, SuperClass }
+import com.twilio.guardrail.SwaggerUtil.ResolvedType
 import com.twilio.guardrail.core.Tracker
 import com.twilio.guardrail.languages.LA
-import com.twilio.guardrail.SwaggerUtil.ResolvedType
+import com.twilio.guardrail.terms.CollectionsLibTerms
+import com.twilio.guardrail.{ ProtocolParameter, StaticDefns, SuperClass }
+import io.swagger.v3.oas.models.media.Schema
 
-abstract class ModelProtocolTerms[L <: LA, F[_]] {
+abstract class ModelProtocolTerms[L <: LA, F[_]](implicit Cl: CollectionsLibTerms[L, F]) {
   def MonadF: Monad[F]
   def extractProperties(swagger: Tracker[Schema[_]]): F[List[(String, Tracker[Schema[_]])]]
   def transformProperty(

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/PolyProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/PolyProtocolTerms.scala
@@ -4,12 +4,13 @@ import cats.Monad
 import com.twilio.guardrail.{ Discriminator, ProtocolParameter, StaticDefns, SuperClass }
 import com.twilio.guardrail.core.Tracker
 import com.twilio.guardrail.languages.LA
+import com.twilio.guardrail.terms.CollectionsLibTerms
 import io.swagger.v3.oas.models.media.{ ComposedSchema, Schema }
 
 /**
   * Protocol for Polymorphic models
   */
-abstract class PolyProtocolTerms[L <: LA, F[_]] {
+abstract class PolyProtocolTerms[L <: LA, F[_]](implicit Cl: CollectionsLibTerms[L, F]) {
   def MonadF: Monad[F]
   def extractSuperClass(
       swagger: Tracker[ComposedSchema],

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ProtocolSupportTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ProtocolSupportTerms.scala
@@ -3,8 +3,9 @@ package com.twilio.guardrail.protocol.terms.protocol
 import cats.Monad
 import com.twilio.guardrail.SupportDefinition
 import com.twilio.guardrail.languages.LA
+import com.twilio.guardrail.terms.CollectionsLibTerms
 
-abstract class ProtocolSupportTerms[L <: LA, F[_]] {
+abstract class ProtocolSupportTerms[L <: LA, F[_]](implicit Cl: CollectionsLibTerms[L, F]) {
   def MonadF: Monad[F]
   def extractConcreteTypes(models: Either[String, List[PropMeta[L]]]): F[List[PropMeta[L]]]
   def staticProtocolImports(pkgName: List[String]): F[List[L#Import]]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerms.scala
@@ -5,7 +5,7 @@ import com.twilio.guardrail.core.Tracker
 import com.twilio.guardrail.generators.LanguageParameters
 import com.twilio.guardrail.languages.LA
 import com.twilio.guardrail.protocol.terms.Responses
-import com.twilio.guardrail.terms.{ RouteMeta, SecurityScheme }
+import com.twilio.guardrail.terms.{ CollectionsLibTerms, RouteMeta, SecurityScheme }
 import com.twilio.guardrail.{ RenderedRoutes, StrictProtocolElems, SupportDefinition, TracingField }
 import io.swagger.v3.oas.models.Operation
 
@@ -19,7 +19,7 @@ case class GenerateRouteMeta[L <: LA](
     responses: Responses[L]
 )
 
-abstract class ServerTerms[L <: LA, F[_]] {
+abstract class ServerTerms[L <: LA, F[_]](implicit Cl: CollectionsLibTerms[L, F]) {
   def MonadF: Monad[F]
   def buildTracingFields(operation: Tracker[Operation], resourceName: List[String], tracing: Boolean): F[Option[TracingField[L]]]
   def generateRoutes(

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/CollectionsLibTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/CollectionsLibTerms.scala
@@ -1,0 +1,58 @@
+package com.twilio.guardrail.terms
+
+import cats.Monad
+import com.twilio.guardrail.SwaggerUtil.LazyResolvedType
+import com.twilio.guardrail.languages.LA
+
+abstract class CollectionsLibTerms[L <: LA, F[_]] {
+  def MonadF: Monad[F]
+
+  def vendorPrefixes(): F[List[String]]
+
+  def liftOptionalType(value: L#Type): F[L#Type]
+  def liftOptionalTerm(value: L#Term): F[L#Term]
+  def liftSomeTerm(value: L#Term): F[L#Term]
+  def emptyOptionalTerm(): F[L#Term]
+
+  def arrayType(format: Option[String]): F[L#Type]
+  def liftVectorType(value: L#Type, customTpe: Option[L#Type]): F[L#Type]
+  def liftVectorTerm(value: L#Term): F[L#Term]
+  def emptyArray(): F[L#Term]
+  def embedArray(tpe: LazyResolvedType[L], customTpe: Option[L#Type]): F[LazyResolvedType[L]]
+
+  def liftMapType(value: L#Type, customTpe: Option[L#Type]): F[L#Type]
+  def emptyMap(): F[L#Term]
+  def embedMap(tpe: LazyResolvedType[L], customTpe: Option[L#Type]): F[LazyResolvedType[L]]
+
+  def copy(
+      newMonadF: Monad[F] = MonadF,
+      newVendorPrefixes: () => F[List[String]] = vendorPrefixes _,
+      newLiftOptionalType: L#Type => F[L#Type] = liftOptionalType,
+      newLiftOptionalTerm: L#Term => F[L#Term] = liftOptionalTerm,
+      newLiftSomeTerm: L#Term => F[L#Term] = liftSomeTerm,
+      newEmptyOptionalTerm: () => F[L#Term] = emptyOptionalTerm _,
+      newArrayType: Option[String] => F[L#Type] = arrayType,
+      newLiftVectorType: (L#Type, Option[L#Type]) => F[L#Type] = liftVectorType,
+      newLiftVectorTerm: L#Term => F[L#Term] = liftVectorTerm,
+      newEmptyArray: () => F[L#Term] = emptyArray _,
+      newEmbedArray: (LazyResolvedType[L], Option[L#Type]) => F[LazyResolvedType[L]] = embedArray,
+      newLiftMapType: (L#Type, Option[L#Type]) => F[L#Type] = liftMapType,
+      newEmptyMap: () => F[L#Term] = emptyMap _,
+      newEmbedMap: (LazyResolvedType[L], Option[L#Type]) => F[LazyResolvedType[L]] = embedMap
+  ): CollectionsLibTerms[L, F] = new CollectionsLibTerms[L, F] {
+    def MonadF: Monad[F]                                                = newMonadF
+    def vendorPrefixes()                                                = newVendorPrefixes()
+    def liftOptionalType(value: L#Type)                                 = newLiftOptionalType(value)
+    def liftOptionalTerm(value: L#Term)                                 = newLiftOptionalTerm(value)
+    def liftSomeTerm(value: L#Term)                                     = newLiftSomeTerm(value)
+    def emptyOptionalTerm()                                             = newEmptyOptionalTerm()
+    def arrayType(format: Option[String])                               = newArrayType(format)
+    def liftVectorType(value: L#Type, customTpe: Option[L#Type])        = newLiftVectorType(value, customTpe)
+    def liftVectorTerm(value: L#Term)                                   = newLiftVectorTerm(value)
+    def emptyArray()                                                    = newEmptyArray()
+    def embedArray(tpe: LazyResolvedType[L], customTpe: Option[L#Type]) = newEmbedArray(tpe, customTpe)
+    def liftMapType(value: L#Type, customTpe: Option[L#Type])           = newLiftMapType(value, customTpe)
+    def emptyMap()                                                      = newEmptyMap()
+    def embedMap(tpe: LazyResolvedType[L], customTpe: Option[L#Type])   = newEmbedMap(tpe, customTpe)
+  }
+}

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
@@ -14,10 +14,9 @@ import com.twilio.guardrail.terms.SecurityRequirements.SecurityScopes
 import com.twilio.guardrail.terms.framework.FrameworkTerms
 import io.swagger.v3.oas.models.PathItem.HttpMethod
 import io.swagger.v3.oas.models.media._
-import io.swagger.v3.oas.models.parameters.{ Parameter, RequestBody }
-import io.swagger.v3.oas.models.responses.ApiResponse
+import io.swagger.v3.oas.models.parameters.Parameter
 import io.swagger.v3.oas.models.security.{ OAuthFlows, SecurityRequirement, SecurityScheme => SwSecurityScheme }
-import io.swagger.v3.oas.models.{ Components, Operation, PathItem }
+import io.swagger.v3.oas.models.Operation
 import java.net.URI
 import scala.collection.JavaConverters._
 import scala.collection.immutable.TreeMap
@@ -237,7 +236,7 @@ case class RouteMeta(path: Tracker[String], method: HttpMethod, operation: Track
 
   def getParameters[L <: LA, F[_]](
       protocolElems: List[StrictProtocolElems[L]]
-  )(implicit Fw: FrameworkTerms[L, F], Sc: LanguageTerms[L, F], Sw: SwaggerTerms[L, F]): F[LanguageParameters[L]] =
+  )(implicit Fw: FrameworkTerms[L, F], Sc: LanguageTerms[L, F], Cl: CollectionsLibTerms[L, F], Sw: SwaggerTerms[L, F]): F[LanguageParameters[L]] =
     for {
       a <- LanguageParameter.fromParameters(protocolElems).apply(parameters)
     } yield new LanguageParameters[L](a)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/framework/FrameworkTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/framework/FrameworkTerms.scala
@@ -3,8 +3,9 @@ package terms.framework
 
 import cats.Monad
 import com.twilio.guardrail.languages.LA
+import com.twilio.guardrail.terms.CollectionsLibTerms
 
-abstract class FrameworkTerms[L <: LA, F[_]] {
+abstract class FrameworkTerms[L <: LA, F[_]](implicit Cl: CollectionsLibTerms[L, F]) {
   def MonadF: Monad[F]
   def getFrameworkImports(tracing: Boolean): F[List[L#Import]]
   def getFrameworkImplicits(): F[Option[(L#TermName, L#ObjectDefinition)]]

--- a/modules/codegen/src/test/scala/core/issues/Issue314.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue314.scala
@@ -247,12 +247,12 @@ class Issue314 extends AnyFunSpec with Matchers with SwaggerSpecRunner {
          |        }
          |
          |        public Builder withHttpClient(final Function<Request, CompletionStage<Response>> httpClient) {
-         |            this.httpClient = java.util.Optional.of(requireNonNull(httpClient, "httpClient is required"));
+         |            this.httpClient = java.util.Optional.ofNullable(httpClient);
          |            return this;
          |        }
          |
          |        public Builder withObjectMapper(final ObjectMapper objectMapper) {
-         |            this.objectMapper = java.util.Optional.of(requireNonNull(JacksonSupport.configureObjectMapper(objectMapper), "configureObjectMapper is required"));
+         |            this.objectMapper = java.util.Optional.ofNullable(JacksonSupport.configureObjectMapper(objectMapper));
          |            return this;
          |        }
          |

--- a/modules/codegen/src/test/scala/core/issues/Issue314.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue314.scala
@@ -234,9 +234,9 @@ class Issue314 extends AnyFunSpec with Matchers with SwaggerSpecRunner {
          |
          |        private URI baseUrl = DEFAULT_BASE_URL;
          |
-         |        private Optional<Function<Request, CompletionStage<Response>>> httpClient = Optional.empty();
+         |        private java.util.Optional<Function<Request, CompletionStage<Response>>> httpClient = java.util.Optional.empty();
          |
-         |        private Optional<ObjectMapper> objectMapper = Optional.empty();
+         |        private java.util.Optional<ObjectMapper> objectMapper = java.util.Optional.empty();
          |
          |        public Builder() {
          |        }
@@ -247,12 +247,12 @@ class Issue314 extends AnyFunSpec with Matchers with SwaggerSpecRunner {
          |        }
          |
          |        public Builder withHttpClient(final Function<Request, CompletionStage<Response>> httpClient) {
-         |            this.httpClient = Optional.of(requireNonNull(httpClient, "httpClient is required"));
+         |            this.httpClient = java.util.Optional.of(requireNonNull(httpClient, "httpClient is required"));
          |            return this;
          |        }
          |
          |        public Builder withObjectMapper(final ObjectMapper objectMapper) {
-         |            this.objectMapper = Optional.of(requireNonNull(JacksonSupport.configureObjectMapper(objectMapper), "configureObjectMapper is required"));
+         |            this.objectMapper = java.util.Optional.of(requireNonNull(JacksonSupport.configureObjectMapper(objectMapper), "configureObjectMapper is required"));
          |            return this;
          |        }
          |


### PR DESCRIPTION
This splits all the collections-library related functionality out of `LanguageTerms` and puts it in a new `CollectionsLibTerms` class.  The impetus for this is supporting [Vavr](https://vavr.io/) as an alternative for `java.util.{Optional,List,Map}`.

This also makes the dropwizard framework collections-lib-agnostic.  I haven't audited the spring framework to see what needs to be changed, and there's currently no need to mess with the scala generators, as I don't know that there's even a need for an alternative collections library there.

In another PR I'll add the actual Vavr support.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
