### PR TITLE
add SBT command alias:  publishM2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -228,6 +228,10 @@ addCommandAlias(
   "publishLocal",
   "; package ; codegen/publishLocal"
 )
+addCommandAlias(
+  "publishM2",
+  "; package ; codegen/publishM2"
+)
 
 resolvers += Resolver.sonatypeRepo("releases")
 addCompilerPlugin("org.typelevel" % "kind-projector"  % kindProjectorVersion cross CrossVersion.binary)


### PR DESCRIPTION
"Similar to publishLocal, publishM2 task will publish to the user’s Maven local repository."

https://www.scala-sbt.org/1.x/docs/Publishing.html
