### PR TITLE
Fix typo in Tracker scaladoc

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/core/Tracker.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/core/Tracker.scala
@@ -19,7 +19,7 @@ import cats.Functor
   *
   * val tracker:        Tracker[        OpenAPI  ] = Tracker(openAPI)
   * val servers:        Tracker[List[   Server  ]] = tracker.downField("servers", _.getServers)
-  * val firstServer:    Tracker[Option[ Server  ]] = tracker.map(_.headOption)
+  * val firstServer:    Tracker[Option[ Server  ]] = servers.map(_.headOption)
   * val firstServerUrl: Tracker[Option[ String  ]] = firstServer.flatDownField("url", _.getUrl)
   *
   * val trackedUrl:     Tracker[Option[ URL     ]] = firstServerUrl.map(_.map(new URL(_)))


### PR DESCRIPTION
In the scaladoc, it looks like the variable `tracker` should be `servers`.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
