### PR TITLE
Introducing new proxies to aide migration for codebases that extend guardrail directly

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
@@ -396,6 +396,7 @@ object AsyncHttpClientClientGenerator {
       (imports, cls)
     }
 
+  def ClientTermInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target] with CollectionsLibType): ClientTerms[JavaLanguage, Target] = new ClientTermInterp
   class ClientTermInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target] with CollectionsLibType) extends ClientTerms[JavaLanguage, Target] {
     implicit def MonadF: Monad[Target] = Target.targetInstances
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/Dropwizard.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/Dropwizard.scala
@@ -13,14 +13,14 @@ import com.twilio.guardrail.languages.JavaLanguage
 
 object Dropwizard extends Framework[JavaLanguage, Target] {
   implicit def CollectionsLibInterp  = new JavaCollectionsInterp with JavaStdLibCollections
-  implicit def ArrayProtocolInterp   = new ArrayProtocolTermInterp
-  implicit def ClientInterp          = new ClientTermInterp
-  implicit def EnumProtocolInterp    = new EnumProtocolTermInterp
-  implicit def FrameworkInterp       = new DropwizardFrameworkInterp
-  implicit def ModelProtocolInterp   = new ModelProtocolTermInterp
-  implicit def PolyProtocolInterp    = new PolyProtocolTermInterp
-  implicit def ProtocolSupportInterp = new ProtocolSupportTermInterp
-  implicit def ServerInterp          = new ServerTermInterp
+  implicit def ArrayProtocolInterp   = ArrayProtocolTermInterp
+  implicit def ClientInterp          = ClientTermInterp
+  implicit def EnumProtocolInterp    = EnumProtocolTermInterp
+  implicit def FrameworkInterp       = DropwizardFrameworkInterp
+  implicit def ModelProtocolInterp   = ModelProtocolTermInterp
+  implicit def PolyProtocolInterp    = PolyProtocolTermInterp
+  implicit def ProtocolSupportInterp = ProtocolSupportTermInterp
+  implicit def ServerInterp          = ServerTermInterp
   implicit def SwaggerInterp         = SwaggerGenerator[JavaLanguage]
   implicit def LanguageInterp        = JavaInterp
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardGenerator.scala
@@ -11,6 +11,8 @@ import com.twilio.guardrail.terms.CollectionsLibTerms
 import com.twilio.guardrail.terms.framework._
 
 object DropwizardGenerator {
+  def FrameworkInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target]): FrameworkTerms[JavaLanguage, Target] =
+    new FrameworkInterp
   class FrameworkInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target]) extends FrameworkTerms[JavaLanguage, Target] {
     implicit def MonadF = Target.targetInstances
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
@@ -187,6 +187,7 @@ object DropwizardServerGenerator {
     }
   }
 
+  def ServerTermInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target] with CollectionsLibType): ServerTerms[JavaLanguage, Target] = new ServerTermInterp
   class ServerTermInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target] with CollectionsLibType) extends ServerTerms[JavaLanguage, Target] {
     implicit def MonadF: Monad[Target] = Target.targetInstances
     override def getExtraImports(tracing: Boolean, supportPackage: List[String]): Target[List[ImportDeclaration]] =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
@@ -138,6 +138,7 @@ object JacksonGenerator {
       ).toNodeList
     )
 
+  def EnumProtocolTermInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target]): EnumProtocolTerms[JavaLanguage, Target] = new EnumProtocolTermInterp
   class EnumProtocolTermInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target]) extends EnumProtocolTerms[JavaLanguage, Target] {
     implicit def MonadF: Monad[Target] = Target.targetInstances
     def extractEnum(swagger: Schema[_]) = {
@@ -326,6 +327,8 @@ object JacksonGenerator {
       Target.pure(new Name(s"${clsName}.${termName}"))
   }
 
+  def ModelProtocolTermInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target] with CollectionsLibType): ModelProtocolTerms[JavaLanguage, Target] =
+    new ModelProtocolTermInterp
   class ModelProtocolTermInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target] with CollectionsLibType)
       extends ModelProtocolTerms[JavaLanguage, Target] {
 
@@ -893,6 +896,7 @@ object JacksonGenerator {
       Target.pure(StaticDefns(clsName, List.empty, List.empty))
   }
 
+  def ArrayProtocolTermInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target]): ArrayProtocolTerms[JavaLanguage, Target] = new ArrayProtocolTermInterp
   class ArrayProtocolTermInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target]) extends ArrayProtocolTerms[JavaLanguage, Target] {
     implicit def MonadF: Monad[Target] = Target.targetInstances
     def extractArrayType(
@@ -915,6 +919,8 @@ object JacksonGenerator {
       } yield result
   }
 
+  def ProtocolSupportTermInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target]): ProtocolSupportTerms[JavaLanguage, Target] =
+    new ProtocolSupportTermInterp
   class ProtocolSupportTermInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target]) extends ProtocolSupportTerms[JavaLanguage, Target] {
     implicit def MonadF: Monad[Target] = Target.targetInstances
     def extractConcreteTypes(definitions: Either[String, List[PropMeta[JavaLanguage]]]) =
@@ -946,6 +952,8 @@ object JacksonGenerator {
       Target.pure(None)
   }
 
+  def PolyProtocolTermInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target] with CollectionsLibType): PolyProtocolTerms[JavaLanguage, Target] =
+    new PolyProtocolTermInterp
   class PolyProtocolTermInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target] with CollectionsLibType) extends PolyProtocolTerms[JavaLanguage, Target] {
     implicit def MonadF: Monad[Target] = Target.targetInstances
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvc.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvc.scala
@@ -1,10 +1,6 @@
 package com.twilio.guardrail.generators.Java
 
 import com.twilio.guardrail.Target
-import com.twilio.guardrail.generators.Java.JacksonGenerator._
-import com.twilio.guardrail.generators.Java.SpringMvcClientGenerator.ClientTermInterp
-import com.twilio.guardrail.generators.Java.SpringMvcGenerator.{ FrameworkInterp => FrameworkTermInterp }
-import com.twilio.guardrail.generators.Java.SpringMvcServerGenerator.ServerTermInterp
 import com.twilio.guardrail.generators.Java.collectionslib.JavaStdLibCollections
 import com.twilio.guardrail.generators.JavaGenerator.JavaInterp
 import com.twilio.guardrail.generators.collections.JavaCollectionsGenerator.JavaCollectionsInterp
@@ -13,14 +9,14 @@ import com.twilio.guardrail.languages.JavaLanguage
 
 object SpringMvc extends Framework[JavaLanguage, Target] {
   implicit def CollectionsLibInterp  = new JavaCollectionsInterp with JavaStdLibCollections
-  implicit def ArrayProtocolInterp   = new ArrayProtocolTermInterp
-  implicit def ClientInterp          = new ClientTermInterp
-  implicit def EnumProtocolInterp    = new EnumProtocolTermInterp
-  implicit def FrameworkInterp       = new FrameworkTermInterp
-  implicit def ModelProtocolInterp   = new ModelProtocolTermInterp
-  implicit def PolyProtocolInterp    = new PolyProtocolTermInterp
-  implicit def ProtocolSupportInterp = new ProtocolSupportTermInterp
-  implicit def ServerInterp          = new ServerTermInterp
+  implicit def ArrayProtocolInterp   = JacksonGenerator.ArrayProtocolTermInterp
+  implicit def ClientInterp          = SpringMvcClientGenerator.ClientTermInterp
+  implicit def EnumProtocolInterp    = JacksonGenerator.EnumProtocolTermInterp
+  implicit def FrameworkInterp       = SpringMvcGenerator.FrameworkInterp
+  implicit def ModelProtocolInterp   = JacksonGenerator.ModelProtocolTermInterp
+  implicit def PolyProtocolInterp    = JacksonGenerator.PolyProtocolTermInterp
+  implicit def ProtocolSupportInterp = JacksonGenerator.ProtocolSupportTermInterp
+  implicit def ServerInterp          = SpringMvcServerGenerator.ServerTermInterp
   implicit def SwaggerInterp         = SwaggerGenerator[JavaLanguage]
   implicit def LanguageInterp        = JavaInterp
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvcClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvcClientGenerator.scala
@@ -12,6 +12,7 @@ import java.net.URI
 
 object SpringMvcClientGenerator {
 
+  def ClientTermInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target]): ClientTerms[JavaLanguage, Target] = new ClientTermInterp
   class ClientTermInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target]) extends ClientTerms[JavaLanguage, Target] {
     def MonadF = Target.targetInstances
     def generateClientOperation(

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvcGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvcGenerator.scala
@@ -9,6 +9,8 @@ import com.twilio.guardrail.terms.CollectionsLibTerms
 import com.twilio.guardrail.terms.framework.FrameworkTerms
 
 object SpringMvcGenerator {
+  def FrameworkInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target]): FrameworkTerms[JavaLanguage, Target] =
+    new FrameworkInterp
   class FrameworkInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target]) extends FrameworkTerms[JavaLanguage, Target] {
     implicit def MonadF                    = Target.targetInstances
     def fileType(format: Option[String])   = safeParseType(format.getOrElse("MultipartFile"))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvcServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvcServerGenerator.scala
@@ -265,6 +265,7 @@ object SpringMvcServerGenerator {
     }
   }
 
+  def ServerTermInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target] with CollectionsLibType): ServerTerms[JavaLanguage, Target] = new ServerTermInterp
   class ServerTermInterp(implicit Cl: CollectionsLibTerms[JavaLanguage, Target] with CollectionsLibType) extends ServerTerms[JavaLanguage, Target] {
     implicit def MonadF: Monad[Target] = Target.targetInstances
     def getExtraImports(tracing: Boolean, supportPackage: List[String]) =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaModule.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaModule.scala
@@ -25,23 +25,23 @@ object JavaModule extends AbstractModule[JavaLanguage] {
       ArrayProtocolTerms[JavaLanguage, Target],
       PolyProtocolTerms[JavaLanguage, Target]
   ) = (
-    new JacksonGenerator.ProtocolSupportTermInterp,
-    new JacksonGenerator.ModelProtocolTermInterp,
-    new JacksonGenerator.EnumProtocolTermInterp,
-    new JacksonGenerator.ArrayProtocolTermInterp,
-    new JacksonGenerator.PolyProtocolTermInterp
+    JacksonGenerator.ProtocolSupportTermInterp,
+    JacksonGenerator.ModelProtocolTermInterp,
+    JacksonGenerator.EnumProtocolTermInterp,
+    JacksonGenerator.ArrayProtocolTermInterp,
+    JacksonGenerator.PolyProtocolTermInterp
   )
 
   def dropwizard(implicit Cl: CollectionsLibTerms[JavaLanguage, Target] with CollectionsLibType): (
       ServerTerms[JavaLanguage, Target],
       FrameworkTerms[JavaLanguage, Target]
-  ) = (new DropwizardServerGenerator.ServerTermInterp, new DropwizardGenerator.FrameworkInterp)
+  ) = (DropwizardServerGenerator.ServerTermInterp, DropwizardGenerator.FrameworkInterp)
   def spring(implicit Cl: CollectionsLibTerms[JavaLanguage, Target] with CollectionsLibType): (
       ServerTerms[JavaLanguage, Target],
       FrameworkTerms[JavaLanguage, Target]
-  ) = (new SpringMvcServerGenerator.ServerTermInterp, new SpringMvcGenerator.FrameworkInterp)
+  ) = (SpringMvcServerGenerator.ServerTermInterp, SpringMvcGenerator.FrameworkInterp)
   def asyncHttpClient(implicit Cl: CollectionsLibTerms[JavaLanguage, Target] with CollectionsLibType): ClientTerms[JavaLanguage, Target] =
-    new AsyncHttpClientClientGenerator.ClientTermInterp
+    AsyncHttpClientClientGenerator.ClientTermInterp
 
   def extract(modules: NonEmptyList[String]): Target[Framework[JavaLanguage, Target]] = {
     implicit val collections = new JavaCollectionsGenerator.JavaCollectionsInterp with JavaStdLibCollections

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttp.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttp.scala
@@ -1,10 +1,6 @@
 package com.twilio.guardrail.generators.Scala
 
 import com.twilio.guardrail.Target
-import com.twilio.guardrail.generators.Scala.AkkaHttpClientGenerator._
-import com.twilio.guardrail.generators.Scala.AkkaHttpGenerator._
-import com.twilio.guardrail.generators.Scala.AkkaHttpServerGenerator._
-import com.twilio.guardrail.generators.Scala.CirceProtocolGenerator._
 import com.twilio.guardrail.generators.Scala.model.CirceModelGenerator
 import com.twilio.guardrail.generators.ScalaGenerator._
 import com.twilio.guardrail.generators.collections.ScalaCollectionsGenerator.ScalaCollectionsInterp
@@ -13,14 +9,14 @@ import com.twilio.guardrail.languages.ScalaLanguage
 
 object AkkaHttp extends Framework[ScalaLanguage, Target] {
   implicit def CollectionsLibInterp  = ScalaCollectionsInterp
-  implicit def ArrayProtocolInterp   = new ArrayProtocolTermInterp
-  implicit def ClientInterp          = new ClientTermInterp(CirceModelGenerator.V012)
-  implicit def EnumProtocolInterp    = new EnumProtocolTermInterp
-  implicit def FrameworkInterp       = new FrameworkInterp(CirceModelGenerator.V012)
-  implicit def ModelProtocolInterp   = new ModelProtocolTermInterp(CirceModelGenerator.V012)
-  implicit def PolyProtocolInterp    = new PolyProtocolTermInterp
-  implicit def ProtocolSupportInterp = new ProtocolSupportTermInterp
-  implicit def ServerInterp          = new ServerTermInterp(CirceModelGenerator.V012)
+  implicit def ArrayProtocolInterp   = CirceProtocolGenerator.ArrayProtocolTermInterp
+  implicit def ClientInterp          = AkkaHttpClientGenerator.ClientTermInterp(CirceModelGenerator.V012)
+  implicit def EnumProtocolInterp    = CirceProtocolGenerator.EnumProtocolTermInterp
+  implicit def FrameworkInterp       = AkkaHttpGenerator.FrameworkInterp(CirceModelGenerator.V012)
+  implicit def ModelProtocolInterp   = CirceProtocolGenerator.ModelProtocolTermInterp(CirceModelGenerator.V012)
+  implicit def PolyProtocolInterp    = CirceProtocolGenerator.PolyProtocolTermInterp
+  implicit def ProtocolSupportInterp = CirceProtocolGenerator.ProtocolSupportTermInterp
+  implicit def ServerInterp          = AkkaHttpServerGenerator.ServerTermInterp(CirceModelGenerator.V012)
   implicit def SwaggerInterp         = SwaggerGenerator[ScalaLanguage]
   implicit def LanguageInterp        = ScalaInterp
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpClientGenerator.scala
@@ -20,6 +20,8 @@ import java.net.URI
 
 object AkkaHttpClientGenerator {
 
+  def ClientTermInterp(modelGeneratorType: ModelGeneratorType)(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): ClientTerms[ScalaLanguage, Target] =
+    new ClientTermInterp(modelGeneratorType)
   class ClientTermInterp(modelGeneratorType: ModelGeneratorType)(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target])
       extends ClientTerms[ScalaLanguage, Target] {
     implicit def MonadF: Monad[Target] = Target.targetInstances

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpGenerator.scala
@@ -8,6 +8,8 @@ import com.twilio.guardrail.terms.framework._
 import scala.meta._
 
 object AkkaHttpGenerator {
+  def FrameworkInterp(modelGeneratorType: ModelGeneratorType)(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): FrameworkTerms[ScalaLanguage, Target] =
+    new FrameworkInterp(modelGeneratorType)
   class FrameworkInterp(modelGeneratorType: ModelGeneratorType)(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target])
       extends FrameworkTerms[ScalaLanguage, Target] {
     implicit def MonadF                  = Target.targetInstances

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpJackson.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpJackson.scala
@@ -2,10 +2,6 @@ package com.twilio.guardrail.generators.Scala
 
 import com.twilio.guardrail.Target
 import com.twilio.guardrail.generators.collections.ScalaCollectionsGenerator
-import com.twilio.guardrail.generators.Scala.AkkaHttpClientGenerator._
-import com.twilio.guardrail.generators.Scala.AkkaHttpGenerator._
-import com.twilio.guardrail.generators.Scala.AkkaHttpServerGenerator._
-import com.twilio.guardrail.generators.Scala.JacksonProtocolGenerator._
 import com.twilio.guardrail.generators.Scala.model.JacksonModelGenerator
 import com.twilio.guardrail.generators.ScalaGenerator._
 import com.twilio.guardrail.generators.{ Framework, SwaggerGenerator }
@@ -13,14 +9,14 @@ import com.twilio.guardrail.languages.ScalaLanguage
 
 object AkkaHttpJackson extends Framework[ScalaLanguage, Target] {
   implicit def CollectionsLibInterp  = ScalaCollectionsGenerator.ScalaCollectionsInterp
-  implicit def ArrayProtocolInterp   = ArrayProtocolTermInterp
-  implicit def ClientInterp          = new ClientTermInterp(JacksonModelGenerator)
-  implicit def EnumProtocolInterp    = EnumProtocolTermInterp
-  implicit def FrameworkInterp       = new FrameworkInterp(JacksonModelGenerator)
-  implicit def ModelProtocolInterp   = ModelProtocolTermInterp
-  implicit def PolyProtocolInterp    = PolyProtocolTermInterp
-  implicit def ProtocolSupportInterp = ProtocolSupportTermInterp
-  implicit def ServerInterp          = new ServerTermInterp(JacksonModelGenerator)
+  implicit def ArrayProtocolInterp   = JacksonProtocolGenerator.ArrayProtocolTermInterp
+  implicit def ClientInterp          = AkkaHttpClientGenerator.ClientTermInterp(JacksonModelGenerator)
+  implicit def EnumProtocolInterp    = JacksonProtocolGenerator.EnumProtocolTermInterp
+  implicit def FrameworkInterp       = AkkaHttpGenerator.FrameworkInterp(JacksonModelGenerator)
+  implicit def ModelProtocolInterp   = JacksonProtocolGenerator.ModelProtocolTermInterp
+  implicit def PolyProtocolInterp    = JacksonProtocolGenerator.PolyProtocolTermInterp
+  implicit def ProtocolSupportInterp = JacksonProtocolGenerator.ProtocolSupportTermInterp
+  implicit def ServerInterp          = AkkaHttpServerGenerator.ServerTermInterp(JacksonModelGenerator)
   implicit def SwaggerInterp         = SwaggerGenerator[ScalaLanguage]
   implicit def LanguageInterp        = ScalaInterp
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpServerGenerator.scala
@@ -31,6 +31,8 @@ import _root_.io.swagger.v3.oas.models.PathItem.HttpMethod
 import _root_.io.swagger.v3.oas.models.Operation
 
 object AkkaHttpServerGenerator {
+  def ServerTermInterp(modelGeneratorType: ModelGeneratorType)(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): ServerTerms[ScalaLanguage, Target] =
+    new ServerTermInterp(modelGeneratorType)
   class ServerTermInterp(modelGeneratorType: ModelGeneratorType)(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target])
       extends ServerTerms[ScalaLanguage, Target] {
     val customExtractionTypeName: Type.Name = Type.Name("E")

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/CirceProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/CirceProtocolGenerator.scala
@@ -38,6 +38,7 @@ object CirceProtocolGenerator {
       .map(_.tpe)
       .map(f)
 
+  def EnumProtocolTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): EnumProtocolTerms[ScalaLanguage, Target] = new EnumProtocolTermInterp
   class EnumProtocolTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]) extends EnumProtocolTerms[ScalaLanguage, Target] {
     implicit def MonadF: Monad[Target] = Target.targetInstances
     def extractEnum(swagger: Schema[_]) = {
@@ -119,6 +120,10 @@ object CirceProtocolGenerator {
       Target.pure(q"${Term.Name(clsName)}.${Term.Name(termName)}")
   }
 
+  def ModelProtocolTermInterp(
+      circeVersion: CirceModelGenerator
+  )(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): ModelProtocolTerms[ScalaLanguage, Target] =
+    new ModelProtocolTermInterp(circeVersion)
   class ModelProtocolTermInterp(circeVersion: CirceModelGenerator)(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target])
       extends ModelProtocolTerms[ScalaLanguage, Target] {
     implicit def MonadF: Monad[Target] = Target.targetInstances
@@ -504,6 +509,7 @@ object CirceProtocolGenerator {
     }
   }
 
+  def ArrayProtocolTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): ArrayProtocolTerms[ScalaLanguage, Target] = new ArrayProtocolTermInterp
   class ArrayProtocolTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]) extends ArrayProtocolTerms[ScalaLanguage, Target] {
     implicit def MonadF: Monad[Target] = Target.targetInstances
     def extractArrayType(arr: SwaggerUtil.ResolvedType[ScalaLanguage], concreteTypes: List[PropMeta[ScalaLanguage]]) =
@@ -526,6 +532,8 @@ object CirceProtocolGenerator {
       } yield result
   }
 
+  def ProtocolSupportTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): ProtocolSupportTerms[ScalaLanguage, Target] =
+    new ProtocolSupportTermInterp
   class ProtocolSupportTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]) extends ProtocolSupportTerms[ScalaLanguage, Target] {
     implicit def MonadF: Monad[Target] = Target.targetInstances
     def extractConcreteTypes(definitions: Either[String, List[PropMeta[ScalaLanguage]]]) =
@@ -617,6 +625,8 @@ object CirceProtocolGenerator {
     def implicitsObject() = Target.pure(None)
   }
 
+  def PolyProtocolTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): PolyProtocolTerms[ScalaLanguage, Target] =
+    new PolyProtocolTermInterp
   class PolyProtocolTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]) extends PolyProtocolTerms[ScalaLanguage, Target] {
     implicit def MonadF: Monad[Target] = Target.targetInstances
     def extractSuperClass(

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Dropwizard.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Dropwizard.scala
@@ -1,9 +1,6 @@
 package com.twilio.guardrail.generators.Scala
 
 import com.twilio.guardrail.Target
-import com.twilio.guardrail.generators.Scala.DropwizardClientGenerator.ClientTermInterp
-import com.twilio.guardrail.generators.Scala.DropwizardServerGenerator.ServerTermInterp
-import com.twilio.guardrail.generators.Scala.JacksonProtocolGenerator._
 import com.twilio.guardrail.generators.ScalaGenerator.ScalaInterp
 import com.twilio.guardrail.generators.collections.ScalaCollectionsGenerator
 import com.twilio.guardrail.generators.{ Framework, SwaggerGenerator }
@@ -15,14 +12,14 @@ import com.twilio.guardrail.terms.framework.FrameworkTerms
 import com.twilio.guardrail.terms.{ CollectionsLibTerms, LanguageTerms, SwaggerTerms }
 
 object Dropwizard extends Framework[ScalaLanguage, Target] {
-  override implicit def ArrayProtocolInterp: ArrayProtocolTerms[ScalaLanguage, Target]     = ArrayProtocolTermInterp
-  override implicit def ClientInterp: ClientTerms[ScalaLanguage, Target]                   = new ClientTermInterp
-  override implicit def EnumProtocolInterp: EnumProtocolTerms[ScalaLanguage, Target]       = EnumProtocolTermInterp
-  override implicit def FrameworkInterp: FrameworkTerms[ScalaLanguage, Target]             = new DropwizardGenerator.FrameworkInterp
-  override implicit def ModelProtocolInterp: ModelProtocolTerms[ScalaLanguage, Target]     = ModelProtocolTermInterp
-  override implicit def PolyProtocolInterp: PolyProtocolTerms[ScalaLanguage, Target]       = PolyProtocolTermInterp
-  override implicit def ProtocolSupportInterp: ProtocolSupportTerms[ScalaLanguage, Target] = ProtocolSupportTermInterp
-  override implicit def ServerInterp: ServerTerms[ScalaLanguage, Target]                   = new ServerTermInterp
+  override implicit def ArrayProtocolInterp: ArrayProtocolTerms[ScalaLanguage, Target]     = JacksonProtocolGenerator.ArrayProtocolTermInterp
+  override implicit def ClientInterp: ClientTerms[ScalaLanguage, Target]                   = DropwizardClientGenerator.ClientTermInterp
+  override implicit def EnumProtocolInterp: EnumProtocolTerms[ScalaLanguage, Target]       = JacksonProtocolGenerator.EnumProtocolTermInterp
+  override implicit def FrameworkInterp: FrameworkTerms[ScalaLanguage, Target]             = DropwizardGenerator.FrameworkInterp
+  override implicit def ModelProtocolInterp: ModelProtocolTerms[ScalaLanguage, Target]     = JacksonProtocolGenerator.ModelProtocolTermInterp
+  override implicit def PolyProtocolInterp: PolyProtocolTerms[ScalaLanguage, Target]       = JacksonProtocolGenerator.PolyProtocolTermInterp
+  override implicit def ProtocolSupportInterp: ProtocolSupportTerms[ScalaLanguage, Target] = JacksonProtocolGenerator.ProtocolSupportTermInterp
+  override implicit def ServerInterp: ServerTerms[ScalaLanguage, Target]                   = DropwizardServerGenerator.ServerTermInterp
   override implicit def SwaggerInterp: SwaggerTerms[ScalaLanguage, Target]                 = SwaggerGenerator[ScalaLanguage]()
   override implicit def LanguageInterp: LanguageTerms[ScalaLanguage, Target]               = ScalaInterp
   override implicit def CollectionsLibInterp: CollectionsLibTerms[ScalaLanguage, Target]   = ScalaCollectionsGenerator.ScalaCollectionsInterp

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/DropwizardClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/DropwizardClientGenerator.scala
@@ -13,6 +13,7 @@ import java.net.URI
 import scala.meta.{ Defn, Import, Term }
 
 object DropwizardClientGenerator {
+  def ClientTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): ClientTerms[ScalaLanguage, Target] = new ClientTermInterp
   class ClientTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]) extends ClientTerms[ScalaLanguage, Target] {
     override def MonadF: Monad[Target]                                   = Target.targetInstances
     override def getImports(tracing: Boolean): Target[List[Import]]      = Target.raiseError(RuntimeFailure("Dropwizard Scala clients are not yet supported"))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/DropwizardGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/DropwizardGenerator.scala
@@ -10,6 +10,8 @@ import scala.meta._
 import scala.util.Try
 
 object DropwizardGenerator {
+  def FrameworkInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): FrameworkTerms[ScalaLanguage, Target] =
+    new FrameworkInterp
   class FrameworkInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]) extends FrameworkTerms[ScalaLanguage, Target] {
     override def MonadF: Monad[Target] = Target.targetInstances
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/DropwizardServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/DropwizardServerGenerator.scala
@@ -131,6 +131,8 @@ object DropwizardServerGenerator {
       buildTransformers(param, httpParameterAnnotation).foldLeft(param.param)((accum, next) => next(accum))
   }
 
+  def ServerTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): ServerTerms[ScalaLanguage, Target] =
+    new ServerTermInterp
   class ServerTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]) extends ServerTerms[ScalaLanguage, Target] {
     override def MonadF: Monad[Target] = Target.targetInstances
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Endpoints.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Endpoints.scala
@@ -1,10 +1,6 @@
 package com.twilio.guardrail.generators.Scala
 
 import com.twilio.guardrail.Target
-import com.twilio.guardrail.generators.Scala.CirceProtocolGenerator._
-import com.twilio.guardrail.generators.Scala.EndpointsClientGenerator._
-import com.twilio.guardrail.generators.Scala.EndpointsGenerator.{ FrameworkInterp => EndpointsFrameworkInterp }
-import com.twilio.guardrail.generators.Scala.EndpointsServerGenerator._
 import com.twilio.guardrail.generators.Scala.model.CirceModelGenerator
 import com.twilio.guardrail.generators.ScalaGenerator._
 import com.twilio.guardrail.generators.collections.ScalaCollectionsGenerator.ScalaCollectionsInterp
@@ -13,14 +9,14 @@ import com.twilio.guardrail.languages.ScalaLanguage
 
 object Endpoints extends Framework[ScalaLanguage, Target] {
   implicit def CollectionsLibInterp  = ScalaCollectionsInterp
-  implicit def ArrayProtocolInterp   = new ArrayProtocolTermInterp
-  implicit def ClientInterp          = new ClientTermInterp
-  implicit def EnumProtocolInterp    = new EnumProtocolTermInterp
-  implicit def FrameworkInterp       = new EndpointsFrameworkInterp
-  implicit def ModelProtocolInterp   = new ModelProtocolTermInterp(CirceModelGenerator.V012)
-  implicit def PolyProtocolInterp    = new PolyProtocolTermInterp
-  implicit def ProtocolSupportInterp = new ProtocolSupportTermInterp
-  implicit def ServerInterp          = new ServerTermInterp
+  implicit def ArrayProtocolInterp   = CirceProtocolGenerator.ArrayProtocolTermInterp
+  implicit def ClientInterp          = EndpointsClientGenerator.ClientTermInterp
+  implicit def EnumProtocolInterp    = CirceProtocolGenerator.EnumProtocolTermInterp
+  implicit def FrameworkInterp       = EndpointsGenerator.FrameworkInterp
+  implicit def ModelProtocolInterp   = CirceProtocolGenerator.ModelProtocolTermInterp(CirceModelGenerator.V012)
+  implicit def PolyProtocolInterp    = CirceProtocolGenerator.PolyProtocolTermInterp
+  implicit def ProtocolSupportInterp = CirceProtocolGenerator.ProtocolSupportTermInterp
+  implicit def ServerInterp          = EndpointsServerGenerator.ServerTermInterp
   implicit def SwaggerInterp         = SwaggerGenerator[ScalaLanguage]
   implicit def LanguageInterp        = ScalaInterp
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/EndpointsClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/EndpointsClientGenerator.scala
@@ -17,6 +17,7 @@ import java.net.URI
 import scala.meta._
 
 object EndpointsClientGenerator {
+  def ClientTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): ClientTerms[ScalaLanguage, Target] = new ClientTermInterp
   class ClientTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]) extends ClientTerms[ScalaLanguage, Target] {
     implicit def MonadF: Monad[Target] = Target.targetInstances
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/EndpointsGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/EndpointsGenerator.scala
@@ -7,6 +7,8 @@ import com.twilio.guardrail.Target
 import com.twilio.guardrail.terms.CollectionsLibTerms
 
 object EndpointsGenerator {
+  def FrameworkInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): FrameworkTerms[ScalaLanguage, Target] =
+    new FrameworkInterp
   class FrameworkInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]) extends FrameworkTerms[ScalaLanguage, Target] {
     implicit def MonadF                    = Target.targetInstances
     def fileType(format: Option[String])   = Target.pure(format.fold[Type](t"org.scalajs.dom.raw.File")(Type.Name(_)))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/EndpointsServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/EndpointsServerGenerator.scala
@@ -10,6 +10,8 @@ import com.twilio.guardrail.terms.{ CollectionsLibTerms, SecurityScheme }
 import com.twilio.guardrail.{ StrictProtocolElems, Target }
 
 object EndpointsServerGenerator {
+  def ServerTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): ServerTerms[ScalaLanguage, Target] =
+    new ServerTermInterp
   class ServerTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]) extends ServerTerms[ScalaLanguage, Target] {
     implicit def MonadF: Monad[Target] = Target.targetInstances
     def generateResponseDefinitions(responseClsName: String, responses: Responses[ScalaLanguage], protocolElems: List[StrictProtocolElems[ScalaLanguage]]) =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4s.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4s.scala
@@ -5,22 +5,18 @@ import com.twilio.guardrail.generators.{ Framework, SwaggerGenerator }
 import com.twilio.guardrail.generators.Scala.model.CirceModelGenerator
 import com.twilio.guardrail.generators.ScalaGenerator._
 import com.twilio.guardrail.languages.ScalaLanguage
-import Http4sClientGenerator._
-import Http4sServerGenerator._
-import Http4sGenerator.{ FrameworkInterp => Http4sFrameworkInterp }
-import CirceProtocolGenerator._
 import com.twilio.guardrail.generators.collections.ScalaCollectionsGenerator.ScalaCollectionsInterp
 
 object Http4s extends Framework[ScalaLanguage, Target] {
   implicit def CollectionsLibInterp  = ScalaCollectionsInterp
-  implicit def ArrayProtocolInterp   = new ArrayProtocolTermInterp
-  implicit def ClientInterp          = new ClientTermInterp
-  implicit def EnumProtocolInterp    = new EnumProtocolTermInterp
-  implicit def FrameworkInterp       = new Http4sFrameworkInterp
-  implicit def ModelProtocolInterp   = new ModelProtocolTermInterp(CirceModelGenerator.V012)
-  implicit def PolyProtocolInterp    = new PolyProtocolTermInterp
-  implicit def ProtocolSupportInterp = new ProtocolSupportTermInterp
-  implicit def ServerInterp          = new ServerTermInterp
+  implicit def ArrayProtocolInterp   = CirceProtocolGenerator.ArrayProtocolTermInterp
+  implicit def ClientInterp          = Http4sClientGenerator.ClientTermInterp
+  implicit def EnumProtocolInterp    = CirceProtocolGenerator.EnumProtocolTermInterp
+  implicit def FrameworkInterp       = Http4sGenerator.FrameworkInterp
+  implicit def ModelProtocolInterp   = CirceProtocolGenerator.ModelProtocolTermInterp(CirceModelGenerator.V012)
+  implicit def PolyProtocolInterp    = CirceProtocolGenerator.PolyProtocolTermInterp
+  implicit def ProtocolSupportInterp = CirceProtocolGenerator.ProtocolSupportTermInterp
+  implicit def ServerInterp          = Http4sServerGenerator.ServerTermInterp
   implicit def SwaggerInterp         = SwaggerGenerator[ScalaLanguage]
   implicit def LanguageInterp        = ScalaInterp
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sClientGenerator.scala
@@ -19,6 +19,7 @@ import java.net.URI
 
 object Http4sClientGenerator {
 
+  def ClientTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): ClientTerms[ScalaLanguage, Target] = new ClientTermInterp
   class ClientTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]) extends ClientTerms[ScalaLanguage, Target] {
     implicit def MonadF: Monad[Target] = Target.targetInstances
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sGenerator.scala
@@ -7,6 +7,8 @@ import com.twilio.guardrail.terms.framework._
 import scala.meta._
 
 object Http4sGenerator {
+  def FrameworkInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): FrameworkTerms[ScalaLanguage, Target] =
+    new FrameworkInterp
   class FrameworkInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]) extends FrameworkTerms[ScalaLanguage, Target] {
     implicit def MonadF = Target.targetInstances
     def fileType(format: Option[String]) =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sServerGenerator.scala
@@ -21,6 +21,8 @@ import _root_.io.swagger.v3.oas.models.PathItem.HttpMethod
 import _root_.io.swagger.v3.oas.models.Operation
 
 object Http4sServerGenerator {
+  def ServerTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): ServerTerms[ScalaLanguage, Target] =
+    new ServerTermInterp
   class ServerTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]) extends ServerTerms[ScalaLanguage, Target] {
     def splitOperationParts(operationId: String): (List[String], String) = {
       val parts = operationId.split('.')

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaModule.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaModule.scala
@@ -20,11 +20,11 @@ object ScalaModule extends AbstractModule[ScalaLanguage] {
       ArrayProtocolTerms[ScalaLanguage, Target],
       PolyProtocolTerms[ScalaLanguage, Target]
   ) = (
-    new CirceProtocolGenerator.ProtocolSupportTermInterp,
-    new CirceProtocolGenerator.ModelProtocolTermInterp(circeModelGenerator),
-    new CirceProtocolGenerator.EnumProtocolTermInterp,
-    new CirceProtocolGenerator.ArrayProtocolTermInterp,
-    new CirceProtocolGenerator.PolyProtocolTermInterp
+    CirceProtocolGenerator.ProtocolSupportTermInterp,
+    CirceProtocolGenerator.ModelProtocolTermInterp(circeModelGenerator),
+    CirceProtocolGenerator.EnumProtocolTermInterp,
+    CirceProtocolGenerator.ArrayProtocolTermInterp,
+    CirceProtocolGenerator.PolyProtocolTermInterp
   )
 
   def circeJava8(circeModelGenerator: CirceModelGenerator)(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): (
@@ -34,7 +34,7 @@ object ScalaModule extends AbstractModule[ScalaLanguage] {
       ArrayProtocolTerms[ScalaLanguage, Target],
       PolyProtocolTerms[ScalaLanguage, Target]
   ) = {
-    val stockProtocolSupportInterp = new CirceProtocolGenerator.ProtocolSupportTermInterp
+    val stockProtocolSupportInterp = CirceProtocolGenerator.ProtocolSupportTermInterp
     val protocolSupportInterp = stockProtocolSupportInterp.copy(
       newPackageObjectImports = () =>
         stockProtocolSupportInterp.packageObjectImports().map { values =>
@@ -44,10 +44,10 @@ object ScalaModule extends AbstractModule[ScalaLanguage] {
     )
     (
       protocolSupportInterp,
-      new CirceProtocolGenerator.ModelProtocolTermInterp(circeModelGenerator),
-      new CirceProtocolGenerator.EnumProtocolTermInterp,
-      new CirceProtocolGenerator.ArrayProtocolTermInterp,
-      new CirceProtocolGenerator.PolyProtocolTermInterp
+      CirceProtocolGenerator.ModelProtocolTermInterp(circeModelGenerator),
+      CirceProtocolGenerator.EnumProtocolTermInterp,
+      CirceProtocolGenerator.ArrayProtocolTermInterp,
+      CirceProtocolGenerator.PolyProtocolTermInterp
     )
   }
 
@@ -70,9 +70,9 @@ object ScalaModule extends AbstractModule[ScalaLanguage] {
       ServerTerms[ScalaLanguage, Target],
       FrameworkTerms[ScalaLanguage, Target]
   ) = (
-    new AkkaHttpClientGenerator.ClientTermInterp(modelGeneratorType),
-    new AkkaHttpServerGenerator.ServerTermInterp(modelGeneratorType),
-    new AkkaHttpGenerator.FrameworkInterp(modelGeneratorType)
+    AkkaHttpClientGenerator.ClientTermInterp(modelGeneratorType),
+    AkkaHttpServerGenerator.ServerTermInterp(modelGeneratorType),
+    AkkaHttpGenerator.FrameworkInterp(modelGeneratorType)
   )
 
   def endpoints(modelGeneratorType: ModelGeneratorType)(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): (
@@ -80,9 +80,9 @@ object ScalaModule extends AbstractModule[ScalaLanguage] {
       ServerTerms[ScalaLanguage, Target],
       FrameworkTerms[ScalaLanguage, Target]
   ) = (
-    new EndpointsClientGenerator.ClientTermInterp,
-    new EndpointsServerGenerator.ServerTermInterp,
-    new EndpointsGenerator.FrameworkInterp
+    EndpointsClientGenerator.ClientTermInterp,
+    EndpointsServerGenerator.ServerTermInterp,
+    EndpointsGenerator.FrameworkInterp
   )
 
   def http4s(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): (
@@ -90,9 +90,9 @@ object ScalaModule extends AbstractModule[ScalaLanguage] {
       ServerTerms[ScalaLanguage, Target],
       FrameworkTerms[ScalaLanguage, Target]
   ) = (
-    new Http4sClientGenerator.ClientTermInterp,
-    new Http4sServerGenerator.ServerTermInterp,
-    new Http4sGenerator.FrameworkInterp
+    Http4sClientGenerator.ClientTermInterp,
+    Http4sServerGenerator.ServerTermInterp,
+    Http4sGenerator.FrameworkInterp
   )
 
   def dropwizard(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): (
@@ -100,9 +100,9 @@ object ScalaModule extends AbstractModule[ScalaLanguage] {
       ServerTerms[ScalaLanguage, Target],
       FrameworkTerms[ScalaLanguage, Target]
   ) = (
-    new DropwizardClientGenerator.ClientTermInterp,
-    new DropwizardServerGenerator.ServerTermInterp,
-    new DropwizardGenerator.FrameworkInterp
+    DropwizardClientGenerator.ClientTermInterp,
+    DropwizardServerGenerator.ServerTermInterp,
+    DropwizardGenerator.FrameworkInterp
   )
 
   def extract(modules: NonEmptyList[String]): Target[Framework[ScalaLanguage, Target]] = {


### PR DESCRIPTION
With the recent extension of alternate collections libraries by enabling different modules, many stable `object`s were converted into `class`es. This PR reintroduces the previous static members of the containing object, reducing syntax noise for consumers.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
