### PR TITLE
Support text/plain in akka-http server responses

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
@@ -671,7 +671,7 @@ object AsyncHttpClientClientGenerator {
                                     new NodeList()
                                   )
                                 )
-                              case Some((valueType, _)) =>
+                              case Some((contentType, valueType, _)) =>
                                 new TryStmt(
                                   new BlockStmt(
                                     new NodeList(

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
@@ -101,7 +101,7 @@ object DropwizardServerGenerator {
         .setExtendedTypes(new NodeList(superClassType))
 
       val (classDecls, creator) = response.value
-        .map(_._1)
+        .map(_._2)
         .orElse({
           if (response.statusCode >= 400 && response.statusCode <= 599) {
             errorEntityFallbackType

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvcServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvcServerGenerator.scala
@@ -179,7 +179,7 @@ object SpringMvcServerGenerator {
         .setExtendedTypes(new NodeList(superClassType))
 
       val (classDecls, creator) = response.value
-        .map(_._1)
+        .map(_._2)
         .orElse({
           if (response.statusCode >= 400 && response.statusCode <= 599) {
             errorEntityFallbackType

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpClientGenerator.scala
@@ -266,7 +266,7 @@ object AkkaHttpClientGenerator {
             (resp.value, resp.headers.value) match {
               case (None, Nil) =>
                 p"case StatusCodes.${resp.statusCodeName} => resp.discardEntityBytes().future.map(_ => Right($responseCompanionTerm.$responseTerm))"
-              case (Some((tpe, _)), Nil) =>
+              case (Some((_, tpe, _)), Nil) =>
                 p"case StatusCodes.${resp.statusCodeName} => Unmarshal(resp.entity).to[${tpe}](${Term
                   .Name(s"$methodName${resp.statusCodeName}Decoder")}, implicitly, implicitly).map(x => Right($responseCompanionTerm.$responseTerm(x)))"
               case (None, headers) =>
@@ -278,7 +278,7 @@ object AkkaHttpClientGenerator {
                    ..$optionalVals
                    resp.discardEntityBytes().future.map(_ => $body)
                 """
-              case (Some((tpe, _)), headers) =>
+              case (Some((_, tpe, _)), headers) =>
                 val (optionalVals, body) = buildHeaders(
                   headers,
                   q"$responseCompanionTerm.$responseTerm(..${Term
@@ -533,7 +533,7 @@ object AkkaHttpClientGenerator {
     def generateDecoders(methodName: String, responses: Responses[ScalaLanguage], produces: Tracker[NonEmptyList[ContentType]]): Target[List[Defn.Val]] =
       (for {
         resp <- responses.value
-        tpe  <- resp.value.map(_._1).toList
+        tpe  <- resp.value.map(_._2).toList
       } yield {
         for {
           (decoder, baseType) <- AkkaHttpHelper.generateDecoder(tpe, produces, modelGeneratorType)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpServerGenerator.scala
@@ -18,7 +18,6 @@ import com.twilio.guardrail.protocol.terms.server._
 import com.twilio.guardrail.terms.{ CollectionsLibTerms, RouteMeta, SecurityScheme }
 import com.twilio.guardrail.shims._
 import scala.meta._
-import scala.meta.Mod.Contravariant
 import _root_.io.swagger.v3.oas.models.PathItem.HttpMethod
 import _root_.io.swagger.v3.oas.models.Operation
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpServerGenerator.scala
@@ -45,21 +45,21 @@ object AkkaHttpServerGenerator {
           case resp =>
             val statusCodeName = resp.statusCodeName
             val statusCode     = q"StatusCodes.${statusCodeName}"
-            val valueType      = resp.value.map(_._1)
             val responseTerm   = Term.Name(s"${responseClsName}${statusCodeName.value}")
             val responseName   = Type.Name(s"${responseClsName}${statusCodeName.value}")
-            valueType.fold[(Defn, Defn, Case)](
+            resp.value.fold[(Defn, Defn, Case)](
               (
                 q"case object $responseTerm                      extends $responseSuperType($statusCode)",
                 q"def $statusCodeName: $responseSuperType = $responseTerm",
                 p"case r: $responseTerm.type => scala.concurrent.Future.successful(Marshalling.Opaque { () => HttpResponse(r.statusCode) } :: Nil)"
               )
-            ) { valueType =>
-              (
-                q"case class  $responseName(value: $valueType) extends $responseSuperType($statusCode)",
-                q"def $statusCodeName(value: $valueType): $responseSuperType = $responseTerm(value)",
-                p"case r@$responseTerm(value) => Marshal(value).to[ResponseEntity].map { entity => Marshalling.Opaque { () => HttpResponse(r.statusCode, entity=entity) } :: Nil }"
-              )
+            ) {
+              case (contentType, valueType, _) =>
+                (
+                  q"case class  $responseName(value: $valueType) extends $responseSuperType($statusCode)",
+                  q"def $statusCodeName(value: $valueType): $responseSuperType = $responseTerm(value)",
+                  p"case r@$responseTerm(value) => Marshal(value).to[ResponseEntity].map { entity => Marshalling.Opaque { () => HttpResponse(r.statusCode, entity=entity) } :: Nil }"
+                )
             }
         }
         (terms, aliases, marshallers) = instances.unzip3

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/DropwizardServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/DropwizardServerGenerator.scala
@@ -256,7 +256,7 @@ object DropwizardServerGenerator {
             q"def ${response.statusCodeName}: $responseClsType = $responseClsSubTerm"
           )
         )({
-          case (valueType, _) =>
+          case (contentType, valueType, _) =>
             (
               q"case class $responseClsSubType(value: $valueType) extends $responseClsType($statusCodeTerm)",
               q"def ${response.statusCodeName}(value: $valueType): $responseClsType = $responseClsSubTerm(value)"

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/EndpointsClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/EndpointsClientGenerator.scala
@@ -232,7 +232,7 @@ object EndpointsClientGenerator {
                 p"""case ${Lit.Int(resp.statusCode)} =>
                   Right($responseCompanionTerm.$responseTerm(..$params))
                 """
-              case (Some((tpe, _)), headers) =>
+              case (Some((_, tpe, _)), headers) =>
                 val params = Term.Name("v") :: headers.map { header =>
                         val lit  = Lit.String(header.name)
                         val expr = q"xhr.getResponseHeader($lit)"

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sClientGenerator.scala
@@ -514,7 +514,7 @@ object Http4sClientGenerator {
     def generateDecoders(methodName: String, responses: Responses[ScalaLanguage], produces: Seq[ContentType]): List[Defn.Val] =
       for {
         resp <- responses.value
-        tpe  <- resp.value.map(_._1)
+        tpe  <- resp.value.map(_._2)
       } yield q"private[this] val ${Pat.Var(Term.Name(s"$methodName${resp.statusCodeName}Decoder"))} = ${Http4sHelper.generateDecoder(tpe, produces)}"
   }
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sHelper.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sHelper.scala
@@ -106,7 +106,7 @@ object Http4sHelper {
   def isDefinitionGeneric(responses: Responses[ScalaLanguage]): Boolean =
     responses.value.exists { response =>
       response.value.exists {
-        case (tpe, _) =>
+        case (_, tpe, _) =>
           tpe match {
             case t"fs2.Stream[F,Byte]" => true
             case _                     => false

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sServerGenerator.scala
@@ -826,9 +826,8 @@ object Http4sServerGenerator {
 
     def generateEncoders(methodName: String, responses: Responses[ScalaLanguage], produces: Seq[ContentType]): List[Defn.Val] =
       for {
-        response        <- responses.value
-        typeDefaultPair <- response.value
-        (tpe, _) = typeDefaultPair
+        response    <- responses.value
+        (_, tpe, _) <- response.value
       } yield {
         q"private[this] val ${Pat.Var(Term.Name(s"$methodName${response.statusCodeName}Encoder"))} = ${Http4sHelper.generateEncoder(tpe, produces)}"
       }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/helpers/DropwizardHelpers.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/helpers/DropwizardHelpers.scala
@@ -42,7 +42,7 @@ object DropwizardHelpers {
       fallbackIsString: L#Type => Boolean
   ): Option[ContentType] =
     response.value
-      .map(_._1)
+      .map(_._2)
       .flatMap({ valueType =>
         PRODUCES_PRIORITY
           .collectFirstSome(ct => contentTypes.find(_ == ct))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/Responses.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/Responses.scala
@@ -9,12 +9,17 @@ import com.twilio.guardrail.{ StrictProtocolElems, SwaggerUtil, monadForFramewor
 import io.swagger.v3.oas.models.Operation
 import scala.collection.JavaConverters._
 
-class Response[L <: LA](val statusCodeName: L#TermName, val statusCode: Int, val value: Option[(L#Type, Option[L#Term])], val headers: Headers[L]) {
+class Response[L <: LA](
+    val statusCodeName: L#TermName,
+    val statusCode: Int,
+    val value: Option[(ContentType, L#Type, Option[L#Term])],
+    val headers: Headers[L]
+) {
   override def toString: String = s"Response($statusCodeName, $statusCode, $value, $headers)"
 }
 object Response {
   def unapply[L <: LA](value: Response[L]): Option[(L#TermName, Option[L#Type], Headers[L])] =
-    Some((value.statusCodeName, value.value.map(_._1), value.headers))
+    Some((value.statusCodeName, value.value.map(_._2), value.headers))
 }
 
 class Responses[L <: LA](val value: List[Response[L]]) {
@@ -40,15 +45,16 @@ object Responses {
               httpCode <- lookupStatusCode(key)
               (statusCode, statusCodeName) = httpCode
               valueTypes <- (for {
-                (_, content) <- resp.downField("content", _.getContent()).indexedDistribute.value
-                schema       <- content.downField("schema", _.getSchema()).indexedDistribute.toList
-              } yield schema).traverse { prop =>
-                for {
-                  meta     <- SwaggerUtil.propMeta[L, F](prop)
-                  resolved <- SwaggerUtil.ResolvedType.resolve[L, F](meta, protocolElems)
-                  SwaggerUtil.Resolved(baseType, _, baseDefaultValue, _, _) = resolved
-
-                } yield (baseType, baseDefaultValue)
+                (rawContentType, content) <- resp.downField("content", _.getContent()).indexedDistribute.value
+                contentType               <- ContentType.unapply(rawContentType).toList
+                schema                    <- content.downField("schema", _.getSchema()).indexedDistribute.toList
+              } yield (contentType, schema)).traverse {
+                case (contentType, prop) =>
+                  for {
+                    meta     <- SwaggerUtil.propMeta[L, F](prop)
+                    resolved <- SwaggerUtil.ResolvedType.resolve[L, F](meta, protocolElems)
+                    SwaggerUtil.Resolved(baseType, _, baseDefaultValue, _, _) = resolved
+                  } yield (contentType, baseType, baseDefaultValue)
               }
               headers <- Option(resp.get.getHeaders).map(_.asScala.toList).getOrElse(List.empty).traverse {
                 case (name, header) =>

--- a/modules/sample-akkaHttp/src/test/scala/core/issues/Issue405.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/issues/Issue405.scala
@@ -40,7 +40,7 @@ class Issue405 extends AnyFunSuite with Matchers with EitherValues with ScalaFut
     /* Pass empty string to required Bar param */
     Post("/v1/Foo", FormData(Map("Bar" -> ""))) ~> route ~> check {
       response.status shouldBe (StatusCodes.OK)
-      responseAs[String] shouldBe "\"Bar is ''\""
+      responseAs[String] shouldBe "Bar is ''"
     }
   }
 
@@ -57,7 +57,7 @@ class Issue405 extends AnyFunSuite with Matchers with EitherValues with ScalaFut
     /* Pass empty string to required Bar param */
     Post("/v1/Foo", FormData(Map("Bar" -> "whatevs", "Baz" -> ""))) ~> route ~> check {
       response.status shouldBe (StatusCodes.OK)
-      responseAs[String] shouldBe "\"Baz is present: ''\""
+      responseAs[String] shouldBe "Baz is present: ''"
     }
   }
 
@@ -89,7 +89,7 @@ class Issue405 extends AnyFunSuite with Matchers with EitherValues with ScalaFut
     /* Pass empty string to required Bar param */
     Post("/v1/Foo", FormData(Map("Bar" -> "yo"))) ~> route ~> check {
       response.status shouldBe (StatusCodes.OK)
-      responseAs[String] shouldBe "\"Baz is missing\""
+      responseAs[String] shouldBe "Baz is missing"
     }
   }
 }

--- a/modules/sample-akkaHttp/src/test/scala/generators/AkkaHttp/Client/contentType/AkkaHttpTextPlainTest.scala
+++ b/modules/sample-akkaHttp/src/test/scala/generators/AkkaHttp/Client/contentType/AkkaHttpTextPlainTest.scala
@@ -31,7 +31,7 @@ class AkkaHttpTextPlainTest extends AnyFunSuite with Matchers with EitherValues 
     }
     val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
     val fooClient                                   = FooClient.httpClient(client)
-    new EitherTValuable(fooClient.doFoo("sample")).rightValue.futureValue shouldBe DoFooResponse.Created
+    fooClient.doFoo("sample").rightValue.futureValue shouldBe DoFooResponse.Created
   }
 
   test("Plain text should be emitted for optional parameters (raw)") {
@@ -115,6 +115,6 @@ class AkkaHttpTextPlainTest extends AnyFunSuite with Matchers with EitherValues 
 
     val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
     val fooClient                                   = FooClient.httpClient(client)
-    new EitherTValuable(fooClient.doBar(None)).rightValue.futureValue shouldBe DoBarResponse.Created
+    fooClient.doBar(None).rightValue.futureValue shouldBe DoBarResponse.Created
   }
 }

--- a/modules/sample-akkaHttp/src/test/scala/generators/AkkaHttp/Client/contentType/AkkaHttpTextPlainTest.scala
+++ b/modules/sample-akkaHttp/src/test/scala/generators/AkkaHttp/Client/contentType/AkkaHttpTextPlainTest.scala
@@ -38,7 +38,7 @@ class AkkaHttpTextPlainTest extends AnyFunSuite with Matchers with EitherValues 
     val route: Route = (path("bar") & extractRequestEntity & entity(as[String])) { (entity, value) =>
       complete({
         if (entity.contentType == ContentTypes.`text/plain(UTF-8)` && value == "sample") {
-          StatusCodes.Created
+          HttpResponse(StatusCodes.Created).withEntity(HttpEntity(ContentTypes.`text/plain(UTF-8)`, "response"))
         } else {
           StatusCodes.NotAcceptable
         }
@@ -46,7 +46,7 @@ class AkkaHttpTextPlainTest extends AnyFunSuite with Matchers with EitherValues 
     }
     val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
     val fooClient                                   = FooClient.httpClient(client)
-    new EitherTValuable(fooClient.doBar(Some("sample"))).rightValue.futureValue shouldBe DoBarResponse.Created
+    fooClient.doBar(Some("sample")).rightValue.futureValue shouldBe DoBarResponse.Created("response")
   }
 
   test("Plain text should be emitted for required parameters") {

--- a/modules/sample-akkaHttp/src/test/scala/generators/AkkaHttp/Client/contentType/AkkaHttpTextPlainTest.scala
+++ b/modules/sample-akkaHttp/src/test/scala/generators/AkkaHttp/Client/contentType/AkkaHttpTextPlainTest.scala
@@ -23,7 +23,7 @@ class AkkaHttpTextPlainTest extends AnyFunSuite with Matchers with EitherValues 
     val route: Route = (path("foo") & extractRequestEntity & entity(as[String])) { (entity, value) =>
       complete({
         if (entity.contentType == ContentTypes.`text/plain(UTF-8)` && value == "sample") {
-          StatusCodes.Created
+          HttpResponse(StatusCodes.Created).withEntity(HttpEntity(ContentTypes.`text/plain(UTF-8)`, "response"))
         } else {
           StatusCodes.NotAcceptable
         }
@@ -31,7 +31,7 @@ class AkkaHttpTextPlainTest extends AnyFunSuite with Matchers with EitherValues 
     }
     val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
     val fooClient                                   = FooClient.httpClient(client)
-    fooClient.doFoo("sample").rightValue.futureValue shouldBe DoFooResponse.Created
+    fooClient.doFoo("sample").rightValue.futureValue shouldBe DoFooResponse.Created("response")
   }
 
   test("Plain text should be emitted for optional parameters (raw)") {
@@ -55,7 +55,7 @@ class AkkaHttpTextPlainTest extends AnyFunSuite with Matchers with EitherValues 
           respond: tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.DoFooResponse.type
       )(body: String): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.DoFooResponse] =
         if (body == "sample") {
-          Future.successful(respond.Created)
+          Future.successful(respond.Created("response"))
         } else {
           Future.successful(respond.NotAcceptable)
         }
@@ -69,7 +69,7 @@ class AkkaHttpTextPlainTest extends AnyFunSuite with Matchers with EitherValues 
 
     val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
     val fooClient                                   = FooClient.httpClient(client)
-    new EitherTValuable(fooClient.doFoo("sample")).rightValue.futureValue shouldBe DoFooResponse.Created
+    fooClient.doFoo("sample").rightValue.futureValue shouldBe DoFooResponse.Created("response")
   }
 
   test("Plain text should be emitted for present optional parameters") {
@@ -81,7 +81,7 @@ class AkkaHttpTextPlainTest extends AnyFunSuite with Matchers with EitherValues 
           body: Option[String]
       ): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.DoBarResponse] =
         if (body.contains("sample")) {
-          Future.successful(respond.Created)
+          Future.successful(respond.Created("response"))
         } else {
           Future.successful(respond.NotAcceptable)
         }
@@ -92,7 +92,7 @@ class AkkaHttpTextPlainTest extends AnyFunSuite with Matchers with EitherValues 
 
     val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
     val fooClient                                   = FooClient.httpClient(client)
-    new EitherTValuable(fooClient.doBar(Some("sample"))).rightValue.futureValue shouldBe DoBarResponse.Created
+    fooClient.doBar(Some("sample")).rightValue.futureValue shouldBe DoBarResponse.Created("response")
   }
 
   test("Plain text should be emitted for missing optional parameters") {
@@ -104,7 +104,7 @@ class AkkaHttpTextPlainTest extends AnyFunSuite with Matchers with EitherValues 
           body: Option[String]
       ): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.DoBarResponse] =
         if (body.isEmpty) {
-          Future.successful(respond.Created)
+          Future.successful(respond.Created("response"))
         } else {
           Future.successful(respond.NotAcceptable)
         }
@@ -115,6 +115,6 @@ class AkkaHttpTextPlainTest extends AnyFunSuite with Matchers with EitherValues 
 
     val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
     val fooClient                                   = FooClient.httpClient(client)
-    fooClient.doBar(None).rightValue.futureValue shouldBe DoBarResponse.Created
+    fooClient.doBar(None).rightValue.futureValue shouldBe DoBarResponse.Created("response")
   }
 }

--- a/modules/sample-akkaHttpJackson/src/test/scala/core/issues/Issue405.scala
+++ b/modules/sample-akkaHttpJackson/src/test/scala/core/issues/Issue405.scala
@@ -39,7 +39,7 @@ class Issue405 extends AnyFunSuite with TestImplicits with Matchers with EitherV
     /* Pass empty string to required Bar param */
     Post("/v1/Foo", FormData(Map("Bar" -> ""))) ~> route ~> check {
       response.status shouldBe (StatusCodes.OK)
-      responseAs[String] shouldBe "\"Bar is ''\""
+      responseAs[String] shouldBe "Bar is ''"
     }
   }
 
@@ -56,7 +56,7 @@ class Issue405 extends AnyFunSuite with TestImplicits with Matchers with EitherV
     /* Pass empty string to required Bar param */
     Post("/v1/Foo", FormData(Map("Bar" -> "whatevs", "Baz" -> ""))) ~> route ~> check {
       response.status shouldBe (StatusCodes.OK)
-      responseAs[String] shouldBe "\"Baz is present: ''\""
+      responseAs[String] shouldBe "Baz is present: ''"
     }
   }
 
@@ -88,7 +88,7 @@ class Issue405 extends AnyFunSuite with TestImplicits with Matchers with EitherV
     /* Pass empty string to required Bar param */
     Post("/v1/Foo", FormData(Map("Bar" -> "yo"))) ~> route ~> check {
       response.status shouldBe (StatusCodes.OK)
-      responseAs[String] shouldBe "\"Baz is missing\""
+      responseAs[String] shouldBe "Baz is missing"
     }
   }
 }

--- a/modules/sample-akkaHttpJackson/src/test/scala/generators/AkkaHttp/Client/contentType/AkkaHttpTextPlainTest.scala
+++ b/modules/sample-akkaHttpJackson/src/test/scala/generators/AkkaHttp/Client/contentType/AkkaHttpTextPlainTest.scala
@@ -42,7 +42,7 @@ class AkkaHttpTextPlainTest
     }
     val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
     val fooClient                                   = FooClient.httpClient(client)
-    new EitherTValuable(fooClient.doFoo("sample")).rightValue.futureValue shouldBe DoFooResponse.Created
+    fooClient.doFoo("sample").rightValue.futureValue shouldBe DoFooResponse.Created
   }
 
   test("Plain text should be emitted for optional parameters (raw)") {
@@ -57,7 +57,7 @@ class AkkaHttpTextPlainTest
     }
     val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
     val fooClient                                   = FooClient.httpClient(client)
-    new EitherTValuable(fooClient.doBar(Some("sample"))).rightValue.futureValue shouldBe DoBarResponse.Created
+    fooClient.doBar(Some("sample")).rightValue.futureValue shouldBe DoBarResponse.Created
   }
 
   test("Plain text should be emitted for required parameters") {
@@ -80,7 +80,7 @@ class AkkaHttpTextPlainTest
 
     val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
     val fooClient                                   = FooClient.httpClient(client)
-    new EitherTValuable(fooClient.doFoo("sample")).rightValue.futureValue shouldBe DoFooResponse.Created
+    fooClient.doFoo("sample").rightValue.futureValue shouldBe DoFooResponse.Created
   }
 
   test("Plain text should be emitted for present optional parameters") {
@@ -103,7 +103,7 @@ class AkkaHttpTextPlainTest
 
     val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
     val fooClient                                   = FooClient.httpClient(client)
-    new EitherTValuable(fooClient.doBar(Some("sample"))).rightValue.futureValue shouldBe DoBarResponse.Created
+    fooClient.doBar(Some("sample")).rightValue.futureValue shouldBe DoBarResponse.Created
   }
 
   test("Plain text should be emitted for missing optional parameters") {
@@ -126,6 +126,6 @@ class AkkaHttpTextPlainTest
 
     val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
     val fooClient                                   = FooClient.httpClient(client)
-    new EitherTValuable(fooClient.doBar(None)).rightValue.futureValue shouldBe DoBarResponse.Created
+    fooClient.doBar(None).rightValue.futureValue shouldBe DoBarResponse.Created
   }
 }

--- a/modules/sample-akkaHttpJackson/src/test/scala/generators/AkkaHttp/Client/contentType/AkkaHttpTextPlainTest.scala
+++ b/modules/sample-akkaHttpJackson/src/test/scala/generators/AkkaHttp/Client/contentType/AkkaHttpTextPlainTest.scala
@@ -34,7 +34,7 @@ class AkkaHttpTextPlainTest
     val route: Route = (path("foo") & extractRequestEntity & entity(as[String])) { (entity, value) =>
       complete({
         if (entity.contentType == ContentTypes.`text/plain(UTF-8)` && value == "sample") {
-          StatusCodes.Created
+          HttpResponse(StatusCodes.Created).withEntity(HttpEntity(ContentTypes.`text/plain(UTF-8)`, "response"))
         } else {
           StatusCodes.NotAcceptable
         }
@@ -42,14 +42,14 @@ class AkkaHttpTextPlainTest
     }
     val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
     val fooClient                                   = FooClient.httpClient(client)
-    fooClient.doFoo("sample").rightValue.futureValue shouldBe DoFooResponse.Created
+    fooClient.doFoo("sample").rightValue.futureValue shouldBe DoFooResponse.Created("response")
   }
 
   test("Plain text should be emitted for optional parameters (raw)") {
     val route: Route = (path("bar") & extractRequestEntity & entity(as[String])) { (entity, value) =>
       complete({
         if (entity.contentType == ContentTypes.`text/plain(UTF-8)` && value == "sample") {
-          StatusCodes.Created
+          HttpResponse(StatusCodes.Created).withEntity(HttpEntity(ContentTypes.`text/plain(UTF-8)`, "response"))
         } else {
           StatusCodes.NotAcceptable
         }
@@ -57,7 +57,7 @@ class AkkaHttpTextPlainTest
     }
     val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
     val fooClient                                   = FooClient.httpClient(client)
-    fooClient.doBar(Some("sample")).rightValue.futureValue shouldBe DoBarResponse.Created
+    fooClient.doBar(Some("sample")).rightValue.futureValue shouldBe DoBarResponse.Created("response")
   }
 
   test("Plain text should be emitted for required parameters") {
@@ -66,7 +66,7 @@ class AkkaHttpTextPlainTest
           respond: tests.contentTypes.textPlain.server.akkaHttpJackson.foo.FooResource.DoFooResponse.type
       )(body: String): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttpJackson.foo.FooResource.DoFooResponse] =
         if (body == "sample") {
-          Future.successful(respond.Created)
+          Future.successful(respond.Created("response"))
         } else {
           Future.successful(respond.NotAcceptable)
         }
@@ -80,7 +80,7 @@ class AkkaHttpTextPlainTest
 
     val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
     val fooClient                                   = FooClient.httpClient(client)
-    fooClient.doFoo("sample").rightValue.futureValue shouldBe DoFooResponse.Created
+    fooClient.doFoo("sample").rightValue.futureValue shouldBe DoFooResponse.Created("response")
   }
 
   test("Plain text should be emitted for present optional parameters") {
@@ -92,7 +92,7 @@ class AkkaHttpTextPlainTest
           body: Option[String]
       ): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttpJackson.foo.FooResource.DoBarResponse] =
         if (body.contains("sample")) {
-          Future.successful(respond.Created)
+          Future.successful(respond.Created("response"))
         } else {
           Future.successful(respond.NotAcceptable)
         }
@@ -103,7 +103,7 @@ class AkkaHttpTextPlainTest
 
     val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
     val fooClient                                   = FooClient.httpClient(client)
-    fooClient.doBar(Some("sample")).rightValue.futureValue shouldBe DoBarResponse.Created
+    fooClient.doBar(Some("sample")).rightValue.futureValue shouldBe DoBarResponse.Created("response")
   }
 
   test("Plain text should be emitted for missing optional parameters") {
@@ -115,7 +115,7 @@ class AkkaHttpTextPlainTest
           body: Option[String]
       ): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttpJackson.foo.FooResource.DoBarResponse] =
         if (body.isEmpty) {
-          Future.successful(respond.Created)
+          Future.successful(respond.Created("response"))
         } else {
           Future.successful(respond.NotAcceptable)
         }
@@ -126,6 +126,6 @@ class AkkaHttpTextPlainTest
 
     val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
     val fooClient                                   = FooClient.httpClient(client)
-    fooClient.doBar(None).rightValue.futureValue shouldBe DoBarResponse.Created
+    fooClient.doBar(None).rightValue.futureValue shouldBe DoBarResponse.Created("response")
   }
 }

--- a/modules/sample-dropwizard/src/test/scala/core/Dropwizard/AsyncHttpClientContentHeaderTest.scala
+++ b/modules/sample-dropwizard/src/test/scala/core/Dropwizard/AsyncHttpClientContentHeaderTest.scala
@@ -49,6 +49,7 @@ class AsyncHttpClientContentHeaderTest extends AnyFreeSpec with Matchers with Wi
           .willReturn(
             aResponse()
               .withStatus(201)
+              .withBody(MOCK_RESPONSE_BODY)
           )
       )
       val client = new FooClient.Builder().withBaseUrl(wireMockBaseUrl).build()
@@ -57,8 +58,10 @@ class AsyncHttpClientContentHeaderTest extends AnyFreeSpec with Matchers with Wi
         .call()
         .toCompletableFuture
         .get()
-        .fold(
-          () => (), { () =>
+        .fold({
+          case MOCK_RESPONSE_BODY => ()
+          case other              => fail(s"Unexpected response: ${other}")
+        }, { () =>
             fail("Should have gotten 201 response"); ()
           }
         )

--- a/modules/sample-http4s/src/test/scala/generators/Http4s/Client/contentType/Http4sTextPlainTest.scala
+++ b/modules/sample-http4s/src/test/scala/generators/Http4s/Client/contentType/Http4sTextPlainTest.scala
@@ -22,13 +22,13 @@ class Http4sTextPlainTest extends AnyFunSuite with Matchers with EitherValues {
         if (req.contentType.contains(`Content-Type`(MediaType.text.plain, Charset.`UTF-8`))) {
           for {
             value <- req.as[String]
-            resp  <- if (value == "sample") Created() else NotAcceptable()
+            resp  <- if (value == "sample") Created("response") else NotAcceptable()
           } yield resp
         } else NotAcceptable()
     }
     val client: Client[IO] = Client.fromHttpApp(route.orNotFound)
     val fooClient          = FooClient.httpClient(client)
-    fooClient.doFoo("sample").attempt.unsafeRunSync().right.value shouldBe cdefs.foo.DoFooResponse.Created
+    fooClient.doFoo("sample").attempt.unsafeRunSync().right.value shouldBe cdefs.foo.DoFooResponse.Created("response")
   }
 
   test("Plain text should be emitted for optional parameters (raw)") {
@@ -37,20 +37,20 @@ class Http4sTextPlainTest extends AnyFunSuite with Matchers with EitherValues {
         if (req.contentType.contains(`Content-Type`(MediaType.text.plain, Charset.`UTF-8`))) {
           for {
             value <- req.as[String]
-            resp  <- if (value == "sample") Created() else NotAcceptable()
+            resp  <- if (value == "sample") Created("response") else NotAcceptable()
           } yield resp
         } else NotAcceptable()
     }
     val client: Client[IO] = Client.fromHttpApp(route.orNotFound)
     val fooClient          = FooClient.httpClient(client)
-    fooClient.doBar(Some("sample")).attempt.unsafeRunSync().right.value shouldBe cdefs.foo.DoBarResponse.Created
+    fooClient.doBar(Some("sample")).attempt.unsafeRunSync().right.value shouldBe cdefs.foo.DoBarResponse.Created("response")
   }
 
   test("Plain text should be emitted for required parameters") {
     val route: HttpRoutes[IO] = new FooResource[IO]().routes(new FooHandler[IO] {
       def doFoo(respond: DoFooResponse.type)(body: String): IO[sdefs.foo.DoFooResponse] =
         if (body == "sample") {
-          IO.pure(respond.Created)
+          IO.pure(respond.Created("response"))
         } else {
           IO.pure(respond.NotAcceptable)
         }
@@ -60,7 +60,7 @@ class Http4sTextPlainTest extends AnyFunSuite with Matchers with EitherValues {
 
     val client: Client[IO] = Client.fromHttpApp(route.orNotFound)
     val fooClient          = FooClient.httpClient(client)
-    fooClient.doFoo("sample").attempt.unsafeRunSync().right.value shouldBe cdefs.foo.DoFooResponse.Created
+    fooClient.doFoo("sample").attempt.unsafeRunSync().right.value shouldBe cdefs.foo.DoFooResponse.Created("response")
   }
 
   test("Plain text should be emitted for present optional parameters") {
@@ -68,7 +68,7 @@ class Http4sTextPlainTest extends AnyFunSuite with Matchers with EitherValues {
       def doFoo(respond: DoFooResponse.type)(body: String): IO[sdefs.foo.DoFooResponse] = ???
       def doBar(respond: DoBarResponse.type)(body: Option[String]): IO[sdefs.foo.DoBarResponse] =
         if (body.contains("sample")) {
-          IO.pure(respond.Created)
+          IO.pure(respond.Created("response"))
         } else {
           IO.pure(respond.NotAcceptable)
         }
@@ -77,7 +77,7 @@ class Http4sTextPlainTest extends AnyFunSuite with Matchers with EitherValues {
 
     val client: Client[IO] = Client.fromHttpApp(route.orNotFound)
     val fooClient          = FooClient.httpClient(client)
-    fooClient.doBar(Some("sample")).attempt.unsafeRunSync().right.value shouldBe cdefs.foo.DoBarResponse.Created
+    fooClient.doBar(Some("sample")).attempt.unsafeRunSync().right.value shouldBe cdefs.foo.DoBarResponse.Created("response")
   }
 
   test("Plain text should be emitted for missing optional parameters") {
@@ -85,7 +85,7 @@ class Http4sTextPlainTest extends AnyFunSuite with Matchers with EitherValues {
       def doFoo(respond: DoFooResponse.type)(body: String): IO[sdefs.foo.DoFooResponse] = ???
       def doBar(respond: DoBarResponse.type)(body: Option[String]): IO[sdefs.foo.DoBarResponse] =
         if (body.isEmpty) {
-          IO.pure(respond.Created)
+          IO.pure(respond.Created("response"))
         } else {
           IO.pure(respond.NotAcceptable)
         }
@@ -94,6 +94,6 @@ class Http4sTextPlainTest extends AnyFunSuite with Matchers with EitherValues {
 
     val client: Client[IO] = Client.fromHttpApp(route.orNotFound)
     val fooClient          = FooClient.httpClient(client)
-    fooClient.doBar(None).attempt.unsafeRunSync().right.value shouldBe cdefs.foo.DoBarResponse.Created
+    fooClient.doBar(None).attempt.unsafeRunSync().right.value shouldBe cdefs.foo.DoBarResponse.Created("response")
   }
 }

--- a/modules/sample/src/main/resources/contentType-textPlain.yaml
+++ b/modules/sample/src/main/resources/contentType-textPlain.yaml
@@ -21,6 +21,8 @@ paths:
       responses:
         201:
           description: "Created"
+          schema:
+            type: string
         406:
           description: "Invalid"
   /bar:

--- a/modules/sample/src/main/resources/contentType-textPlain.yaml
+++ b/modules/sample/src/main/resources/contentType-textPlain.yaml
@@ -39,6 +39,8 @@ paths:
       responses:
         201:
           description: "Created"
+          schema:
+            type: string
         406:
           description: "Invalid"
   /baz:


### PR DESCRIPTION
Resolves #306 

Threading through `produces` into server generators, explicitly adding support for encoding `text/plain` in akka-http servers.

This also gets closer to supporting multiple supported `Content-Type`s for a single request, since the content types are threaded all the way through to the edge.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
