### PR TITLE
Adding raw client text/plain tests for akka-http

### DIFF
--- a/modules/sample-akkaHttp/src/test/scala/generators/AkkaHttp/Client/contentType/AkkaHttpTextPlainTest.scala
+++ b/modules/sample-akkaHttp/src/test/scala/generators/AkkaHttp/Client/contentType/AkkaHttpTextPlainTest.scala
@@ -7,6 +7,7 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.util.ByteString
 import cats.instances.future._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.EitherValues
@@ -116,5 +117,64 @@ class AkkaHttpTextPlainTest extends AnyFunSuite with Matchers with EitherValues 
     val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
     val fooClient                                   = FooClient.httpClient(client)
     fooClient.doBar(None).rightValue.futureValue shouldBe DoBarResponse.Created("response")
+  }
+
+  test("Raw Client: Plain text should be emitted for present empty optional parameters") {
+    val route: Route = FooResource.routes(new FooHandler {
+      def doFoo(
+          respond: FooResource.DoFooResponse.type
+      )(body: String): scala.concurrent.Future[FooResource.DoFooResponse] = ???
+      def doBar(respond: FooResource.DoBarResponse.type)(
+          body: Option[String]
+      ): scala.concurrent.Future[FooResource.DoBarResponse] =
+        if (body.isEmpty) {
+          Future.successful(respond.Created("created"))
+        } else {
+          Future.successful(respond.NotAcceptable)
+        }
+      def doBaz(respond: FooResource.DoBazResponse.type)(
+          body: Option[String]
+      ): scala.concurrent.Future[FooResource.DoBazResponse] = ???
+    })
+
+    val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
+    val data                                        = ""
+    val charset                                     = HttpCharsets.`ISO-8859-1`
+    val contentType                                 = ContentType.WithCharset(MediaTypes.`text/plain`, charset)
+    val entity                                      = HttpEntity(contentType, ByteString.fromArray(data.getBytes(charset.value)))
+    val request                                     = HttpRequest(HttpMethods.POST, "http://localhost/bar").withEntity(entity)
+    client(request).flatMap(_.toStrict(10.seconds)).futureValue.status.isSuccess shouldBe true
+  }
+
+  test("Raw Client: Plain text should be emitted for missing optional parameters") {
+    val route: Route = FooResource.routes(new FooHandler {
+      def doFoo(
+          respond: FooResource.DoFooResponse.type
+      )(body: String): scala.concurrent.Future[FooResource.DoFooResponse] = ???
+      def doBar(respond: FooResource.DoBarResponse.type)(
+          body: Option[String]
+      ): scala.concurrent.Future[FooResource.DoBarResponse] =
+        if (body.isEmpty) {
+          Future.successful(respond.Created("created"))
+        } else {
+          Future.successful(respond.NotAcceptable)
+        }
+      def doBaz(respond: FooResource.DoBazResponse.type)(
+          body: Option[String]
+      ): scala.concurrent.Future[FooResource.DoBazResponse] = ???
+    })
+
+    val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
+    val request                                     = HttpRequest(HttpMethods.POST, "http://localhost/bar")
+    val response                                    = client(request).flatMap(_.toStrict(10.seconds)).futureValue
+    response.status.isSuccess shouldBe true
+    response.entity
+      .toStrict(1.minute)
+      .flatMap(
+        _.dataBytes
+          .runFold(ByteString.empty) { case (acc, b) => acc ++ b }
+          .map(_.utf8String)
+      )
+      .futureValue shouldBe ("created")
   }
 }


### PR DESCRIPTION
I found some more tests for `text/plain` internally, moving these tests to the public guardrail codebase as well.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
