### PR TITLE
[OAS3.0] Fixed responses with different content types for http4s

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -135,7 +135,8 @@ val exampleCases: List[ExampleCase] = List(
   ExampleCase(sampleResource("binary.yaml"), "binary").frameworks("java" -> Set("dropwizard", "dropwizard-vavr"), "scala" -> Set("http4s")),
   ExampleCase(sampleResource("conflicting-names.yaml"), "conflictingNames"),
   ExampleCase(sampleResource("base64.yaml"), "base64").frameworks("scala" -> scalaFrameworks.toSet),
-  ExampleCase(sampleResource("server1.yaml"), "customExtraction").args("--custom-extraction").frameworks("scala" -> Set("akka-http", "http4s"))
+  ExampleCase(sampleResource("server1.yaml"), "customExtraction").args("--custom-extraction").frameworks("scala" -> Set("akka-http", "http4s")),
+  ExampleCase(sampleResource("mixed-content-types-3.0.2.yaml"), "mixedContentTypes").frameworks("scala" -> scalaFrameworks.toSet)
 )
 
 def exampleArgs(language: String, framework: Option[String] = None): List[List[String]] = exampleCases

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sClientGenerator.scala
@@ -516,7 +516,10 @@ object Http4sClientGenerator {
       for {
         resp <- responses.value
         tpe  <- resp.value.map(_._2)
-      } yield q"private[this] val ${Pat.Var(Term.Name(s"$methodName${resp.statusCodeName}Decoder"))} = ${Http4sHelper.generateDecoder(tpe, produces)}"
+      } yield {
+        val contentTypes = resp.value.map(_._1).map(List(_)).getOrElse(produces) //for OpenAPI 3.x we should take ContentType from the response
+        q"private[this] val ${Pat.Var(Term.Name(s"$methodName${resp.statusCodeName}Decoder"))} = ${Http4sHelper.generateDecoder(tpe, contentTypes)}"
+      }
   }
 
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sHelper.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sHelper.scala
@@ -1,8 +1,9 @@
 package com.twilio.guardrail.generators.Scala
 
 import com.twilio.guardrail.languages.ScalaLanguage
-import com.twilio.guardrail.protocol.terms.{ ApplicationJson, ContentType, Response, Responses }
+import com.twilio.guardrail.protocol.terms.{ AnyContentType, ApplicationJson, ContentType, Response, Responses }
 import com.twilio.guardrail.StrictProtocolElems
+
 import scala.meta._
 
 object Http4sHelper {
@@ -62,7 +63,7 @@ object Http4sHelper {
   }
 
   def generateDecoder(tpe: Type, consumes: Seq[ContentType]): Term =
-    if (consumes.contains(ApplicationJson) || consumes.isEmpty)
+    if (isJsonEncoderDecoder(consumes))
       q"jsonOf[F, $tpe]"
     else
       tpe match {
@@ -83,7 +84,7 @@ object Http4sHelper {
       }
 
   def generateEncoder(tpe: Type, produces: Seq[ContentType]): Term =
-    if (produces.contains(ApplicationJson) || produces.isEmpty)
+    if (isJsonEncoderDecoder(produces))
       q"jsonEncoderOf[F, $tpe]"
     else
       tpe match {
@@ -113,4 +114,9 @@ object Http4sHelper {
           }
       }
     }
+
+  private def isJsonEncoderDecoder(consumesOrProduces: Seq[ContentType]): Boolean =
+    consumesOrProduces.contains(ApplicationJson) ||
+      consumesOrProduces.isEmpty ||
+      consumesOrProduces.contains(AnyContentType) //guardrial converts missing contentTypes to */* what should be converted to JSON according OpenAPI
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sServerGenerator.scala
@@ -869,7 +869,8 @@ object Http4sServerGenerator {
         response    <- responses.value
         (_, tpe, _) <- response.value
       } yield {
-        q"private[this] val ${Pat.Var(Term.Name(s"$methodName${response.statusCodeName}Encoder"))} = ${Http4sHelper.generateEncoder(tpe, produces)}"
+        val contentTypes = response.value.map(_._1).map(List(_)).getOrElse(produces) //for OpenAPI 3.x we should take ContentType from the response
+        q"private[this] val ${Pat.Var(Term.Name(s"$methodName${response.statusCodeName}Encoder"))} = ${Http4sHelper.generateEncoder(tpe, contentTypes)}"
       }
 
     def generateResponseGenerators(methodName: String, responses: Responses[ScalaLanguage]): List[Defn.Val] =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/Content.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/Content.scala
@@ -2,6 +2,7 @@ package com.twilio.guardrail.protocol.terms
 
 import cats.Order
 import cats.implicits._
+
 import java.util.Locale
 
 sealed abstract class ContentType(val value: String) {
@@ -29,6 +30,7 @@ case object MultipartFormData  extends TextContent("multipart/form-data")
 case object UrlencodedFormData extends TextContent("application/x-www-form-urlencoded")
 case object TextPlain          extends TextContent("text/plain")
 case object OctetStream        extends BinaryContent("application/octet-stream")
+case object AnyContentType     extends ContentType("*/*")
 
 object ContentType {
   // This is not intended to be exhaustive, but should hopefully cover cases we're likely to see.
@@ -64,6 +66,7 @@ object ContentType {
     case "application/x-www-form-urlencoded"           => Some(UrlencodedFormData)
     case "text/plain"                                  => Some(TextPlain)
     case "application/octet-stream"                    => Some(OctetStream)
+    case "*/*"                                         => Some(AnyContentType)
     case x if isUnsupported(x)                         => None
     case x if isTextRegistry(x) | isApplicationText(x) => Some(new TextContent(value))
     case _                                             => Some(new BinaryContent(value))

--- a/modules/sample-http4s/src/test/scala/core/Http4s/Http4sMixedContentTypesTest.scala
+++ b/modules/sample-http4s/src/test/scala/core/Http4s/Http4sMixedContentTypesTest.scala
@@ -1,0 +1,40 @@
+package core.Http4s
+
+import _root_.mixedContentTypes.client.{ http4s => generatedClient }
+import _root_.mixedContentTypes.server.http4s._
+import _root_.mixedContentTypes.server.http4s.definitions.Error
+import cats.effect.IO
+import cats.effect.IO._
+import org.http4s.client.Client
+import org.http4s.implicits._
+import org.scalatest.EitherValues
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class Http4sMixedContentTypesTest extends AnyFunSuite with Matchers with EitherValues {
+
+  test("handle text/plain") {
+    val server = new Resource[IO]().routes(new Handler[IO] {
+      override def doFoo(respond: DoFooResponse.type)(): IO[DoFooResponse] =
+        IO.pure(respond.Ok("resp"))
+    })
+
+    val client = generatedClient.Client.httpClient(Client.fromHttpApp(server.orNotFound), "http://localhost:1234")
+
+    val actual = client.doFoo(Nil).attempt.unsafeRunSync().value
+    actual shouldBe generatedClient.DoFooResponse.Ok("resp")
+  }
+
+  test("handle application/json") {
+    val server = new Resource[IO]().routes(new Handler[IO] {
+      override def doFoo(respond: DoFooResponse.type)(): IO[DoFooResponse] =
+        IO.pure(respond.BadRequest(Error(Some("err"))))
+    })
+
+    val client = generatedClient.Client.httpClient(Client.fromHttpApp(server.orNotFound), "http://localhost:1234")
+
+    val actual = client.doFoo(Nil).attempt.unsafeRunSync().value
+    actual shouldBe generatedClient.DoFooResponse.BadRequest(generatedClient.definitions.Error(Some("err")))
+  }
+
+}

--- a/modules/sample/src/main/resources/mixed-content-types-3.0.2.yaml
+++ b/modules/sample/src/main/resources/mixed-content-types-3.0.2.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.2
+info:
+  title: 'mixed content types'
+  version: 1.0.0
+paths:
+  /foo:
+    post:
+      operationId: doFoo
+      responses:
+        200:
+          description: success
+          content:
+            text/plain:
+              schema:
+                type: string
+        400:
+          description: "Invalid"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        name:
+          type: string


### PR DESCRIPTION
OpenAPI 3.x allows to define a content type per a response, but in Swagger 2.x you have to define `produces` for an operation. Swagger automatically converts operation without `produces` to content type `application/json`. In the existing code base a response without `produces` is converted to `Response` with content type `*/*`. So I have created new content type `AnyContentType` which is next converted to json in `Http4sHelper`. I'm not sure if it is the best solution, I have also had two other options.

this PR fixes #949 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
