### PR TITLE
Delay confusing codecov comment

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,7 @@
 codecov:
   require_ci_to_pass: yes
+  notify:
+    after_n_builds: 10  # This should cover core, as well as enough buffer to catch both Scala and Java reporters
 
 coverage:
   precision: 2


### PR DESCRIPTION
This was going to be included with the endpoints bump, but that is taking quite a while.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
