### PR TITLE
fix Java 'equals' method

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -385,6 +385,7 @@ val dropwizardProjectDependencies = Seq(
   "org.scala-lang.modules"     %% "scala-java8-compat"     % "0.9.1"            % Test,
   "org.scalatest"              %% "scalatest"              % scalatestVersion   % Test,
   "junit"                      %  "junit"                  % "4.13"             % Test,
+  "nl.jqno.equalsverifier"     %  "equalsverifier"         % "3.4.2"            % Test,
   "com.novocode"               %  "junit-interface"        % "0.11"             % Test,
   "org.mockito"                %% "mockito-scala"          % "1.15.0"           % Test,
   "com.github.tomakehurst"     %  "wiremock"               % "1.58"             % Test,

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
@@ -509,9 +509,9 @@ object JacksonGenerator {
                 )
               case _ =>
                 new MethodCallExpr(
-                  parameterGetterCall(term),
+                  new NameExpr("java.util.Objects"),
                   "equals",
-                  new NodeList[Expression](parameterGetterCall(term, Some("other")))
+                  new NodeList[Expression](new FieldAccessExpr(new ThisExpr, term.parameterName), parameterGetterCall(term, Some("other")))
                 )
             }
         )

--- a/modules/sample-dropwizard/src/test/java/core/Dropwizard/EqualsVerifierTest.java
+++ b/modules/sample-dropwizard/src/test/java/core/Dropwizard/EqualsVerifierTest.java
@@ -1,0 +1,29 @@
+package core.Dropwizard;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+import org.junit.Test;
+
+public class EqualsVerifierTest {
+
+    @Test
+    public void testEqualsContract() {
+        // client classes
+        verify(examples.client.dropwizard.definitions.ApiResponse.class);
+        verify(examples.client.dropwizard.definitions.OrderStatus.class);
+        verify(examples.client.dropwizard.definitions.Pet.class);
+        verify(examples.client.dropwizard.definitions.User.class);
+
+        // server classes
+        verify(examples.server.dropwizard.definitions.ApiResponse.class);
+        verify(examples.server.dropwizard.definitions.OrderStatus.class);
+        verify(examples.server.dropwizard.definitions.Pet.class);
+        verify(examples.server.dropwizard.definitions.User.class);
+    }
+
+    private static void verify(Class clazz) {
+        EqualsVerifier.forClass(clazz)
+                .usingGetClass()
+                .verify();
+    }
+}


### PR DESCRIPTION
The Java code generator was producing an 'equals' method that could not pass the
verification logic in the [equalsverifier] library.

I have added an EqualsVerifier unit test and adjusted the Java code generator
so that Guardrail's Java classes comply with [equalsverifier]

Reference:
https://github.com/jqno/equalsverifier

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
