### PR TITLE
Formatting race condition redux

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/CLI.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/CLI.scala
@@ -170,7 +170,7 @@ trait CLICommon {
           rs =>
             ReadSwagger
               .readSwagger(rs)
-              .map(_.map(WriteTree.unsafeWriteTree))
+              .flatMap(_.traverse(WriteTree.writeTree))
               .leftFlatMap(
                 value =>
                   Target.pushLogger(StructuredLogger.error(s"${AnsiColor.RED}Error in ${rs.path}${AnsiColor.RESET}")) *> Target.raiseError[List[Path]](value)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/WriteTree.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/WriteTree.scala
@@ -13,52 +13,61 @@ sealed trait WriteTreeState
 case object FileAbsent    extends WriteTreeState
 case object FileDifferent extends WriteTreeState
 case object FileIdentical extends WriteTreeState
-case class WriteTree(path: Path, contents: Future[Array[Byte]])
+case class WriteTree(path: Path, contents: Future[Target[Array[Byte]]])
 object WriteTree {
-  val unsafeWriteTreeLogged: WriteTree => Writer[List[String], Path] = {
+  val writeTreeLogged: WriteTree => Target[Writer[List[String], Path]] = {
     case WriteTree(path, dataF) =>
-      val _    = Files.createDirectories(path.getParent)
-      val data = Await.result(dataF, Duration.Inf)
-      for {
-        writeState <- if (Files.exists(path)) {
-          val exists: Array[Byte] = Files.readAllBytes(path)
-          val diffIdx: Option[Int] =
-            exists
-              .zip(data)
-              .zipWithIndex
-              .find({ case ((a, b), _) => a != b })
-              .map(_._2)
-              .orElse(Some(Math.max(exists.length, data.length)))
-              .filterNot(Function.const(data.length == exists.length))
+      val _ = Files.createDirectories(path.getParent)
+      Await
+        .result(dataF, Duration.Inf)
+        .map { data =>
+          for {
+            writeState <- if (Files.exists(path)) {
+              val exists: Array[Byte] = Files.readAllBytes(path)
+              val diffIdx: Option[Int] =
+                exists
+                  .zip(data)
+                  .zipWithIndex
+                  .find({ case ((a, b), _) => a != b })
+                  .map(_._2)
+                  .orElse(Some(Math.max(exists.length, data.length)))
+                  .filterNot(Function.const(data.length == exists.length))
 
-          diffIdx.fold[Writer[List[String], WriteTreeState]](Writer.value(FileIdentical))({ diffIdx =>
-            val existSample = new String(exists, UTF_8)
-              .slice(Math.max(diffIdx - 10, diffIdx), Math.max(diffIdx - 10, diffIdx) + 50)
-              .replace("\n", "\\n")
-            val newSample = new String(data, UTF_8)
-              .slice(Math.max(diffIdx - 10, diffIdx), Math.max(diffIdx - 10, diffIdx) + 50)
-              .replace("\n", "\\n")
+              diffIdx.fold[Writer[List[String], WriteTreeState]](Writer.value(FileIdentical))({ diffIdx =>
+                val existSample = new String(exists, UTF_8)
+                  .slice(Math.max(diffIdx - 10, diffIdx), Math.max(diffIdx - 10, diffIdx) + 50)
+                  .replace("\n", "\\n")
+                val newSample = new String(data, UTF_8)
+                  .slice(Math.max(diffIdx - 10, diffIdx), Math.max(diffIdx - 10, diffIdx) + 50)
+                  .replace("\n", "\\n")
 
-            Writer.tell(List(s"""|
-            |${AnsiColor.RED}Warning:${AnsiColor.RESET}
-            |  The file $path contained different content than was expected.
-            |
-            |  Existing file: $existSample
-            |  New file     : $newSample
-            |""".stripMargin)) >> Writer.value(FileDifferent)
-          })
-        } else Writer.value[List[String], WriteTreeState](FileAbsent)
-      } yield writeState match {
-        case FileAbsent    => Files.write(path, data, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)
-        case FileDifferent => Files.write(path, data, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)
-        case FileIdentical => path
-      }
+                Writer.tell(List(s"""|
+                |${AnsiColor.RED}Warning:${AnsiColor.RESET}
+                |  The file $path contained different content than was expected.
+                |
+                |  Existing file: $existSample
+                |  New file     : $newSample
+                |""".stripMargin)) >> Writer.value(FileDifferent)
+              })
+            } else Writer.value[List[String], WriteTreeState](FileAbsent)
+          } yield writeState match {
+            case FileAbsent    => Files.write(path, data, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)
+            case FileDifferent => Files.write(path, data, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)
+            case FileIdentical => path
+          }
+        }
   }
 
-  val unsafeWriteTree: WriteTree => Path =
-    unsafeWriteTreeLogged.map {
+  val writeTree: WriteTree => Target[Path] =
+    writeTreeLogged(_).map {
       case WriterT((lines, path)) =>
         lines.foreach(System.err.println(_))
         path
     }
+
+  val unsafeWriteTreeLogged: WriteTree => Writer[List[String], Path] =
+    writeTreeLogged.map(Target.unsafeExtract)
+
+  val unsafeWriteTree: WriteTree => Path =
+    writeTree.map(Target.unsafeExtract)
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
@@ -42,22 +42,22 @@ object JavaGenerator {
     DefaultCodeFormatterConstants.FORMATTER_INSERT_SPACE_BEFORE_COLON_IN_DEFAULT -> DefaultCodeFormatterConstants.FALSE
   ).asJava
 
-  def prettyPrintSource(source: CompilationUnit): Target[Future[Array[Byte]]] = {
+  def prettyPrintSource(path: Path, source: CompilationUnit): Target[WriteTree] = {
     val _         = source.getChildNodes.asScala.headOption.fold(source.addOrphanComment _)(_.setComment)(GENERATED_CODE_COMMENT)
     val className = Try[TypeDeclaration[_]](source.getType(0)).fold(_ => "(unknown)", _.getNameAsString)
     val sourceStr = source.toString
     val formatter = ToolFactory.createCodeFormatter(FORMATTER_OPTIONS)
     Option(formatter.format(CodeFormatter.K_COMPILATION_UNIT, sourceStr, 0, sourceStr.length, 0, "\n"))
       .fold(
-        Target.raiseUserError[Future[Array[Byte]]](s"Failed to format class '$className'")
+        Target.raiseUserError[WriteTree](s"Failed to format class '$className'")
       )({ textEdit =>
         val doc = new Document(sourceStr)
         Try(textEdit.apply(doc)).fold(
-          t => Target.raiseUserError[Future[Array[Byte]]](s"Failed to format class '$className': $t"),
+          t => Target.raiseUserError[WriteTree](s"Failed to format class '$className': $t"),
           _ =>
-            Target.pure(Future {
+            Target.pure(WriteTree(path, Future {
               doc.get.getBytes(StandardCharsets.UTF_8)
-            })
+            }))
         )
       })
   }
@@ -73,9 +73,9 @@ object JavaGenerator {
       case td: TypeDeclaration[_] =>
         val cu = new CompilationUnit()
         cu.setPackageDeclaration(pkgDecl)
-        imports.map(cu.addImport)
+        imports.foreach(cu.addImport)
         cu.addType(td)
-        prettyPrintSource(cu).map(bytes => WriteTree(resolveFile(pkgPath)(pkg :+ s"${td.getNameAsString}.java"), bytes))
+        prettyPrintSource(resolveFile(pkgPath)(pkg :+ s"${td.getNameAsString}.java"), cu)
       case other =>
         Target.raiseUserError(s"Class definition must be a TypeDeclaration but it is a ${other.getClass.getName}")
     }
@@ -91,9 +91,9 @@ object JavaGenerator {
       case td: TypeDeclaration[_] =>
         val cu = new CompilationUnit()
         cu.setPackageDeclaration(pkgDecl)
-        imports.map(cu.addImport)
+        imports.foreach(cu.addImport)
         cu.addType(td)
-        prettyPrintSource(cu).map(bytes => WriteTree(resolveFile(pkgPath)(pkg :+ s"${td.getNameAsString}.java"), bytes))
+        prettyPrintSource(resolveFile(pkgPath)(pkg :+ s"${td.getNameAsString}.java"), cu)
       case other =>
         Target.raiseUserError(s"Class definition must be a TypeDeclaration but it is a ${other.getClass.getName}")
     }
@@ -273,8 +273,8 @@ object JavaGenerator {
           }
           cu
         }
-        bytes <- prettyPrintSource(cu)
-      } yield WriteTree(resolveFile(pkgPath)(List(s"${frameworkDefinitionsName.asString}.java")), bytes)
+        writeTree <- prettyPrintSource(resolveFile(pkgPath)(List(s"${frameworkDefinitionsName.asString}.java")), cu)
+      } yield writeTree
 
     def writePackageObject(
         dtoPackagePath: Path,
@@ -288,8 +288,10 @@ object JavaGenerator {
     ): Target[Option[WriteTree]] =
       for {
         pkgDecl <- dtoComponents.traverse(xs => buildPkgDecl(xs.toList))
-        bytes   <- pkgDecl.traverse(x => prettyPrintSource(new CompilationUnit().setPackageDeclaration(x)))
-      } yield bytes.map(WriteTree(resolveFile(dtoPackagePath)(List.empty).resolve("package-info.java"), _))
+        writeTree <- pkgDecl.traverse(
+          x => prettyPrintSource(resolveFile(dtoPackagePath)(List.empty).resolve("package-info.java"), new CompilationUnit().setPackageDeclaration(x))
+        )
+      } yield writeTree
 
     private def staticifyInnerObjects(decl: BodyDeclaration[_ <: BodyDeclaration[_]]): BodyDeclaration[_ <: BodyDeclaration[_]] = {
       def rec(decl: BodyDeclaration[_ <: BodyDeclaration[_]]): Unit =
@@ -349,14 +351,8 @@ object JavaGenerator {
           case RandomType(_, _) =>
             Option.empty
         }
-        nameAndBytes <- nameAndCompilationUnit.fold(Target.pure(Option.empty[(String, Future[Array[Byte]])]))({
-          case (name, cu) =>
-            prettyPrintSource(cu).map(bytes => Option((name, bytes)))
-        })
-      } yield nameAndBytes.fold((List.empty[WriteTree], List.empty[Statement]))({
-        case (name, bytes) =>
-          (List(WriteTree(resolveFile(outputPath)(dtoComponents).resolve(s"$name.java"), bytes)), List.empty[Statement])
-      })
+        writeTree <- nameAndCompilationUnit.traverse { case (name, cu) => prettyPrintSource(resolveFile(outputPath)(dtoComponents).resolve(s"$name.java"), cu) }
+      } yield (writeTree.toList, List.empty[Statement])
     def writeClient(
         pkgPath: Path,
         pkgName: List[String],

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
@@ -57,11 +57,11 @@ object JavaGenerator {
               _ <- Try(textEdit.apply(doc)).toEither.leftMap(Some(_))
             } yield doc.get.getBytes(StandardCharsets.UTF_8)
             result
-              .fold(
-                _.fold(throw new Exception(s"Failed to format class '$className'")) { t =>
-                  throw new Exception(s"Failed to format class '$className': $t")
+              .fold[Target[Array[Byte]]](
+                _.fold[Target[Array[Byte]]](Target.raiseUserError(s"Failed to format class '$className'")) { t =>
+                  Target.raiseUserError(s"Failed to format class '$className': $t")
                 },
-                identity _
+                Target.pure _
               )
           }
         }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
@@ -17,9 +17,10 @@ import scala.concurrent.Future
 import scala.meta._
 
 object ScalaGenerator {
-  private def sourceToBytes(source: Source): Future[Array[Byte]] = Future {
-    (GENERATED_CODE_COMMENT + source.syntax).getBytes(StandardCharsets.UTF_8)
-  }
+  private def sourceToBytes(path: Path, source: Source): WriteTree =
+    WriteTree(path, Future {
+      (GENERATED_CODE_COMMENT + source.syntax).getBytes(StandardCharsets.UTF_8)
+    })
 
   object ScalaInterp extends LanguageTerms[ScalaLanguage, Target] {
     // TODO: Very interesting bug. 2.11.12 barfs if these two definitions are
@@ -247,7 +248,7 @@ object ScalaGenerator {
 
             }
           """
-      Target.pure(Some(WriteTree(pkgPath.resolve("Implicits.scala"), sourceToBytes(implicits))))
+      Target.pure(Some(sourceToBytes(pkgPath.resolve("Implicits.scala"), implicits)))
     }
     def renderFrameworkImplicits(
         pkgPath: Path,
@@ -276,7 +277,7 @@ object ScalaGenerator {
 
             $frameworkImplicits
           """
-      Target.pure(WriteTree(pkgPath.resolve(s"${frameworkImplicitName.value}.scala"), sourceToBytes(frameworkImplicitsFile)))
+      Target.pure(sourceToBytes(pkgPath.resolve(s"${frameworkImplicitName.value}.scala"), frameworkImplicitsFile))
     }
     def renderFrameworkDefinitions(
         pkgPath: Path,
@@ -293,7 +294,7 @@ object ScalaGenerator {
 
             ..$frameworkDefinitions
           """
-      Target.pure(WriteTree(pkgPath.resolve(s"${frameworkDefinitionsName.value}.scala"), sourceToBytes(frameworkDefinitionsFile)))
+      Target.pure(sourceToBytes(pkgPath.resolve(s"${frameworkDefinitionsName.value}.scala"), frameworkDefinitionsFile))
     }
 
     def writePackageObject(
@@ -321,21 +322,21 @@ object ScalaGenerator {
               val List(Pat.Var(mirror)) = stat.pats
               stat.copy(rhs = q"$companion.$mirror")
             }
-            WriteTree(
+            sourceToBytes(
               dtoPackagePath.resolve("package.scala"),
-              sourceToBytes(source"""
-                package $dtoPkg
+              source"""
+              package $dtoPkg
 
-                ..${customImports ++ packageObjectImports ++ protocolImports :+ pkgImplicitsImport}
+              ..${customImports ++ packageObjectImports ++ protocolImports :+ pkgImplicitsImport}
 
-                object $companion {
-                  ..${implicits.map(_.copy(mods = List.empty))}
-                }
+              object $companion {
+                ..${implicits.map(_.copy(mods = List.empty))}
+              }
 
-                package object ${Term.Name(dtoComponents.last)} {
-                  ..${(mirroredImplicits ++ statements ++ extraTypes).toList}
-                }
-                """)
+              package object ${Term.Name(dtoComponents.last)} {
+                ..${(mirroredImplicits ++ statements ++ extraTypes).toList}
+              }
+              """
             )
           }
       })
@@ -356,15 +357,15 @@ object ScalaGenerator {
         case EnumDefinition(_, _, _, _, cls, staticDefns) =>
           (
             List(
-              WriteTree(
+              sourceToBytes(
                 resolveFile(outputPath)(dtoComponents).resolve(s"${cls.name.value}.scala"),
-                sourceToBytes(source"""
+                source"""
               package ${buildPkgTerm(dtoComponents)}
                 ..$imports
                 ..$implicitImports
                 $cls
                 ${companionForStaticDefns(staticDefns)}
-              """)
+              """
               )
             ),
             List.empty[Stat]
@@ -372,15 +373,15 @@ object ScalaGenerator {
         case ClassDefinition(_, _, _, cls, staticDefns, _) =>
           (
             List(
-              WriteTree(
+              sourceToBytes(
                 resolveFile(outputPath)(dtoComponents).resolve(s"${cls.name.value}.scala"),
-                sourceToBytes(source"""
+                source"""
               package ${buildPkgTerm(dtoComponents)}
                 ..$imports
                 ..$implicitImports
                 $cls
                 ${companionForStaticDefns(staticDefns)}
-              """)
+              """
               )
             ),
             List.empty[Stat]
@@ -389,16 +390,16 @@ object ScalaGenerator {
           val polyImports: Import = q"import cats.syntax.either._"
           (
             List(
-              WriteTree(
+              sourceToBytes(
                 resolveFile(outputPath)(dtoComponents).resolve(s"$name.scala"),
-                sourceToBytes(source"""
+                source"""
                     package ${buildPkgTerm(dtoComponents)}
                     ..$imports
                     ..$implicitImports
                     $polyImports
                     $trt
                     ${companionForStaticDefns(staticDefns)}
-                  """)
+                  """
               )
             ),
             List.empty[Stat]
@@ -419,9 +420,9 @@ object ScalaGenerator {
       val Client(pkg, clientName, imports, staticDefns, client, responseDefinitions) = _client
       Target.pure(
         List(
-          WriteTree(
+          sourceToBytes(
             resolveFile(pkgPath)(pkg :+ (s"$clientName.scala")),
-            sourceToBytes(source"""
+            source"""
               package ${buildPkgTerm(pkgName ++ pkg)}
               import ${buildPkgTerm(List("_root_") ++ pkgName ++ List("Implicits"))}._
               ..${frameworkImplicitNames.map(name => q"import ${buildPkgTerm(List("_root_") ++ pkgName)}.$name._")}
@@ -431,7 +432,7 @@ object ScalaGenerator {
               ${companionForStaticDefns(staticDefns)};
               ..${client.toList.map(_.merge)};
               ..$responseDefinitions
-              """)
+              """
           )
         )
       )
@@ -447,9 +448,9 @@ object ScalaGenerator {
       val Server(pkg, extraImports, handlerDefinition, serverDefinitions) = server
       Target.pure(
         List(
-          WriteTree(
+          sourceToBytes(
             resolveFile(pkgPath)(pkg.toList :+ "Routes.scala"),
-            sourceToBytes(source"""
+            source"""
               package ${buildPkgTerm(pkgName ++ pkg.toList)}
               ..$extraImports
               import ${buildPkgTerm(List("_root_") ++ pkgName ++ List("Implicits"))}._
@@ -458,7 +459,7 @@ object ScalaGenerator {
               ..$customImports
               $handlerDefinition
               ..$serverDefinitions
-              """)
+              """
           )
         )
       )

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
@@ -19,7 +19,7 @@ import scala.meta._
 object ScalaGenerator {
   private def sourceToBytes(path: Path, source: Source): WriteTree =
     WriteTree(path, Future {
-      (GENERATED_CODE_COMMENT + source.syntax).getBytes(StandardCharsets.UTF_8)
+      Target.pure((GENERATED_CODE_COMMENT + source.syntax).getBytes(StandardCharsets.UTF_8))
     })
 
   object ScalaInterp extends LanguageTerms[ScalaLanguage, Target] {

--- a/modules/codegen/src/test/scala/codegen/WritePackageSpec.scala
+++ b/modules/codegen/src/test/scala/codegen/WritePackageSpec.scala
@@ -70,7 +70,7 @@ class WritePackageSpec extends AnyFunSuite with Matchers {
   def extractPackage(path: Path, results: List[WriteTree]): Term.Ref = {
     val Some(source"""package ${fooPkg }
     ..${stats }
-    """) = results.find(_.path == path).headOption.map(_.contents).map(x => new String(Await.result(x, Duration.Inf)).parse[Source].get)
+    """) = results.find(_.path == path).headOption.map(_.contents).map(x => new String(Target.unsafeExtract(Await.result(x, Duration.Inf))).parse[Source].get)
     fooPkg
   }
 

--- a/modules/codegen/src/test/scala/com/twilio/guardrail/core/WriteTreeSuite.scala
+++ b/modules/codegen/src/test/scala/com/twilio/guardrail/core/WriteTreeSuite.scala
@@ -1,6 +1,6 @@
 package com.twilio.guardrail.core
 
-import com.twilio.guardrail.WriteTree
+import com.twilio.guardrail.{ Target, WriteTree }
 import java.nio.file.Files
 import scala.concurrent.Future
 import org.scalatest.funsuite.AnyFunSuite
@@ -13,8 +13,8 @@ class WriteTreeSuite extends AnyFunSuite with Matchers {
 
     val contents = "example contents".getBytes
 
-    val (firstLog, firstPath)   = WriteTree.unsafeWriteTreeLogged(WriteTree(path, Future.successful(contents))).run
-    val (secondLog, secondPath) = WriteTree.unsafeWriteTreeLogged(WriteTree(path, Future.successful(contents))).run
+    val (firstLog, firstPath)   = WriteTree.unsafeWriteTreeLogged(WriteTree(path, Future.successful(Target.pure(contents)))).run
+    val (secondLog, secondPath) = WriteTree.unsafeWriteTreeLogged(WriteTree(path, Future.successful(Target.pure(contents)))).run
 
     val _1 = firstLog shouldBe (Nil)
     val _2 = secondLog shouldBe (Nil)

--- a/modules/sample-dropwizard/src/test/scala/core/Dropwizard/AsyncHttpClientContentHeaderTest.scala
+++ b/modules/sample-dropwizard/src/test/scala/core/Dropwizard/AsyncHttpClientContentHeaderTest.scala
@@ -62,9 +62,8 @@ class AsyncHttpClientContentHeaderTest extends AnyFreeSpec with Matchers with Wi
           case MOCK_RESPONSE_BODY => ()
           case other              => fail(s"Unexpected response: ${other}")
         }, { () =>
-            fail("Should have gotten 201 response"); ()
-          }
-        )
+          fail("Should have gotten 201 response"); ()
+        })
     }
   }
 }

--- a/modules/sample-dropwizard/src/test/scala/core/Dropwizard/JavaInvalidCharacterEscapingTest.scala
+++ b/modules/sample-dropwizard/src/test/scala/core/Dropwizard/JavaInvalidCharacterEscapingTest.scala
@@ -3,15 +3,15 @@ package core.Dropwizard
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.ObjectMapper
 import invalidCharacters.client.dropwizard.invalidCharacters.InvalidCharactersClient
-import invalidCharacters.server.dropwizard.definitions.{InvalidCharacters, InvalidCharactersEnum}
+import invalidCharacters.server.dropwizard.definitions.{ InvalidCharacters, InvalidCharactersEnum }
 import io.netty.buffer.Unpooled
-import java.net.{SocketAddress, URI, URLDecoder}
-import java.util.concurrent.{CompletableFuture, CompletionStage}
+import java.net.{ SocketAddress, URI, URLDecoder }
+import java.util.concurrent.{ CompletableFuture, CompletionStage }
 import java.util.function
 import org.asynchttpclient.Response.ResponseBuilder
 import org.asynchttpclient.netty.EagerResponseBodyPart
 import org.asynchttpclient.uri.Uri
-import org.asynchttpclient.{HttpResponseStatus, Request, Response}
+import org.asynchttpclient.{ HttpResponseStatus, Request, Response }
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import scala.collection.JavaConverters._
@@ -22,14 +22,14 @@ object JavaInvalidCharacterEscapingTest {
   }
 
   private object OkStatus extends HttpResponseStatus(Uri.create("http://localhost:1234/foo?foo^bar=query-param")) {
-    override def getStatusCode = 200
-    override def getStatusText = "OK"
-    override def getProtocolName = "HTTP"
-    override def getProtocolMajorVersion = 1
-    override def getProtocolMinorVersion = 1
-    override def getProtocolText = "HTTP/1.1"
+    override def getStatusCode                   = 200
+    override def getStatusText                   = "OK"
+    override def getProtocolName                 = "HTTP"
+    override def getProtocolMajorVersion         = 1
+    override def getProtocolMinorVersion         = 1
+    override def getProtocolText                 = "HTTP/1.1"
     override def getRemoteAddress: SocketAddress = ???
-    override def getLocalAddress: SocketAddress = ???
+    override def getLocalAddress: SocketAddress  = ???
   }
 }
 
@@ -65,15 +65,17 @@ class JavaInvalidCharacterEscapingTest extends AnyFreeSpec with Matchers {
         fps.find(_._1 == "d/c").map(_._2) mustBe Some("fourtharg")
         val response = new ResponseBuilder()
         response.accumulate(OkStatus)
-        response.accumulate(new EagerResponseBodyPart(
-          Unpooled.copiedBuffer(new ObjectMapper().writeValueAsBytes(new InvalidCharacters.Builder("foo", InvalidCharactersEnum.WEIRD_AT).build())),
-          true
-        ))
+        response.accumulate(
+          new EagerResponseBodyPart(
+            Unpooled.copiedBuffer(new ObjectMapper().writeValueAsBytes(new InvalidCharacters.Builder("foo", InvalidCharactersEnum.WEIRD_AT).build())),
+            true
+          )
+        )
         CompletableFuture.completedFuture(response.build())
       }
     }
 
-    val client = new InvalidCharactersClient.Builder(new URI("http://localhost:1234")).withHttpClient(httpClient).build()
+    val client   = new InvalidCharactersClient.Builder(new URI("http://localhost:1234")).withHttpClient(httpClient).build()
     val response = client.getFoo("firstarg", "secondarg", "thirdarg", "fourtharg").call().toCompletableFuture.get()
     response.fold(
       { invChar =>


### PR DESCRIPTION
1. Deduplicated `WriteTree` sprawl in Scala and Java generators
2. Made `WriteTree` contain `Future[Target[Array[Byte]]]` so the render can safely fail
3. Incorporated that failure into the main runner instead of just throwing an exception

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
