### PR TITLE
Including deps in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,17 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Set up JDK
-      uses: actions/setup-java@v1
+    - uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java }}
+    - uses: actions/setup-ruby@v1
+      with:
+        ruby-version: '2.6'
+    - name: Install microsite deps
+      run: |
+        gem update --system
+        gem install sass
+        gem install jekyll -v 4.0.0
     - name: print Java version
       run: java -version
     - uses: actions/cache@v1

--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -16,7 +16,7 @@ jobs:
           java-version: 8
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: '2.6.0'
+          ruby-version: '2.6'
       - name: Install microsite deps
         run: |
           gem update --system

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           java-version: 8
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: '2.6.0'
+          ruby-version: '2.6'
       - name: Install microsite deps
         run: |
           gem update --system


### PR DESCRIPTION
2.6.0 isn't valid when kicking off a release, install the deps in CI to ensure we discover as early as possible.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
