### PR TITLE
Add Coproduct support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,7 @@ val springBootVersion      = "2.3.4.RELEASE"
 val jacksonVersion         = "2.11.3"
 val hibernateVersion       = "6.1.6.Final"
 val javaxElVersion         = "3.0.0"
+val shapelessVersion       = "2.3.3"
 
 mainClass in assembly := Some("com.twilio.guardrail.CLI")
 assemblyMergeStrategy in assembly := {
@@ -344,7 +345,8 @@ val akkaProjectDependencies = Seq(
   "io.circe"          %% "circe-jawn"        % circeVersion,
   "io.circe"          %% "circe-parser"      % circeVersion,
   "org.scalatest"     %% "scalatest"         % scalatestVersion % Test,
-  "org.typelevel"     %% "cats-core"         % catsVersion
+  "org.typelevel"     %% "cats-core"         % catsVersion,
+  "com.chuusai"       %% "shapeless"         % shapelessVersion
 )
 
 val akkaJacksonProjectDependencies = Seq(
@@ -362,6 +364,7 @@ val akkaJacksonProjectDependencies = Seq(
   "org.glassfish"                  %  "javax.el"                % javaxElVersion,
   "org.typelevel"                  %% "cats-core"               % catsVersion,
   "org.scalatest"                  %% "scalatest"               % scalatestVersion % Test,
+  "com.chuusai"                    %% "shapeless"               % shapelessVersion
 )
 
 val http4sProjectDependencies = Seq(
@@ -374,7 +377,8 @@ val http4sProjectDependencies = Seq(
   "org.http4s"    %% "http4s-dsl"          % http4sVersion,
   "org.scalatest" %% "scalatest"           % scalatestVersion % Test,
   "org.typelevel" %% "cats-core"           % catsVersion,
-  "org.typelevel" %% "cats-effect"         % catsEffectVersion
+  "org.typelevel" %% "cats-effect"         % catsEffectVersion,
+  "com.chuusai"   %% "shapeless"           % shapelessVersion
 )
 
 val dropwizardProjectDependencies = Seq(
@@ -481,7 +485,8 @@ lazy val endpointsSample = (project in file("modules/sample-endpoints"))
       "org.julienrf"      %%% "endpoints-xhr-client-circe"    % endpointsVersion,
       "org.julienrf"      %%% "endpoints-xhr-client-faithful" % endpointsVersion,
       "org.scalatest"     %%% "scalatest"                     % scalatestVersion % Test,
-      "org.typelevel"     %%% "cats-core"                     % catsVersion
+      "org.typelevel"     %%% "cats-core"                     % catsVersion,
+      "com.chuusai"       %%% "shapeless"                     % shapelessVersion
     ),
     unmanagedSourceDirectories in Compile += baseDirectory.value / "target" / "generated",
     skip in publish := true,

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpGenerator.scala
@@ -42,7 +42,8 @@ object AkkaHttpGenerator {
           q"import java.io.File",
           q"import java.security.MessageDigest",
           q"import java.util.concurrent.atomic.AtomicReference",
-          q"import scala.util.{Failure, Success}"
+          q"import scala.util.{Failure, Success}",
+          q"import shapeless.{:+:, CNil, Coproduct}"
         ) ++ (modelGeneratorType match {
               case _: CirceModelGenerator => List(q"import io.circe.Decoder")
               case JacksonModelGenerator  => List()

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/EndpointsGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/EndpointsGenerator.scala
@@ -25,7 +25,8 @@ object EndpointsGenerator {
           q"import endpoints.algebra.Documentation",
           q"import endpoints.xhr",
           q"import io.circe.{parser, Decoder => CirceDecoder, Encoder => CirceEncoder}",
-          q"import org.scalajs.dom.raw.XMLHttpRequest"
+          q"import org.scalajs.dom.raw.XMLHttpRequest",
+          q"import shapeless.{:+:, CNil, Coproduct}"
         )
       )
     def getFrameworkImplicits() = Target.pure(Some((q"EndpointsImplicits", q"""

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sGenerator.scala
@@ -39,7 +39,8 @@ object Http4sGenerator {
           q"import fs2.Stream",
           q"import io.circe.Json",
           q"import scala.language.higherKinds",
-          q"import scala.language.implicitConversions"
+          q"import scala.language.implicitConversions",
+          q"import shapeless.{:+:, CNil, Coproduct}"
         )
       )
     def getFrameworkImplicits() =

--- a/modules/codegen/src/test/scala/tests/core/FullyQualifiedNames.scala
+++ b/modules/codegen/src/test/scala/tests/core/FullyQualifiedNames.scala
@@ -69,6 +69,9 @@ class FullyQualifiedNames extends AnyFunSuite with Matchers with SwaggerSpecRunn
           case x: GetUserResponse.Ok =>
             handleOk(x.value)
           }
+
+          type CoproductType = _root_.com.test.User :+: CNil
+          def toCoproduct: CoproductType = fold(value => Coproduct[CoproductType](value))
         }
        """
 

--- a/modules/codegen/src/test/scala/tests/generators/http4s/BasicTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/http4s/BasicTest.scala
@@ -206,6 +206,9 @@ class BasicTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
           def fold[A](handleOk: => A): A = this match {
             case GetBarResponse.Ok => handleOk
           }
+
+          type CoproductType = Unit :+: CNil
+          def toCoproduct: CoproductType = fold(Coproduct[CoproductType](()))
         }
       """,
       q"""object GetBarResponse { case object Ok extends GetBarResponse }""",
@@ -215,6 +218,9 @@ class BasicTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
             case x: GetBazResponse.Ok =>
               handleOk(x.value)
           }
+
+          type CoproductType = io.circe.Json :+: CNil
+          def toCoproduct: CoproductType = fold(value => Coproduct[CoproductType](value))
         }
       """,
       q"""object GetBazResponse { case class Ok(value: io.circe.Json) extends GetBazResponse }""",
@@ -223,6 +229,9 @@ class BasicTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
           def fold[A](handleOk: => A): A = this match {
             case PostFooResponse.Ok => handleOk
           }
+
+          type CoproductType = Unit :+: CNil
+          def toCoproduct: CoproductType = fold(Coproduct[CoproductType](()))
         }
       """,
       q"""object PostFooResponse { case object Ok extends PostFooResponse }""",
@@ -231,6 +240,9 @@ class BasicTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
           def fold[A](handleOk: => A): A = this match {
             case GetFooResponse.Ok => handleOk
           }
+
+          type CoproductType = Unit :+: CNil
+          def toCoproduct: CoproductType = fold(Coproduct[CoproductType](()))
         }
       """,
       q"""object GetFooResponse { case object Ok extends GetFooResponse }""",
@@ -239,6 +251,9 @@ class BasicTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
           def fold[A](handleOk: => A): A = this match {
             case PutFooResponse.Ok => handleOk
           }
+
+          type CoproductType = Unit :+: CNil
+          def toCoproduct: CoproductType = fold(Coproduct[CoproductType](()))
         }
       """,
       q"""object PutFooResponse { case object Ok extends PutFooResponse }""",
@@ -247,6 +262,9 @@ class BasicTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
           def fold[A](handleOk: => A): A = this match {
             case PatchFooResponse.Ok => handleOk
           }
+
+          type CoproductType = Unit :+: CNil
+          def toCoproduct: CoproductType = fold(Coproduct[CoproductType](()))
         }
       """,
       q"""object PatchFooResponse { case object Ok extends PatchFooResponse }""",
@@ -255,6 +273,9 @@ class BasicTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
           def fold[A](handleOk: => A): A = this match {
             case DeleteFooResponse.Ok => handleOk
           }
+
+          type CoproductType = Unit :+: CNil
+          def toCoproduct: CoproductType = fold(Coproduct[CoproductType](()))
         }
       """,
       q"""object DeleteFooResponse { case object Ok extends DeleteFooResponse }"""

--- a/modules/codegen/src/test/scala/tests/generators/http4s/client/DefaultParametersTest.scala
+++ b/modules/codegen/src/test/scala/tests/generators/http4s/client/DefaultParametersTest.scala
@@ -183,6 +183,9 @@ class DefaultParametersTest extends AnyFunSuite with Matchers with SwaggerSpecRu
             case GetOrderByIdResponse.NotFound =>
               handleNotFound
           }
+
+          type CoproductType = Order :+: Unit :+: CNil
+          def toCoproduct: CoproductType = fold(value => Coproduct[CoproductType](value), Coproduct[CoproductType](()), Coproduct[CoproductType](()))
         }
       """,
       q"""object GetOrderByIdResponse {
@@ -196,6 +199,9 @@ class DefaultParametersTest extends AnyFunSuite with Matchers with SwaggerSpecRu
             case DeleteOrderResponse.BadRequest => handleBadRequest
             case DeleteOrderResponse.NotFound => handleNotFound
           }
+
+          type CoproductType = Unit :+: CNil
+          def toCoproduct: CoproductType = fold(Coproduct[CoproductType](()), Coproduct[CoproductType](()))
         }
       """,
       q"""object DeleteOrderResponse {


### PR DESCRIPTION
This PR adds Coproduct support to Guardrail for Scala projects. What this means is that, if I have a Swagger/Open API schema which defines responses for some operation `foo` like the following:

```yaml
responses:
  responses:
    '200':
      schema:
        $ref: '#/definitions/Success'
    '400':
      schema:
        $ref: '#/definitions/Failure'
    '500':
      schema:
        $ref: '#/definitions/Failure'
```

Then Guardrail will generate a FooResponse like the following:

```scala
sealed abstract class FooResponse {
  type CoproductType = Success :+: Failure :+: CNil
  def toCoproduct: CoproductType
}
```

Then, any time I have a value `fooResponse` of type FooResponse, I can `select`, `map`, etc., the various response values:

```scala
val successO: Option[Success] = fooResponse.toCoproduct.select[Success]
val failureO: Option[Failure] = fooResponse.toCoproduct.select[Failure]

object handler extends Poly1 {
  implicit def caseSuccess = at[Success](success => log(s"Succeeded with $success"))
  implicit def caseFailure = at[Failure](failure => log(s"Failed with $failure"))
}

fooResponse.toCoproduct.map(handler)
```

**Pros**

- Guardrail responses are effectively sum types. Shapeless offers [Coproducts](https://github.com/milessabin/shapeless/wiki/Feature-overview:-shapeless-2.0.0#coproducts-and-discriminated-unions), a powerful type for working generically with sum types. By providing a mapping from Guardrail responses to Coproducts, we enable engineers to leverage features in Shapeless while saving them the trouble of writing error-prone conversions themselves.
- Coproducts offer `map`, `flatMap`, etc., operations that ensure each case is covered. Unless you enable fatal warnings (not always feasible), this is something `match` won't give you. `fold` is better but, due to the way handlers are often written in-line, it's possible that, when updating Open API schemas, cases get mixed up.
- Coproducts offer a `select` function which projects/selects the Coproduct to an Option of the desired type. In other words, if a Coproduct contains a value `foo` of type `Foo`, you can `select[Foo]` to get `Some(foo)`; if the Coproduct does not contain a value of type `Foo`, you get `None`.
- The way Coproduct is used here allows distinct responses to be projected to a common value. For example, some HTTP applications return a uniform error response, irrespective of the actual HTTP status code. If your client doesn't care that it got a 400, 401, etc., just that it got an error response, using `select`, `map`, etc., with Coproduct reduces the number of cases you have to handle. Same for success cases.

**Cons**

- All Scala projects incur a dependency on Shapeless 2.x, even if they'll never use Coproduct. This could perhaps be solved with a configuration option to include/exclude Coproduct support, not unlike tracing.
- We could provide many of the same "Pros" listed above by implementing our own `select`, our own traits for consuming responses, without depending on Shapeless.
- The way Coproduct is used here is (intentionally) lossy. For example, if two Guardrail responses are empty, they'll both map to Unit. Now, when calling `map` on the Coproduct, we can no longer distinguish the two responses: we only have a single Unit case to deal with. This could be solved using [discriminated unions](https://github.com/milessabin/shapeless/wiki/Feature-overview:-shapeless-2.0.0#coproducts-and-discriminated-unions), where elements of the Coproduct are labeled with their HTTP status code, the type of the response they were projected from, etc. I plan to explore this next.
- Coproduct performance may be slower (at both compile- time and run-time).

**Other Notes/Questions**

- In this PR, in order to access the Coproduct representation, you call a function `toCoproduct` on the Guardrail response. Should we instead provide an implicit conversion to `CoproductType`, such that, if the implicit is in scope, calling `toCoproduct` is not necessary?
- In this PR, Coproduct support is directly added to the Guardrail response, right below the `fold` function. Should we instead generate this in its own file? Would that be easier to include/exclude if we wanted to allow toggling Coproduct?

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
