### PR TITLE
Fix stdlib collections stream/collect

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
@@ -58,7 +58,7 @@ object AsyncHttpClientClientGenerator {
     def doShow(tpe: Type)(implicit Ca: CollectionsAbstraction[JavaLanguage]): Expression = {
       import Ca._
       tpe match {
-        case cls: ClassOrInterfaceType if cls.isOptionalType || cls.isVectorType =>
+        case cls: ClassOrInterfaceType if cls.isOptionalType || cls.isListType =>
           doShow(cls.containedType)
         case _ =>
           new MethodCallExpr(
@@ -80,7 +80,7 @@ object AsyncHttpClientClientGenerator {
 
     val finalMethodName = if (needsMultipart) "addBodyPart" else builderMethodName
     val argName         = param.paramName.asString
-    val isArray         = param.argType.isVectorType
+    val isArray         = param.argType.isListType
 
     val makeArgList: String => NodeList[Expression] = name =>
       if (param.isFile) {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
@@ -365,7 +365,7 @@ object DropwizardServerGenerator {
               }
 
               def stripOptionalFromCollections(parameter: Parameter, param: LanguageParameter[JavaLanguage]): Parameter =
-                if (!param.required && parameter.getType.containedType.isVectorType) {
+                if (!param.required && parameter.getType.containedType.isListType) {
                   parameter.setType(parameter.getType.containedType)
                 } else {
                   parameter

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/collections/CollectionsAbstraction.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/collections/CollectionsAbstraction.scala
@@ -52,7 +52,7 @@ trait MonadFSyntax[L <: LA] {
 
   implicit class TermHolderExpressionSyntaxMonadF[From <: L#Expression, A](fa: TermHolder[L, From, A]) {
     def liftOptional(implicit ev: MonadF[L, Option]): TermHolder[L, L#Apply, Option[A]]  = ev.pure(fa)
-    def liftVector(implicit ev: MonadF[L, Vector]): TermHolder[L, L#Apply, Vector[A]]    = ev.pure(fa)
+    def liftList(implicit ev: MonadF[L, List]): TermHolder[L, L#Apply, List[A]]          = ev.pure(fa)
     def liftMap(implicit ev: MonadF[L, StringMap]): TermHolder[L, L#Apply, StringMap[A]] = ev.pure(fa)
     def liftFuture(implicit ev: MonadF[L, Future]): TermHolder[L, L#Apply, Future[A]]    = ev.pure(fa)
   }
@@ -74,16 +74,16 @@ trait EmptyF[L <: LA, F[_]] {
 
 trait EmptyFBuilders[L <: LA] {
   def emptyOptional[A](implicit ev: EmptyF[L, Option]): TermHolder[L, L#Apply, Option[A]]  = ev.empty
-  def emptyVector[A](implicit ev: EmptyF[L, Vector]): TermHolder[L, L#Apply, Vector[A]]    = ev.empty
+  def emptyList[A](implicit ev: EmptyF[L, List]): TermHolder[L, L#Apply, List[A]]          = ev.empty
   def emptyMap[A](implicit ev: EmptyF[L, StringMap]): TermHolder[L, L#Apply, StringMap[A]] = ev.empty
 }
 
-trait VectorF[L <: LA] extends MonadF[L, Vector] with EmptyF[L, Vector] with ToArrayF[L, Vector]
+trait ListF[L <: LA] extends MonadF[L, List] with EmptyF[L, List] with ToArrayF[L, List]
 
-trait VectorFSyntax[L <: LA] {
-  implicit class VectorTypeSyntaxMonadF(tpe: L#Type)(implicit ev: VectorF[L]) {
-    def liftVectorType: L#Type = ev.liftType(tpe)
-    def isVectorType: Boolean  = ev.isType(tpe)
+trait ListFSyntax[L <: LA] {
+  implicit class ListTypeSyntaxMonadF(tpe: L#Type)(implicit ev: ListF[L]) {
+    def liftListType: L#Type = ev.liftType(tpe)
+    def isListType: Boolean  = ev.isType(tpe)
   }
 }
 
@@ -146,7 +146,7 @@ trait FutureFSyntax[L <: LA] {
 trait CollectionsAbstractionSyntax[L <: LA]
     extends MonadFSyntax[L]
     with ToArrayFSyntax[L]
-    with VectorFSyntax[L]
+    with ListFSyntax[L]
     with OptionFSyntax[L]
     with FutureFSyntax[L]
     with EmptyFBuilders[L] {
@@ -157,16 +157,16 @@ trait CollectionsAbstractionSyntax[L <: LA]
 
 trait CollectionsAbstraction[L <: LA] extends CollectionsAbstractionSyntax[L] {
   implicit def optionInstances: OptionF[L]
-  implicit def vectorInstances: VectorF[L]
+  implicit def listInstances: ListF[L]
   implicit def futureInstances: FutureF[L]
 
   def copy(
       newOptionInstances: OptionF[L] = optionInstances,
-      newVectorInstances: VectorF[L] = vectorInstances,
+      newListInstances: ListF[L] = listInstances,
       newFutureInstances: FutureF[L] = futureInstances
   ): CollectionsAbstraction[L] = new CollectionsAbstraction[L] {
     override implicit def optionInstances: OptionF[L] = newOptionInstances
-    override implicit def vectorInstances: VectorF[L] = newVectorInstances
+    override implicit def listInstances: ListF[L]     = newListInstances
     override implicit def futureInstances: FutureF[L] = newFutureInstances
   }
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/collections/CollectionsAbstraction.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/collections/CollectionsAbstraction.scala
@@ -34,13 +34,17 @@ trait MonadF[L <: LA, F[_]] {
   def liftType(tpe: L#Type): L#Type
   def isType(tpe: L#Type): Boolean
   def pure[From <: L#Expression, A](fa: TermHolder[L, From, A]): TermHolder[L, L#Apply, F[A]]
+  def filter[From <: L#Expression, A, Func <: L#Expression](f: TermHolder[L, Func, A => Boolean])(fa: TermHolder[L, From, F[A]])(
+      implicit clsA: ClassTag[A]
+  ): TermHolder[L, L#Apply, F[A]]
   def foreach[From <: L#Expression, A, Func <: L#Expression](f: TermHolder[L, Func, A => Unit])(fa: TermHolder[L, From, F[A]]): TermHolder[L, L#Apply, Unit]
   def map[From <: L#Expression, A, B, Func <: L#Expression](f: TermHolder[L, Func, A => B])(fa: TermHolder[L, From, F[A]]): TermHolder[L, L#Apply, F[B]]
   def flatMap[From <: L#Expression, A, B, Func <: L#Expression](f: TermHolder[L, Func, A => F[B]])(fa: TermHolder[L, From, F[A]]): TermHolder[L, L#Apply, F[B]]
 }
 
 trait MonadFSyntax[L <: LA] {
-  implicit class TermHolderSyntaxMonadF[From <: L#Expression, F[_], A](fa: TermHolder[L, From, F[A]])(implicit ev: MonadF[L, F]) {
+  implicit class TermHolderSyntaxMonadF[From <: L#Expression, F[_], A: ClassTag](fa: TermHolder[L, From, F[A]])(implicit ev: MonadF[L, F]) {
+    def filter[Func <: L#Expression](f: TermHolder[L, Func, A => Boolean]): TermHolder[L, L#Apply, F[A]]  = ev.filter(f)(fa)
     def foreach[Func <: L#Expression](f: TermHolder[L, Func, A => Unit]): TermHolder[L, L#Apply, Unit]    = ev.foreach(f)(fa)
     def map[Func <: L#Expression, B](f: TermHolder[L, Func, A => B]): TermHolder[L, L#Apply, F[B]]        = ev.map(f)(fa)
     def flatMap[Func <: L#Expression, B](f: TermHolder[L, Func, A => F[B]]): TermHolder[L, L#Apply, F[B]] = ev.flatMap(f)(fa)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/collections/CollectionsAbstraction.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/collections/CollectionsAbstraction.scala
@@ -6,9 +6,22 @@ import java.util.concurrent.CompletionStage
 import scala.concurrent.Future
 import scala.reflect.ClassTag
 
-case class TermHolder[L <: LA, +A, HeldType](value: A)
+class TermHolder[L <: LA, +A, HeldType](_value: A) {
+  def value: A = _value
+
+  override def equals(obj: Any): Boolean = Option(obj) match {
+    case Some(other: TermHolder[_, _, _]) => value.equals(other.value)
+    case _                                => false
+  }
+  override def hashCode(): Int  = value.hashCode()
+  override def toString: String = value.toString
+}
+
 object TermHolder {
   type StringMap[A] = Map[String, A]
+
+  def apply[L <: LA, A, HeldType](value: A): TermHolder[L, A, HeldType] = new TermHolder[L, A, HeldType](value)
+  def unapply[A](th: TermHolder[_, A, _]): Option[A]                    = Some(th.value)
 
   final private[collections] class TermHolderPartiallyApplied[L <: LA, HeldType] private[TermHolder] (private val dummy: Boolean = true) extends AnyVal {
     def apply[A <: L#Expression](fa: A): TermHolder[L, A, HeldType] = TermHolder[L, A, HeldType](fa)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/collections/JavaStdLibCollections.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/collections/JavaStdLibCollections.scala
@@ -72,14 +72,14 @@ trait JavaStdLibCollections extends CollectionsAbstraction[JavaLanguage] {
       doMethodCall(fa.value, "orElseThrow", f.value)
   }
 
-  override implicit val vectorInstances: VectorF[JavaLanguage] = new VectorF[JavaLanguage] {
+  override implicit val listInstances: ListF[JavaLanguage] = new ListF[JavaLanguage] {
     override def liftType(tpe: Type): Type = StaticJavaParser.parseClassOrInterfaceType("java.util.List").setTypeArguments(tpe)
     override def isType(tpe: Type): Boolean =
       isContainerOfType(tpe, "java.util", "List") ||
-        isContainerOfType(tpe, "java.util", "Vector")
+        isContainerOfType(tpe, "java.util", "List")
 
-    override def pure[From <: Expression, A](fa: TermHolder[JavaLanguage, From, A]): TermHolder[JavaLanguage, MethodCallExpr, Vector[A]] =
-      TermHolder[JavaLanguage, MethodCallExpr, Vector[A]](
+    override def pure[From <: Expression, A](fa: TermHolder[JavaLanguage, From, A]): TermHolder[JavaLanguage, MethodCallExpr, List[A]] =
+      TermHolder[JavaLanguage, MethodCallExpr, List[A]](
         new MethodCallExpr(
           new NameExpr("java.util.Collections"),
           "singletonList",
@@ -87,15 +87,15 @@ trait JavaStdLibCollections extends CollectionsAbstraction[JavaLanguage] {
         )
       )
 
-    override def empty[A]: TermHolder[JavaLanguage, MethodCallExpr, Vector[A]] =
-      TermHolder[JavaLanguage, MethodCallExpr, Vector[A]](
+    override def empty[A]: TermHolder[JavaLanguage, MethodCallExpr, List[A]] =
+      TermHolder[JavaLanguage, MethodCallExpr, List[A]](
         new MethodCallExpr(new NameExpr("java.util.Collections"), "emptyList")
       )
 
     override def filter[From <: Expression, A, Func <: Expression](
         f: TermHolder[JavaLanguage, Func, A => Boolean]
-    )(fa: TermHolder[JavaLanguage, From, Vector[A]])(implicit clsA: ClassTag[A]): TermHolder[JavaLanguage, MethodCallExpr, Vector[A]] =
-      JavaStdLibTermHolder[Vector[A]](
+    )(fa: TermHolder[JavaLanguage, From, List[A]])(implicit clsA: ClassTag[A]): TermHolder[JavaLanguage, MethodCallExpr, List[A]] =
+      JavaStdLibTermHolder[List[A]](
         new MethodCallExpr(
           // If we already are a Stream, use it as-is.  Otherwise call stream()
           fa match {
@@ -109,7 +109,7 @@ trait JavaStdLibCollections extends CollectionsAbstraction[JavaLanguage] {
 
     override def foreach[From <: Expression, A, Func <: Expression](
         f: TermHolder[JavaLanguage, Func, A => Unit]
-    )(fa: TermHolder[JavaLanguage, From, Vector[A]]): TermHolder[JavaLanguage, MethodCallExpr, Unit] =
+    )(fa: TermHolder[JavaLanguage, From, List[A]]): TermHolder[JavaLanguage, MethodCallExpr, Unit] =
       TermHolder[JavaLanguage, MethodCallExpr, Unit](
         new MethodCallExpr(
           // forEach() exists on both Stream and List; if we're already a Stream, stick with the Stream,
@@ -125,8 +125,8 @@ trait JavaStdLibCollections extends CollectionsAbstraction[JavaLanguage] {
 
     override def map[From <: Expression, A, B, Func <: Expression](
         f: TermHolder[JavaLanguage, Func, A => B]
-    )(fa: TermHolder[JavaLanguage, From, Vector[A]]): TermHolder[JavaLanguage, MethodCallExpr, Vector[B]] =
-      JavaStdLibTermHolder[Vector[B]](
+    )(fa: TermHolder[JavaLanguage, From, List[A]]): TermHolder[JavaLanguage, MethodCallExpr, List[B]] =
+      JavaStdLibTermHolder[List[B]](
         new MethodCallExpr(
           // If we already are a Stream, use it as-is.  Otherwise call stream()
           fa match {
@@ -139,9 +139,9 @@ trait JavaStdLibCollections extends CollectionsAbstraction[JavaLanguage] {
       )
 
     override def flatMap[From <: Expression, A, B, Func <: Expression](
-        f: TermHolder[JavaLanguage, Func, A => Vector[B]]
-    )(fa: TermHolder[JavaLanguage, From, Vector[A]]): TermHolder[JavaLanguage, MethodCallExpr, Vector[B]] =
-      JavaStdLibTermHolder[Vector[B]](
+        f: TermHolder[JavaLanguage, Func, A => List[B]]
+    )(fa: TermHolder[JavaLanguage, From, List[A]]): TermHolder[JavaLanguage, MethodCallExpr, List[B]] =
+      JavaStdLibTermHolder[List[B]](
         new MethodCallExpr(
           // If we already are a Stream, use it as-is.  Otherwise call stream()
           fa match {
@@ -154,7 +154,7 @@ trait JavaStdLibCollections extends CollectionsAbstraction[JavaLanguage] {
       )
 
     override def toArray[From <: Expression, A](
-        fa: TermHolder[JavaLanguage, From, Vector[A]]
+        fa: TermHolder[JavaLanguage, From, List[A]]
     )(implicit clsA: ClassTag[A]): TermHolder[JavaLanguage, MethodCallExpr, Array[A]] =
       TermHolder[JavaLanguage, MethodCallExpr, Array[A]](
         fa match {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/collections/JavaVavrCollections.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/collections/JavaVavrCollections.scala
@@ -27,6 +27,11 @@ trait JavaVavrCollections extends CollectionsAbstraction[JavaLanguage] {
     )(fa: TermHolder[JavaLanguage, From, Option[A]]): TermHolder[JavaLanguage, MethodCallExpr, Unit] =
       doMethodCall(fa.value, "forEach", f.value)
 
+    override def filter[From <: Expression, A, Func <: Expression](
+        f: TermHolder[JavaLanguage, Func, A => Boolean]
+    )(fa: TermHolder[JavaLanguage, From, Option[A]])(implicit clsA: ClassTag[A]): TermHolder[JavaLanguage, MethodCallExpr, Option[A]] =
+      doMethodCall(fa.value, "filter", f.value)
+
     override def map[From <: Expression, A, B, Func <: Expression](
         f: TermHolder[JavaLanguage, Func, A => B]
     )(fa: TermHolder[JavaLanguage, From, Option[A]]): TermHolder[JavaLanguage, MethodCallExpr, Option[B]] =
@@ -84,6 +89,11 @@ trait JavaVavrCollections extends CollectionsAbstraction[JavaLanguage] {
         )
       )
 
+    override def filter[From <: Expression, A, Func <: Expression](
+        f: TermHolder[JavaLanguage, Func, A => Boolean]
+    )(fa: TermHolder[JavaLanguage, From, Vector[A]])(implicit clsA: ClassTag[A]): TermHolder[JavaLanguage, MethodCallExpr, Vector[A]] =
+      doMethodCall(fa.value, "filter", f.value)
+
     override def map[From <: Expression, A, B, Func <: Expression](
         f: TermHolder[JavaLanguage, Func, A => B]
     )(fa: TermHolder[JavaLanguage, From, Vector[A]]): TermHolder[JavaLanguage, MethodCallExpr, Vector[B]] =
@@ -134,6 +144,11 @@ trait JavaVavrCollections extends CollectionsAbstraction[JavaLanguage] {
         f: TermHolder[JavaLanguage, Func, A => Unit]
     )(fa: TermHolder[JavaLanguage, From, Future[A]]): TermHolder[JavaLanguage, MethodCallExpr, Unit] =
       doMethodCall(fa.value, "onSuccess", f.value)
+
+    override def filter[From <: Expression, A, Func <: Expression](
+        f: TermHolder[JavaLanguage, Func, A => Boolean]
+    )(fa: TermHolder[JavaLanguage, From, Future[A]])(implicit clsA: ClassTag[A]): TermHolder[JavaLanguage, MethodCallExpr, Future[A]] =
+      doMethodCall(fa.value, "filter", f.value)
 
     override def map[From <: Expression, A, B, Func <: Expression](
         f: TermHolder[JavaLanguage, Func, A => B]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/collections/JavaVavrCollections.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/collections/JavaVavrCollections.scala
@@ -56,16 +56,16 @@ trait JavaVavrCollections extends CollectionsAbstraction[JavaLanguage] {
       doMethodCall(fa.value, "getOrElseThrow", f.value)
   }
 
-  override implicit val vectorInstances: VectorF[JavaLanguage] = new VectorF[JavaLanguage] {
+  override implicit val listInstances: ListF[JavaLanguage] = new ListF[JavaLanguage] {
     override def liftType(tpe: Type): Type = StaticJavaParser.parseClassOrInterfaceType("io.vavr.collection.Vector").setTypeArguments(tpe)
 
     override def isType(tpe: Type): Boolean =
       isContainerOfType(tpe, "io.vavr.collection", "Vector") ||
-        isContainerOfType(tpe, "io.vavr.collection", "Vector") ||
+        isContainerOfType(tpe, "io.vavr.collection", "List") ||
         isContainerOfType(tpe, "io.vavr.collection", "Seq")
 
-    override def pure[From <: Expression, A](fa: TermHolder[JavaLanguage, From, A]): TermHolder[JavaLanguage, MethodCallExpr, Vector[A]] =
-      TermHolder[JavaLanguage, MethodCallExpr, Vector[A]](
+    override def pure[From <: Expression, A](fa: TermHolder[JavaLanguage, From, A]): TermHolder[JavaLanguage, MethodCallExpr, List[A]] =
+      TermHolder[JavaLanguage, MethodCallExpr, List[A]](
         new MethodCallExpr(
           new NameExpr("io.vavr.collection.Vector"),
           "of",
@@ -73,14 +73,14 @@ trait JavaVavrCollections extends CollectionsAbstraction[JavaLanguage] {
         )
       )
 
-    override def empty[A]: TermHolder[JavaLanguage, MethodCallExpr, Vector[A]] =
-      TermHolder[JavaLanguage, MethodCallExpr, Vector[A]](
-        new MethodCallExpr(new NameExpr("Vector"), "empty")
+    override def empty[A]: TermHolder[JavaLanguage, MethodCallExpr, List[A]] =
+      TermHolder[JavaLanguage, MethodCallExpr, List[A]](
+        new MethodCallExpr(new NameExpr("List"), "empty")
       )
 
     override def foreach[From <: Expression, A, Func <: Expression](
         f: TermHolder[JavaLanguage, Func, A => Unit]
-    )(fa: TermHolder[JavaLanguage, From, Vector[A]]): TermHolder[JavaLanguage, MethodCallExpr, Unit] =
+    )(fa: TermHolder[JavaLanguage, From, List[A]]): TermHolder[JavaLanguage, MethodCallExpr, Unit] =
       TermHolder[JavaLanguage, MethodCallExpr, Unit](
         new MethodCallExpr(
           fa.value,
@@ -91,13 +91,13 @@ trait JavaVavrCollections extends CollectionsAbstraction[JavaLanguage] {
 
     override def filter[From <: Expression, A, Func <: Expression](
         f: TermHolder[JavaLanguage, Func, A => Boolean]
-    )(fa: TermHolder[JavaLanguage, From, Vector[A]])(implicit clsA: ClassTag[A]): TermHolder[JavaLanguage, MethodCallExpr, Vector[A]] =
+    )(fa: TermHolder[JavaLanguage, From, List[A]])(implicit clsA: ClassTag[A]): TermHolder[JavaLanguage, MethodCallExpr, List[A]] =
       doMethodCall(fa.value, "filter", f.value)
 
     override def map[From <: Expression, A, B, Func <: Expression](
         f: TermHolder[JavaLanguage, Func, A => B]
-    )(fa: TermHolder[JavaLanguage, From, Vector[A]]): TermHolder[JavaLanguage, MethodCallExpr, Vector[B]] =
-      TermHolder[JavaLanguage, MethodCallExpr, Vector[B]](
+    )(fa: TermHolder[JavaLanguage, From, List[A]]): TermHolder[JavaLanguage, MethodCallExpr, List[B]] =
+      TermHolder[JavaLanguage, MethodCallExpr, List[B]](
         new MethodCallExpr(
           fa.value,
           "map",
@@ -106,9 +106,9 @@ trait JavaVavrCollections extends CollectionsAbstraction[JavaLanguage] {
       )
 
     override def flatMap[From <: Expression, A, B, Func <: Expression](
-        f: TermHolder[JavaLanguage, Func, A => Vector[B]]
-    )(fa: TermHolder[JavaLanguage, From, Vector[A]]): TermHolder[JavaLanguage, MethodCallExpr, Vector[B]] =
-      TermHolder[JavaLanguage, MethodCallExpr, Vector[B]](
+        f: TermHolder[JavaLanguage, Func, A => List[B]]
+    )(fa: TermHolder[JavaLanguage, From, List[A]]): TermHolder[JavaLanguage, MethodCallExpr, List[B]] =
+      TermHolder[JavaLanguage, MethodCallExpr, List[B]](
         new MethodCallExpr(
           fa.value,
           "flatMap",
@@ -117,7 +117,7 @@ trait JavaVavrCollections extends CollectionsAbstraction[JavaLanguage] {
       )
 
     override def toArray[From <: Expression, A](
-        fa: TermHolder[JavaLanguage, From, Vector[A]]
+        fa: TermHolder[JavaLanguage, From, List[A]]
     )(implicit clsA: ClassTag[A]): TermHolder[JavaLanguage, MethodCallExpr, Array[A]] = {
       val resultType = typeFromClass(clsA.runtimeClass, boxPrimitives = false)
       TermHolder[JavaLanguage, MethodCallExpr, Array[A]](

--- a/modules/codegen/src/test/scala/com/twilio/guardrail/collections/CollectionsAbstractionTest.scala
+++ b/modules/codegen/src/test/scala/com/twilio/guardrail/collections/CollectionsAbstractionTest.scala
@@ -51,7 +51,12 @@ class CollectionsAbstractionTest extends AnyFreeSpec with Matchers {
       new BinaryExpr(new NameExpr("a"), new IntegerLiteralExpr("1"), BinaryExpr.Operator.PLUS)
     ).lift[Int => Int]
 
-    fa.map(f)
+    val f1 = new LambdaExpr(
+      new Parameter(new UnknownType, "a"),
+      new BinaryExpr(new NameExpr("a"), new IntegerLiteralExpr("5"), BinaryExpr.Operator.MULTIPLY)
+    ).lift[Int => Int]
+
+    fa.map(f).map(f1)
   }
 
   def futurePipeline(implicit Ca: CollectionsAbstraction[JavaLanguage]): TermHolder[JavaLanguage, MethodCallExpr, Future[Int]] = {
@@ -109,7 +114,7 @@ class CollectionsAbstractionTest extends AnyFreeSpec with Matchers {
     }
 
     "Vector pipelines should render" in {
-      vectorPipeline.value.toString mustBe "java.util.Collections.singletonList(5).stream().map(a -> a + 1).collect(java.util.stream.Collectors.toList())"
+      vectorPipeline.value.toString mustBe "java.util.Collections.singletonList(5).stream().map(a -> a + 1).map(a -> a * 5).collect(java.util.stream.Collectors.toList())"
     }
 
     "Future pipelines should render" in {
@@ -156,7 +161,7 @@ class CollectionsAbstractionTest extends AnyFreeSpec with Matchers {
     }
 
     "Vector pipelines should render" in {
-      vectorPipeline.value.toString mustBe "io.vavr.collection.Vector.of(5).map(a -> a + 1)"
+      vectorPipeline.value.toString mustBe "io.vavr.collection.Vector.of(5).map(a -> a + 1).map(a -> a * 5)"
     }
 
     "Future pipelines should render" in {

--- a/modules/codegen/src/test/scala/com/twilio/guardrail/collections/CollectionsAbstractionTest.scala
+++ b/modules/codegen/src/test/scala/com/twilio/guardrail/collections/CollectionsAbstractionTest.scala
@@ -44,12 +44,12 @@ class CollectionsAbstractionTest extends AnyFreeSpec with Matchers {
     fa.flatMap(f).map(f2).filter(f3).getOrElse(f4)
   }
 
-  def vectorPipeline(implicit Ca: CollectionsAbstraction[JavaLanguage]): TermHolder[JavaLanguage, MethodCallExpr, Vector[Int]] = {
+  def listPipeline(implicit Ca: CollectionsAbstraction[JavaLanguage]): TermHolder[JavaLanguage, MethodCallExpr, List[Int]] = {
     import Ca._
 
     val a = new IntegerLiteralExpr("5").lift[Int]
 
-    val fa = a.liftVector
+    val fa = a.liftList
 
     val f = new LambdaExpr(
       new Parameter(new UnknownType, "a"),
@@ -111,16 +111,16 @@ class CollectionsAbstractionTest extends AnyFreeSpec with Matchers {
       import Ca._
 
       val optionalType  = StaticJavaParser.parseClassOrInterfaceType("java.util.Optional").setTypeArguments(PrimitiveType.intType.toBoxedType)
-      val vectorType    = StaticJavaParser.parseClassOrInterfaceType("java.util.List").setTypeArguments(PrimitiveType.intType.toBoxedType)
+      val listType      = StaticJavaParser.parseClassOrInterfaceType("java.util.List").setTypeArguments(PrimitiveType.intType.toBoxedType)
       val futureType    = StaticJavaParser.parseClassOrInterfaceType("java.util.concurrent.CompletionStage").setTypeArguments(PrimitiveType.intType.toBoxedType)
       val exceptionType = StaticJavaParser.parseClassOrInterfaceType("Exception")
 
       optionalType.isOptionalType mustBe true
-      vectorType.isVectorType mustBe true
+      listType.isListType mustBe true
       futureType.isFutureType mustBe true
 
       exceptionType.isOptionalType mustBe false
-      exceptionType.isVectorType mustBe false
+      exceptionType.isListType mustBe false
       exceptionType.isFutureType mustBe false
     }
 
@@ -128,17 +128,17 @@ class CollectionsAbstractionTest extends AnyFreeSpec with Matchers {
       optionalPipeline.value.toString mustBe "java.util.Optional.ofNullable(5).flatMap(a -> a >= 0 ? java.util.Optional.ofNullable(a) : java.util.Optional.empty()).map(a -> a + 1).filter(a -> a > 3).orElseGet(() -> 42)"
     }
 
-    "Vector pipelines should render" in {
-      vectorPipeline.value.toString mustBe "java.util.Collections.singletonList(5).stream().map(a -> a + 1).map(a -> a * 5).filter(a -> a > 3).collect(java.util.stream.Collectors.toList())"
+    "List pipelines should render" in {
+      listPipeline.value.toString mustBe "java.util.Collections.singletonList(5).stream().map(a -> a + 1).map(a -> a * 5).filter(a -> a > 3).collect(java.util.stream.Collectors.toList())"
     }
 
-    "Vector pipeline with toArray() should render" in {
+    "List pipeline with toArray() should render" in {
       import Ca._
 
-      vectorPipeline.toArray.value.toString mustBe "java.util.Collections.singletonList(5).stream().map(a -> a + 1).map(a -> a * 5).filter(a -> a > 3).toArray(Integer[]::new)"
+      listPipeline.toArray.value.toString mustBe "java.util.Collections.singletonList(5).stream().map(a -> a + 1).map(a -> a * 5).filter(a -> a > 3).toArray(Integer[]::new)"
 
-      val vectorOfOneFive = new IntegerLiteralExpr("5").lift[Int].liftVector
-      vectorOfOneFive.toArray.value.toString mustBe "java.util.Collections.singletonList(5).toArray(new int[0])"
+      val listOfOneFive = new IntegerLiteralExpr("5").lift[Int].liftList
+      listOfOneFive.toArray.value.toString mustBe "java.util.Collections.singletonList(5).toArray(new int[0])"
     }
 
     "Future pipelines should render" in {
@@ -177,16 +177,16 @@ class CollectionsAbstractionTest extends AnyFreeSpec with Matchers {
       import Ca._
 
       val optionalType  = StaticJavaParser.parseClassOrInterfaceType("io.vavr.control.Option").setTypeArguments(PrimitiveType.intType.toBoxedType)
-      val vectorType    = StaticJavaParser.parseClassOrInterfaceType("io.vavr.collection.Vector").setTypeArguments(PrimitiveType.intType.toBoxedType)
+      val listType      = StaticJavaParser.parseClassOrInterfaceType("io.vavr.collection.Vector").setTypeArguments(PrimitiveType.intType.toBoxedType)
       val futureType    = StaticJavaParser.parseClassOrInterfaceType("io.vavr.concurrent.Future").setTypeArguments(PrimitiveType.intType.toBoxedType)
       val exceptionType = StaticJavaParser.parseClassOrInterfaceType("Exception")
 
       optionalType.isOptionalType mustBe true
-      vectorType.isVectorType mustBe true
+      listType.isListType mustBe true
       futureType.isFutureType mustBe true
 
       exceptionType.isOptionalType mustBe false
-      exceptionType.isVectorType mustBe false
+      exceptionType.isListType mustBe false
       exceptionType.isFutureType mustBe false
     }
 
@@ -194,17 +194,17 @@ class CollectionsAbstractionTest extends AnyFreeSpec with Matchers {
       optionalPipeline.value.toString mustBe "io.vavr.control.Option.of(5).flatMap(a -> a >= 0 ? io.vavr.control.Option.of(a) : io.vavr.control.Option.none()).map(a -> a + 1).filter(a -> a > 3).getOrElse(() -> 42)"
     }
 
-    "Vector pipelines should render" in {
-      vectorPipeline.value.toString mustBe "io.vavr.collection.Vector.of(5).map(a -> a + 1).map(a -> a * 5).filter(a -> a > 3)"
+    "List pipelines should render" in {
+      listPipeline.value.toString mustBe "io.vavr.collection.Vector.of(5).map(a -> a + 1).map(a -> a * 5).filter(a -> a > 3)"
     }
 
-    "Vector pipeline with toArray() should render" in {
+    "List pipeline with toArray() should render" in {
       import Ca._
 
-      vectorPipeline.toArray.value.toString mustBe "io.vavr.collection.Vector.of(5).map(a -> a + 1).map(a -> a * 5).filter(a -> a > 3).asJava().toArray(new int[0])"
+      listPipeline.toArray.value.toString mustBe "io.vavr.collection.Vector.of(5).map(a -> a + 1).map(a -> a * 5).filter(a -> a > 3).asJava().toArray(new int[0])"
 
-      val vectorOfOneFive = new IntegerLiteralExpr("5").lift[Int].liftVector
-      vectorOfOneFive.toArray.value.toString mustBe "io.vavr.collection.Vector.of(5).asJava().toArray(new int[0])"
+      val listOfOneFive = new IntegerLiteralExpr("5").lift[Int].liftList
+      listOfOneFive.toArray.value.toString mustBe "io.vavr.collection.Vector.of(5).asJava().toArray(new int[0])"
     }
 
     "Future pipelines should render" in {

--- a/modules/codegen/src/test/scala/com/twilio/guardrail/collections/CollectionsAbstractionTest.scala
+++ b/modules/codegen/src/test/scala/com/twilio/guardrail/collections/CollectionsAbstractionTest.scala
@@ -117,6 +117,15 @@ class CollectionsAbstractionTest extends AnyFreeSpec with Matchers {
       vectorPipeline.value.toString mustBe "java.util.Collections.singletonList(5).stream().map(a -> a + 1).map(a -> a * 5).collect(java.util.stream.Collectors.toList())"
     }
 
+    "Vector pipeline with toArray() should render" in {
+      import Ca._
+
+      vectorPipeline.toArray.value.toString mustBe "java.util.Collections.singletonList(5).stream().map(a -> a + 1).map(a -> a * 5).toArray(Integer[]::new)"
+
+      val vectorOfOneFive = new IntegerLiteralExpr("5").lift[Int].liftVector
+      vectorOfOneFive.toArray.value.toString mustBe "java.util.Collections.singletonList(5).toArray(new int[0])"
+    }
+
     "Future pipelines should render" in {
       futurePipeline.value.toString mustBe
         """java.util.concurrent.CompletableFuture.completedFuture(5).thenCompose(a -> a >= 0 ? java.util.concurrent.CompletableFuture.completedFuture(a) : ((java.util.function.Supplier<java.util.concurrent.CompletionStage<Integer>>) () -> {
@@ -162,6 +171,15 @@ class CollectionsAbstractionTest extends AnyFreeSpec with Matchers {
 
     "Vector pipelines should render" in {
       vectorPipeline.value.toString mustBe "io.vavr.collection.Vector.of(5).map(a -> a + 1).map(a -> a * 5)"
+    }
+
+    "Vector pipeline with toArray() should render" in {
+      import Ca._
+
+      vectorPipeline.toArray.value.toString mustBe "io.vavr.collection.Vector.of(5).map(a -> a + 1).map(a -> a * 5).asJava().toArray(new int[0])"
+
+      val vectorOfOneFive = new IntegerLiteralExpr("5").lift[Int].liftVector
+      vectorOfOneFive.toArray.value.toString mustBe "io.vavr.collection.Vector.of(5).asJava().toArray(new int[0])"
     }
 
     "Future pipelines should render" in {


### PR DESCRIPTION
Properly handles the need to call `stream()` when starting "monadic operations" on `java.util.List`, and then `collect(Collectors.toList())` when finishing.  I do this by creating a `TermHolder` subclass that is used _after_ `stream()` has been called.  This way multiple monadic calls will not require a round trip between `Stream` and `List`.

Also adds `.toArray()` and `.filter()` to the collections abstraction.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
