### PR TITLE
Logging tweak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ target/
 .bloop/
 .bsp/
 .metals/
+vendor/
 
 .idea

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/SwaggerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/SwaggerGenerator.scala
@@ -144,7 +144,7 @@ object SwaggerGenerator {
                     .indexedCosequence
                     .map { tags =>
                       println(
-                        s"Warning: Using `tags` to define package membership is deprecated in favor of the `x-jvm-package` vendor extension (${tags.history})"
+                        s"Warning: Using `tags` to define package membership is deprecated in favor of the `x-jvm-package` vendor extension (${tags.showHistory})"
                       )
                       tags.get.toList
                     }
@@ -187,7 +187,7 @@ object SwaggerGenerator {
           .raiseErrorIfEmpty(s"$$ref not defined for parameter '${parameter.downField("name", _.getName()).get.getOrElse("<name missing as well>")}'")
 
       def fallbackParameterHandler(parameter: Tracker[Parameter]) =
-        Target.raiseUserError(s"Unsure how to handle ${parameter.unwrapTracker} (${parameter.history})")
+        Target.raiseUserError(s"Unsure how to handle ${parameter.unwrapTracker} (${parameter.showHistory})")
 
       def getOperationId(operation: Tracker[Operation]) =
         operation


### PR DESCRIPTION
Instead of

    Warning: Using `tags` to define package membership is deprecated in favor of the `x-jvm-package` vendor extension (Vector(.paths, ./store/order/{orderId}, .operations, .DELETE, .tags))

show

    Warning: Using `tags` to define package membership is deprecated in favor of the `x-jvm-package` vendor extension (.paths./store/order/{orderId}.operations.DELETE.tags)

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
