### PR TITLE
Automatically tag scala-steward PRs with "chore"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,20 @@ on:
       - master
 
 jobs:
+  scala-steward-label:
+    runs-on: ubuntu-20.04
+    if: github.actor == 'scala-steward'
+    steps:
+      - uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['chore']
+            })
   core:
     runs-on: ubuntu-20.04
     strategy:


### PR DESCRIPTION
Reducing the maintenance burden of categorizing scala-steward PRs

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
