### PR TITLE
Fix Object.getClass() clash with DTO properties named "class"

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
@@ -95,7 +95,7 @@ object JacksonGenerator {
   // TODO: handle emptyToNull in the return for the getters
   private def addParameterGetter(cls: ClassOrInterfaceDeclaration, param: ParameterTerm): Unit = {
     val _ = cls
-      .addMethod(s"get${param.parameterName.unescapeIdentifier.capitalize}", PUBLIC)
+      .addMethod(getterMethodNameForParameter(param.parameterName), PUBLIC)
       .setType(param.fieldType)
       .setBody(
         new BlockStmt(
@@ -348,7 +348,7 @@ object JacksonGenerator {
         terms.filterNot(term => discriminatorNames.contains(term.propertyName))
 
       def parameterGetterCall(term: ParameterTerm, scope: Option[String] = None): MethodCallExpr = {
-        val methodName = s"get${term.parameterName.unescapeIdentifier.capitalize}"
+        val methodName = getterMethodNameForParameter(term.parameterName)
         scope.fold(new MethodCallExpr(methodName))(s => new MethodCallExpr(new NameExpr(s), methodName))
       }
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/Java.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/Java.scala
@@ -170,6 +170,19 @@ object Java {
 
   val GENERATED_CODE_COMMENT: Comment = new BlockComment(GENERATED_CODE_COMMENT_LINES.mkString("\n * ", "\n * ", "\n"))
 
+  private val reservedMethodNames = Set(
+    "getClass"
+  )
+
+  def getterMethodNameForParameter(parameterName: String): String = {
+    val name = s"get${parameterName.unescapeIdentifier.capitalize}"
+    if (reservedMethodNames.contains(name)) {
+      name + "_"
+    } else {
+      name
+    }
+  }
+
   // from https://en.wikipedia.org/wiki/List_of_Java_keywords
   private val reservedWords = Set(
     "abstract",

--- a/modules/codegen/src/test/scala/com/twilio/guardrail/generators/syntax/JavaSyntaxTest.scala
+++ b/modules/codegen/src/test/scala/com/twilio/guardrail/generators/syntax/JavaSyntaxTest.scala
@@ -15,12 +15,16 @@ object JavaSyntaxTest {
     "else",
     "throw"
   )
+
+  val TEST_PARAMETER_NAMES = Map(
+    "class_" -> "getClass_"
+  )
 }
 
 class JavaSyntaxTest extends AnyFreeSpec with Matchers {
   import JavaSyntaxTest._
 
-  "Reserved work escaper should" - {
+  "Reserved word escaper should" - {
     "Escape reserved words" in {
       TEST_RESERVED_WORDS.foreach({ word =>
         word.escapeReservedWord shouldBe (word + "_")
@@ -98,5 +102,12 @@ class JavaSyntaxTest extends AnyFreeSpec with Matchers {
       val result     = formatException("my prefix")(e)
       result shouldBe """my prefix: Unexpected "}" at character 2 (valid: "enum", "strictfp", "yield", "requires", "to", "with", "open", "opens", "uses", "module", "exports", "provides", "transitive", <IDENTIFIER>)"""
     }
+  }
+
+  "Reserved method names should be escaped" in {
+    TEST_PARAMETER_NAMES.foreach({
+      case (name, escapedName) =>
+        getterMethodNameForParameter(name) shouldBe escapedName
+    })
   }
 }

--- a/modules/codegen/src/test/scala/support/SwaggerSpecRunner.scala
+++ b/modules/codegen/src/test/scala/support/SwaggerSpecRunner.scala
@@ -3,12 +3,14 @@ package support
 import _root_.io.swagger.parser.OpenAPIParser
 import _root_.io.swagger.v3.oas.models._
 import _root_.io.swagger.v3.parser.core.models.ParseOptions
+import cats.data.NonEmptyList
 import com.twilio.guardrail._
 import com.twilio.guardrail.core.{ StructuredLogger, Tracker }
 import com.twilio.guardrail.generators.Framework
 import com.twilio.guardrail.languages.LA
 import org.scalactic.Equality
 import org.scalatest.{ EitherValues, OptionValues }
+
 import scala.meta.Tree
 
 trait SwaggerSpecRunner extends EitherValues with OptionValues {
@@ -28,7 +30,7 @@ trait SwaggerSpecRunner extends EitherValues with OptionValues {
   )(
       context: Context,
       framework: Framework[L, Target],
-      targets: List[CodegenTarget] = List(CodegenTarget.Client, CodegenTarget.Server)
+      targets: NonEmptyList[CodegenTarget] = NonEmptyList.of(CodegenTarget.Client, CodegenTarget.Server)
   ): (ProtocolDefinitions[L], Clients[L], Servers[L]) = {
     val parseOpts = new ParseOptions
     parseOpts.setResolve(true)
@@ -43,7 +45,7 @@ trait SwaggerSpecRunner extends EitherValues with OptionValues {
       swagger: OpenAPI,
       dtoPackage: List[String],
       supportPackage: List[String]
-  )(context: Context, framework: Framework[L, Target], targets: List[CodegenTarget]): (ProtocolDefinitions[L], Clients[L], Servers[L]) = {
+  )(context: Context, framework: Framework[L, Target], targets: NonEmptyList[CodegenTarget]): (ProtocolDefinitions[L], Clients[L], Servers[L]) = {
     import framework._
     targets
       .map(

--- a/modules/codegen/src/test/scala/tests/generators/dropwizard/JacksonGetterTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/dropwizard/JacksonGetterTest.scala
@@ -1,0 +1,42 @@
+package tests.generators.dropwizard
+
+import cats.data.NonEmptyList
+import com.twilio.guardrail.generators.Java.Dropwizard
+import com.twilio.guardrail.languages.JavaLanguage
+import com.twilio.guardrail.{ ClassDefinition, CodegenTarget, Context, ProtocolDefinitions }
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import support.SwaggerSpecRunner
+
+class JacksonGetterTest extends AnyFreeSpec with Matchers with SwaggerSpecRunner {
+  private val openapi =
+    s"""openapi: 3.0.2
+       |info:
+       |  title: Jackson Getter Test
+       |  version: 1.0.0
+       |paths: {}
+       |components:
+       |  schemas:
+       |    Foo:
+       |      type: object
+       |      required:
+       |        - class
+       |        - blah
+       |      properties:
+       |        class:
+       |          type: string
+       |        blah:
+       |          type: string
+       |""".stripMargin
+
+  "Jackson POJO getter for property called 'class' should not clash with Object.getClass()" in {
+    val (ProtocolDefinitions(ClassDefinition("Foo", _, _, classDef, _, _) :: Nil, _, _, _, _), _, _) =
+      runSwaggerSpec[JavaLanguage](openapi)(Context.empty, Dropwizard, targets = NonEmptyList.of(CodegenTarget.Models))
+
+    classDef.getMethodsByName("getClass").size mustBe 0
+    classDef.getMethodsByName("getClass_").size mustBe 1
+
+    classDef.getMethodsByName("getBlah_").size mustBe 0
+    classDef.getMethodsByName("getBlah").size mustBe 1
+  }
+}

--- a/modules/codegen/src/test/scala/tests/generators/dropwizardScala/server/DropwizardScalaJsr310Test.scala
+++ b/modules/codegen/src/test/scala/tests/generators/dropwizardScala/server/DropwizardScalaJsr310Test.scala
@@ -1,10 +1,12 @@
 package tests.generators.dropwizardScala.server
 
+import cats.data.NonEmptyList
 import com.twilio.guardrail.{ CodegenTarget, Context, Server, Servers }
 import com.twilio.guardrail.generators.Scala.Dropwizard
 import org.scalatest.OptionValues
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
+
 import scala.meta._
 import support.SwaggerSpecRunner
 
@@ -52,7 +54,7 @@ class DropwizardScalaJsr310Test extends AnyFreeSpec with Matchers with OptionVal
       _,
       _,
       Servers(Server(_, _, handler, server) :: Nil, _)
-    ) = runSwaggerSpec(openapi, supportPackage = List("support"))(Context.empty, Dropwizard, List(CodegenTarget.Server))
+    ) = runSwaggerSpec(openapi, supportPackage = List("support"))(Context.empty, Dropwizard, targets = NonEmptyList.of(CodegenTarget.Server))
 
     handler match {
       case Defn.Trait(


### PR DESCRIPTION
Addresses https://github.com/twilio/guardrail/issues/862

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
