### PR TITLE
update Java reserved words list

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/Java.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/syntax/Java.scala
@@ -219,11 +219,14 @@ object Java {
     "new",
     "null",
     "package",
+    "permits",
     "private",
     "protected",
     "public",
+    "record",
     "requires",
     "return",
+    "sealed",
     "short",
     "static",
     "strictfp",
@@ -239,7 +242,8 @@ object Java {
     "var",
     "void",
     "volatile",
-    "while"
+    "while",
+    "yield"
   )
 
   implicit class RichJavaString(private val s: String) extends AnyVal {

--- a/modules/codegen/src/test/scala/com/twilio/guardrail/generators/syntax/JavaSyntaxTest.scala
+++ b/modules/codegen/src/test/scala/com/twilio/guardrail/generators/syntax/JavaSyntaxTest.scala
@@ -13,6 +13,8 @@ object JavaSyntaxTest {
     "public",
     "if",
     "else",
+    "enum",
+    "record",
     "throw"
   )
 
@@ -39,7 +41,8 @@ class JavaSyntaxTest extends AnyFreeSpec with Matchers {
         "monkey",
         "cheese",
         "blah-moo",
-        "aasdad2"
+        "aasdad2",
+        "record123"
       ).foreach({ word =>
         word.escapeReservedWord shouldBe word
       })


### PR DESCRIPTION
new reserved words: permits, record, sealed, yield


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
